### PR TITLE
fix(browser): stop an unresponsive extension wedging every session

### DIFF
--- a/docs/design/browser-extension.md
+++ b/docs/design/browser-extension.md
@@ -440,19 +440,70 @@ own command heals the link), the command-timeout **promotion rule**, and a
 bounded send (§5.4).
 
 The promotion rule fires when a command exhausted its budget while the link was
-ALSO silent for **1.5 ping intervals** (> 30 s), not one. The slack is the same
-reasoning the 50 s threshold above uses, and it is required here rather than
-optional: a healthy peer speaks only when spoken to, so its silence is a
-sawtooth from 0 to one interval plus whatever the DAEMON's own loop adds (a
-dropped tick; `_supervise`'s up-to-30 s backoff after a failed one), and the
-daemon is the only party that solicits speech — daemon-side delay is otherwise
-indistinguishable from peer death. With zero slack a healthy link was measured
-torn down (close 4000, every session's pending futures failed). A slow SITE
-cannot trip it at any slack: the extension pongs throughout, so `silent_for()`
-stays ~0. The cost of a false positive is not small — `_drop_unproven_link`
+ALSO silent for **1.5 ping intervals** (> 30 s), **or** when a direct, bounded
+liveness solicitation goes unanswered inside that method's own budget.
+
+**Why the threshold alone was not enough (recorded from review R2-3 / QA Q2-4).**
+The slack above is the same reasoning the 50 s threshold uses, and it is
+required rather than optional: a healthy peer speaks only when spoken to, so its
+silence is a sawtooth from 0 to one interval plus whatever the DAEMON's own loop
+adds (a dropped tick; `_supervise`'s up-to-30 s backoff after a failed one), and
+the daemon is the only party that solicits speech — daemon-side delay is
+otherwise indistinguishable from peer death. With zero slack a healthy link was
+measured torn down (close 4000, every session's pending futures failed). But
+`1.5 × 20 s = 30 s` is ABOVE the 20 s budget of `read`/`snapshot`/`screenshot`,
+so the rule went **inert for exactly the methods the threshold was introduced to
+serve** — the record's own justification for not using 50 s here was "requiring
+50 s would make a `read` (20 s budget) unable to ever corroborate, since its own
+timeout fires first". Measured: a frozen worker returned
+`internal {timeout_s: 20.0}` where the pre-slack build returned
+`extension_unresponsive`.
+
+Lowering the threshold is NOT the fix: any threshold at or below one ping
+interval re-opens the false positive above, because the daemon cannot tell a
+delayed tick from a dead peer by looking at a clock. The rule therefore stops
+inferring and ASKS: `_peer_answers_a_solicited_ping` sends a ping on the captured
+wire and waits `PING_PROBE_TIMEOUT_S = 5 s` for ANY frame back (the same "any
+frame" rule the silence detector uses). A healthy worker answers within one
+event-loop turn whatever it is doing (§5.4), and the daemon is demonstrably alive
+at the moment it probes — it is running the timeout path — which is precisely the
+ambiguity R1-2 was about. An unanswered SOLICITATION is evidence; an elapsed
+clock is not. The 5 s window is bounded by the same generosity argument as
+`LINK_SEND_TIMEOUT_S`, and it is a magnitude below the smallest method budget,
+which is what "respects each method's budget" has to mean here. The clearly
+corroborated case short-circuits on the OR before probing, so a dead peer is
+still severed without the extra wait.
+
+The cost of a false positive is not small — `_drop_unproven_link`
 fails every pending future across ALL sessions and clears `driven` and
 `awaiting_origin`, so one drifted tick would convert a slow page into every
 session losing its tab handles.
+
+**The teardown is FENCED to the socket it was decided about, and its close is
+bounded.** Both halves are one defect class: a decision that spans an `await`.
+`link.send` is bound to the wire the caller captured — sending to `self.websocket`
+at call time is how a command from a superseded connection was delivered to its
+replacement, a request that peer never received, for a tab it does not own. The
+ping tick, the send deadline and the promotion rule each pass the wire they
+measured, and `_drop_unproven_link` refuses a teardown whose wire is no longer
+authoritative (returning that refusal, so the session is told "the extension
+replaced its connection" rather than being handed a claim about a peer that is
+answering). The receive loop checks the same predicate on every frame, so a
+superseded socket still draining a buffered `tab_update` cannot stamp liveness or
+publish into the live link's driven record. Both halves were reproduced by an
+independent concurrency audit against the pre-fix build — the command-send case
+closed the HEALTHY replacement with 4000 and failed every new session's futures;
+the receive case inserted a stale tab into the new link's records.
+
+The teardown's close is wrapped in `LINK_CLOSE_TIMEOUT_S` because it runs INSIDE
+the recovery it performs: the gate, the command-timeout path and the ping
+supervisor all await `_drop_unproven_link`, so an unbounded `close()` on a
+peer that has stopped draining parked the initiating RPC and stalled the
+liveness loop inside its own recovery. The audit reproduced that too
+(`{"case":"drop with blocked close","link_cleared":true,
+"drop_completed":false}`). The same bound covers the two sibling closes on this
+path (the later-connection-wins eviction and the 4003 revoke) and the two
+handshake/`hello_ack` sends, so the hole is not merely relocated.
 
 **The reason a link was severed is LATCHED, because the teardown is the answer.**
 `_drop_unproven_link` records the silence it measured (`note_unproven_drop`),
@@ -468,7 +519,13 @@ remove. For the same window the `rpc()` gate answers `extension_unresponsive`
 advises cannot land on the wrong message either. The latch is cleared by
 anything that means the daemon did not sever the link — every ordinary socket
 end, a revoke, and a new authoritative socket — so a browser the user simply
-closed still reads as absent. 60 s is sized to the slowest real recovery
+closed still reads as absent. The REVOKE half is cleared by the revocation
+WATCHER, not by `revoke()`: a drop nulls the socket AND `paired`, so every
+`revoke()` path was unreachable while the latch was live, and the out-of-process
+`lop browser pair --reset` left a deliberately unpaired bridge answering
+"attached and paired … pairing is preserved" for the rest of the window (QA
+Q2-1 / review R2-1). The watcher only needs the pairing FILE and clears within
+one `REVOKE_WATCH_S` tick. 60 s is sized to the slowest real recovery
 (the 58.21 s alarm floor below), after which a worker that never re-dials
 correctly reads as absent because by then nothing is attached.
 
@@ -586,10 +643,21 @@ extension per-call deadline (5-15 s)
   < session client timeout (base + 65 + 5)
 ```
 
-So a single stalled call answers before the daemon gives up. A pathological
+So a single stalled call answers before the daemon gives up. **The margin is one
+call wide, not two, on the four 20 s methods** (recorded from review R2-3):
+`snapshot` issues three sequential `cdp()` calls inside one 20 s budget
+(`Accessibility.enable` → `getFullAXTree` → `disable`), each bounded at 15 s, so
+a single stalled call plus any real work on the other two now exceeds the budget
+where at the old 10 s bound two stalls were needed to do so. At 10 s one stall
+consumed half the budget; at 15 s it consumes three-quarters (`click`/`type` have
+25 s and 10 s of slack; `open`/`goto` 30 s and 15 s). The old sentence — that the
+ceiling was raised and the rule "only gained slack" — was wrong in both
+directions: the ceiling change costs this margin, and the promotion rule did not
+gain slack, it went inert for those same methods (see §5.2). A pathological
 CHAIN of stalls can still exceed the daemon's budget, which is acceptable — the
 daemon's own timeout is then correct, and §5.2's promotion rule corroborates it
-into `extension_unresponsive` rather than a silent wedge.
+into `extension_unresponsive` rather than a silent wedge, because the
+corroboration is now a solicitation the peer either answers or does not.
 
 Two things must NOT get a deadline. `settle()` is already bounded and its 30 s
 default is calibrated to `open`/`goto`; `input.ts`'s
@@ -649,6 +717,96 @@ epoch answers `element_not_found` with "the page has navigated since that
 snapshot; take a new snapshot" — matching the format the model already knows
 from cmux's `snapshot`/`[e5]` refs (the `BrowserParams.selector` description,
 builtin.py:4693-4697, names `e5` explicitly and is unchanged).
+
+### 5.6 Concurrency: whose budget a stuck call spends (audit A3/A4)
+
+§5.4 answers "does one stuck call settle?". It does. This answers the next
+question an independent concurrency audit asked: **whose budget does it settle
+out of?** Every lane that was module-global was a lane where a healthy-but-slow
+owner spent a *different* owner's budget, and the daemon had a matching one. Four
+rescopes, all of them scope rather than a new number (the ceilings stay 15 s:
+see below for why a smaller global ceiling cannot work).
+
+- **AX lane → per target tab.** The `enable → read → disable` window is
+  serialized per `tabId`, not module-globally, with the per-key identity-check
+  eviction `ownership.ts` already uses. The hazard the lane exists for is one a11y
+  engine interleaving `enable/enable/read/DISABLE/read`, and the CDP
+  `Accessibility` domain is per debuggee (`cdp()` is addressed by `tabId`) — two
+tabs have two engines, so serializing across them protected nothing while
+letting owner A's 15 s `getFullAXTree` plus its 15 s `finally` disable stop owner
+B issuing even `Accessibility.enable` inside B's own 20 s budget.
+- **Daemon no-tab keys → per owner.** `lock_key_for` keys a command on its `tab`
+  when it has one, else `__owner__:<owner_proof>`, and `__global__` only for the
+  proof-less remainder (`tabs`, a handle-less `status`, legacy capability
+  clients). `open`, `owner_recover`, `owner_finish`, `owner_retain` and
+  `owner_release` all carry no `tab`, so under the old single key a parked `open`
+  serialized against a *different* owner's `open` — and against the
+  `owner_recover` whose only job is recovering from one — across a 30 s
+  navigation or a +65 s approval wait.
+- **Daemon lock duration → admission only, for those keys.** The lock now covers
+  *register the pending future + write the frame* and is released before the
+  answer is awaited; per-TAB keys still span the whole command, because that span
+  IS the CDP-interleave guard and it starves nobody. Nothing in the response
+  phase reads shared daemon state under a key (`_await_response` resolves one
+  future out of `link.pending`; the timeout and teardown paths key off
+  `request.id` plus §5.2's wire fence), so the release gives up nothing — but it
+  is the one claim in this change that wants an independent confirmation rather
+  than the author's word, and it is recorded as such in the PR thread. Proof keys
+  are EVICTED after use (a per-owner key is minted per session-resource, which
+  would otherwise grow `_tab_locks` for the daemon's lifetime — the defect
+  round-3 M1 fixed for the `__await__` keys).
+- **Extension pool admission → the cap's own read-modify-write.** The lane that
+  used to span the whole `open` handler is now `withAdmission` in `state.ts`,
+  wrapping exactly *cap read (`liveSurfaces` + `atSurfaceCap`) → `tabs.create` →
+  `putSurface`*. That is where the eight-surface cap actually is: the cap counts
+  the **surfaces map**, and the slot is consumed by the write that puts the
+  surface in it — not by the allocation journal, so narrowing to the journal
+  writes would have broken the cap. Attach, log capture, grouping, `navigate()`
+  (including a redirect that parks on a human decision) and the whole rollback
+  run outside it. The per-owner lane still spans the handler, which is what stops
+  a same-owner `owner_finish` overtaking its own `open`.
+
+**D2 and D3 are one change, not two.** The daemon's `__global__` key was the cap's
+only *current* guard, and it was a proxy: the daemon does not know `MAX_SURFACES`
+(the cap lives in the extension's session storage). Removing it without moving
+the guard onto the data would be a regression, so the per-owner key, the
+admission-only release and `withAdmission` ship together.
+
+**Why not a smaller global AX ceiling instead.** Arithmetic, not taste: for a
+global lane to be safe, A's whole three-call window must fit inside B's budget
+minus B's own work — `3 × ceiling ≤ ~15 s`, i.e. a ceiling of ~5 s. QA measured a
+legitimate heavy `screenshot` at **10.91 s**, so a 5 s ceiling kills work the
+daemon's own 20 s budget would have accepted. No ceiling the measurements permit
+makes a global AX lane safe; per-target is forced.
+
+**Flagged, not fixed (addendum D5).** After rescoping, an owner shares only
+`storeQueue` and `groupQueue` with a stranger (both 5 s ceilings), so the
+cross-owner term shrinks from *n* × 15 s to a small multiple of 5 s. Two honest
+costs remain, both recorded rather than hidden: (1) the 20 s trio
+(`read`/`snapshot`/`screenshot`) has only ~1-2 s of margin against a single 15 s
+stall plus healthy work, and this change does not widen it — raising 20 s is a
+daemon-budget change with client-timeout consequences, so it is not done here;
+(2) `tabs`/`status` have a PRE-EXISTING 8 × 5 s = 40 s worst case in
+`liveSurfaces`, which `withAdmission` now pulls *inside* the admission window, so
+a pathological browser can delay another owner's admission for that long. Whether
+to bound that loop is deferred: a stalled `chrome.tabs.get` must not prune a live
+surface, so it needs its own pruning-semantics work. A stalled `putSurface` can
+also transiently over-admit by one (nine surfaces for as long as the write is in
+flight); it self-corrects on the next `liveSurfaces`.
+
+**What a deadline does and does not buy (addendum D4).** A deadline makes the op
+SETTLE — the lane link drains and the next command runs. It does NOT cancel the
+mutation; `chrome.debugger.sendCommand`, `chrome.tabs.*` and `chrome.storage.*`
+expose no cancellation, so an abandoned write may still commit. `settle.ts`'s
+`deadline()` docstring carries the per-class policy stating, for each kind of
+write on these paths, either the mechanism that already reconciles a late write
+(surfaces map, `ownerScopes`, access queue, snapshot refs, log buffers) or the
+one genuine residue that is deferred with its bounds and the evidence that would
+promote it (a once-grant re-spent by the same requester inside its own 10-minute
+TTL). The related ordering hypothesis — a delayed `storage.set` reverting a newer
+write — is recorded there as **UNPROVEN**: nothing in this change measures it in
+a fault-injected or native-Chrome run, and nothing here claims native storage
+reordering.
 
 ## 6. Security and pairing
 
@@ -970,10 +1128,15 @@ than the `internal` + `data` discriminator it can rely on instead (§4.4).
   The popup still renders the state HONESTLY when it is open — a dedicated card
   keyed on `/health`'s `extension_unresponsive`, with the toggle remedy, instead
   of the green "Connected." card that used to be painted over a mute worker —
-  and that is deliberately not the primary signal for this reason: the state can
-  reach an already-open popup (a silent link with the popup up, a worker that
-  wedges while it is open), and a surface that lies is worse than one that is
-  merely unreachable.
+  and that is deliberately not the primary signal for this reason: `render()` is
+  re-entered only by a `chrome.storage.onChanged` write (`connState` /
+  `pendingOrigin` / `accessQueue`), and a MUTING worker writes nothing — so an
+  open popup keeps the card it painted, and the reachable path is the NEXT
+  render, e.g. reopening the popup inside the latch window (rendered and
+  measured: a popup held open across the transition to a mute worker stays on
+  `connected`; design D2-3). That is a real path and enough for the card to earn
+  its place, and a surface that lies is worse than one that is merely
+  unreachable.
 - **Backend precedence surprises**: a cmux user with the extension installed
   gets cmux (7.1). If real usage shows people wanting to prefer the bridge
   inside cmux, add an explicit config knob then — do not guess now.

--- a/docs/design/browser-extension.md
+++ b/docs/design/browser-extension.md
@@ -308,12 +308,29 @@ Session-leg-only methods (answered by the daemon itself, never relayed):
 | `origin_prompt_pending` | Reserved for a future non-blocking flow; v1 never emits it. |
 | `debugger_conflict` | Another debugger (DevTools open on the bridge tab) holds the target. |
 | `busy` | A command is already in flight for this tab (daemon serializes; only returned if the queue is full). |
+| `extension_unresponsive` | The socket is up and paired but the worker has stopped answering (§5.2). Latched, so `/health` also reports it for 60 s after the daemon severs the link — the state it is observed in and the state that follows it must not be byte-identical. |
 | `proto_mismatch` | Handshake version disagreement. |
 | `internal` | Anything unclassified; message carries the detail. |
 
 Timeout is expressed as `nav_timeout`/`internal` with `data.timeout_s` rather
 than a transport-level silence: the daemon's per-command deadline (section
 5.4) guarantees every request gets a typed response.
+
+**`internal` carries structured discriminators, and that is deliberate.** A
+`data` key is how this protocol adds detail the peer can act on without adding
+a code, because of a hard constraint: `ErrorDetail.code` is typed to the
+`ErrorCode` enum, so an UNKNOWN code fails `Response.model_validate` on the
+receiving daemon and the frame is dropped silently — the command then times out,
+which is strictly worse than an `internal` it understands. So the extension
+never invents a code; it attaches a key:
+
+| code | `data` key | meaning |
+|---|---|---|
+| `internal` | `stalled` | One chrome/CDP call hit its own deadline and was abandoned (§5.4). Retryable. |
+| `internal` | `undrivable_tab` | Chrome refuses to debug the tab (e.g. it is another extension's page). The surface has been pruned; `open` a new tab. |
+| `internal` | `tab_crashed` | The page died under us. |
+| `internal` | `timeout_s` | **Daemon-generated**: the command exhausted its budget. Nothing else sets this key, which is why it is the discriminator that stops a daemon-side timeout being reported as "update your extension". |
+| `internal` | `phase` | **Daemon-generated** on an `extension_unresponsive`: `gate` / `send` / `response` names where the link gave up, and `dropped` the state after the daemon severed it. |
 
 ## 5. Extension architecture (Manifest V3)
 
@@ -385,6 +402,85 @@ as a feature**: it is the user-visible truth that an agent can drive a tab,
 and it disappears when the debugger detaches. We detach on `close` and when
 the bridge tab is gone, so the banner tracks reality.
 
+**Liveness is a property of the CONNECTION, not of the socket object, and this
+is load-bearing.** The daemon keeps a monotonic timestamp of the last frame
+received from the extension — ANY frame, taken at the top of the receive loop
+before any dispatch on its type, so an older build that only pongs counts — and
+exposes it as `ExtensionLink.proven`:
+
+```
+proven  ==  websocket is not None  and  now - last_frame_at <= LINK_SILENCE_TIMEOUT_S (50 s)
+```
+
+A socket OBJECT exists whenever TCP is up and the peer has not closed, so
+`websocket is not None` cannot distinguish a healthy idle extension from one
+that completed `hello`, paired, and then never spoke again. Every consumer of
+`extension_connected` — `publish()` into the discovery file, `/health`, the
+popup, `state.liveness()` ⇒ `available()`/`advertisable()`, and the STALE-rescue
+probe's `_health_ok` — reads that ONE bit, so making it honest fixes all of them
+at once. On the real incident this single unproven boolean is what let `status`
+report "extension connected: yes" for 42 of 42 samples across an 84 s window in
+which every command from three sessions hung.
+
+The threshold is **50 s = 2.5 ping intervals** (`PING_INTERVAL_S = 20`), because
+two consecutive missed pongs are required (one miss can be a dropped tick, and
+the ping loop's `await sleep(20)` drifts under load) plus one interval of slack.
+The cross-check that makes it safe is in the other direction: a HEALTHY worker
+pongs in microseconds from the socket's own `onmessage` handler — off every
+serialized queue, see §5.4 — and emits nothing else while idle, so its longest
+legitimate silence is one ping interval. 2.5× headroom. The one way a healthy
+worker misses a pong is suspension, and a suspended worker has no socket at
+all, which is already the disconnected path.
+
+When the link is unproven the daemon does the same teardown it uses for an
+ordinary disconnect — close with code **4000**, `link.disconnect()`, republish —
+from four triggers: the ping tick (which already runs every 20 s, so an idle
+bridge notices without waiting for a command), the `rpc()` gate (so a session's
+own command heals the link), the command-timeout **promotion rule**, and a
+bounded send (§5.4).
+
+The promotion rule fires when a command exhausted its budget while the link was
+ALSO silent for **1.5 ping intervals** (> 30 s), not one. The slack is the same
+reasoning the 50 s threshold above uses, and it is required here rather than
+optional: a healthy peer speaks only when spoken to, so its silence is a
+sawtooth from 0 to one interval plus whatever the DAEMON's own loop adds (a
+dropped tick; `_supervise`'s up-to-30 s backoff after a failed one), and the
+daemon is the only party that solicits speech — daemon-side delay is otherwise
+indistinguishable from peer death. With zero slack a healthy link was measured
+torn down (close 4000, every session's pending futures failed). A slow SITE
+cannot trip it at any slack: the extension pongs throughout, so `silent_for()`
+stays ~0. The cost of a false positive is not small — `_drop_unproven_link`
+fails every pending future across ALL sessions and clears `driven` and
+`awaiting_origin`, so one drifted tick would convert a slow page into every
+session losing its tab handles.
+
+**The reason a link was severed is LATCHED, because the teardown is the answer.**
+`_drop_unproven_link` records the silence it measured (`note_unproven_drop`),
+and `/health` reports `extension_unresponsive: true` with `link_attached: false`
+for `LINK_DROP_TTL_S = 60 s` afterwards. Without that, the honest
+"attached but not answering" state lived for exactly one command: the teardown
+nulls the socket AS PART OF answering, so the very next `lop browser status` —
+the command the error copy sends the user to — fell back to
+`(browser not currently attached; it reconnects when opened)`, i.e. advice to
+open a browser that is open, which is the misdiagnosis this section exists to
+remove. For the same window the `rpc()` gate answers `extension_unresponsive`
+(`phase: "dropped"`) instead of `extension_disconnected`, so the retry the copy
+advises cannot land on the wrong message either. The latch is cleared by
+anything that means the daemon did not sever the link — every ordinary socket
+end, a revoke, and a new authoritative socket — so a browser the user simply
+closed still reads as absent. 60 s is sized to the slowest real recovery
+(the 58.21 s alarm floor below), after which a worker that never re-dials
+correctly reads as absent because by then nothing is attached.
+
+**4000 is the whole wire-compatibility story.** An already-installed worker
+handles 4000 explicitly: it suppresses the `connState` write (4000 is the
+daemon's later-connection-wins eviction, not a loss of connectivity), still
+resets its state, and calls `scheduleReconnect()`, which with `attempt` reset to
+0 by the last `onopen` waits `backoffDelayMs(0) = 1000 ms`. Measured on real
+hardware, worst case is the alarm floor when the worker suspends inside that
+window: **58.21 s**. A code the peer had to INTERPRET would not be free — see
+§11.
+
 ### 5.3 Navigation settle
 
 Where the cmux backend had to poll two disagreeing views of the URL
@@ -415,6 +511,123 @@ a session): `open`/`goto` 30 s, `click`/`type` 25 s, `read`/`snapshot`/
 `screenshot` 20 s, origin prompt 60 s (section 6.3). Python's HTTP client uses
 budget + 5 s so the typed daemon error always wins the race. Every timeout
 yields a typed response, never a dropped id.
+
+**A hang is not an error, and that is the defect this section exists to
+prevent.** Every serialized queue in the extension is a promise chain built as
+`queue.catch(() => {}).then(op)` so that each link swallows its predecessor's
+failure. That comment is true for a REJECTION and false for a HANG: `.catch()`
+never runs on a promise that never settles, so ONE stuck chrome/CDP call parks
+every later command — and because the queues (`groupQueue`, `storeQueue`, `axQueue`,
+the per-`owner_proof` ownership lane and its global `allocations` lane) are
+module-level, it parks them for EVERY session at once. Reproduced on real
+hardware: a driven tab whose renderer stopped answering made `read` and then
+`tabs` time out at 20.0 s each, the poison held in the per-owner lane, and the
+daemon's own liveness ping is what kept the poisoned worker alive to stay wedged
+(§5.2).
+
+**The rule: bound the awaits INSIDE the ops; never time out the chain itself.**
+Resetting a chain head while the stuck op still holds a half-read copy of
+`surfaces` is a lost update, and via `withSessionMutation` a DOUBLE-SPENT
+one-shot approval — the hazard `state.ts` documents with its reproduced
+round-2 B2. Bounding the inner awaits instead makes the op SETTLE, which is what
+lets the chain's `.catch` drain to the next link. `settle.ts` owns the single
+helper:
+
+```ts
+export function deadline<T>(op: Promise<T>, ms: number, what: string): Promise<T>
+```
+
+It rejects with `BridgeCommandError("internal", …, {stalled: what})`, and the op
+is ABANDONED rather than cancelled (`chrome.debugger.sendCommand` has no
+cancellation); a stuck call may still complete later into nothing, which is safe
+because its result is discarded and the attach state is reconciled by
+`chrome.debugger.onDetach` and by prune. Per call class:
+
+| call class | deadline | why |
+|---|---|---|
+| `chrome.debugger.sendCommand` (every `cdp()` call) | 15 s | must fit under the tightest daemon budget that reaches CDP (20 s for `read`/`snapshot`/`screenshot`), leaving the handler 5 s to build and send its answer |
+| `chrome.debugger.attach`/`detach`, `ownAttachment`'s probe | 5 s | local browser IPC with no page involvement: milliseconds or broken |
+| `chrome.tabs.*`, `chrome.tabGroups.*`, `chrome.storage.*` (session and LOCAL — including every grant write in `access-grants.ts`), `chrome.alarms.clear` | 5 s | browser-process IPC with no page script on the path |
+| `chrome.scripting.executeScript` | 15 s | runs page script, so it shares the CDP risk profile and the same 20 s `read` budget |
+
+These are **catastrophe ceilings** — "this is milliseconds when healthy" — not
+measured distributions, so they are collected in one table rather than spelled
+at each site, and the tests exercise them with injected hangs rather than
+wall-clock measurements. They were originally derived from the "milliseconds
+when healthy" premise alone, and the record flagged them as its weakest numbers
+with the rule "raise a bound if real measurements land within 2× of it". They
+did, on the real-Chrome rig (QA round 1): a legitimate (not `SIGSTOP`ped) `read`
+took **7.49 s** and a heavy `screenshot` **10.91 s**, the second EXCEEDING the
+old 10 s ceiling, so a 10 s bound killed work the daemon's own 20 s budget would
+have accepted. The load A/B is the rest of the evidence: over one 16-call
+sequence on the same rig, daemon, ports and extension source, the fixed head was
+9/16 under a starved host (load 190–290) where the pre-fix extension — which had
+no inner bound at all — was 14/16, while both were 16/16 at normal load. So the
+10 s bound was load-sensitive rather than wrong, and 15 s is insurance for a
+starved host rather than a behaviour change at normal load.
+
+15 s is exactly as far as the nesting invariant below permits for the tightest
+budget these classes must stay inside: 20 s (`read`/`snapshot`/`screenshot`)
+minus 5 s for the handler to answer. It therefore still fires strictly before
+the daemon's deadline, and it still makes a HUNG call settle, which is the
+property the helper exists for. The remaining honest limit is unchanged and is
+stated rather than hidden: a pathological CHAIN of stalls can still exceed the
+daemon's budget (see below).
+
+The nesting invariant, extending the one in `protocol.py`, is that the innermost
+deadline must fire first:
+
+```
+extension per-call deadline (5-15 s)
+  < extension nav settle (30 s — unchanged; it is bounded already and calibrated
+    to the 30 s open/goto budget)
+  < daemon COMMAND_TIMEOUTS (20-30 s)
+  < daemon awaiting_origin extension (+65 s)
+  < session client timeout (base + 65 + 5)
+```
+
+So a single stalled call answers before the daemon gives up. A pathological
+CHAIN of stalls can still exceed the daemon's budget, which is acceptable — the
+daemon's own timeout is then correct, and §5.2's promotion rule corroborates it
+into `extension_unresponsive` rather than a silent wedge.
+
+Two things must NOT get a deadline. `settle()` is already bounded and its 30 s
+default is calibrated to `open`/`goto`; `input.ts`'s
+`settle(tabId, 10_000).catch(() => undefined)` is deliberately best-effort. And
+`await_access`'s slice is a PRODUCT deadline, not a hang guard.
+
+One deliberate asymmetry to know when reading a `catch`: a deadline rejection
+is OUR event loop stalling, not a fact about the tab. Every `catch` that reads a
+failure as "the tab is gone, prune the surface" must test `isStalled(error)`
+first, or a slow `chrome.tabs.get` retires a live surface and tells the session
+its tab was closed.
+
+The coverage of the rule is a CLOSED SET, and it is one grep rather than a
+review judgement:
+
+```sh
+grep -rn 'await chrome\.' extension/src --include=*.ts | grep -v '/popup/\|/options/'
+```
+
+Everything that returns must carry a `deadline`. That includes
+`access-grants.ts`, which is easy to miss because it looks like its own module
+but is the SAME module-global lane: `withSessionMutation` **is** `withStore`
+(`state.ts`), so its `chrome.storage.local` awaits queue every command of every
+session, and they are command-reachable — the popup's Allow path is
+`worker.ts` → `origins.ts` → `approval-store.ts` → `grantExactOriginLocked` /
+`grantSiteLocked`. Eleven bare awaits there re-opened the incident's exact shape
+on a button click, and falsified the comment in `state.ts` that claimed the lane
+was covered. Bound at source rather than documented as an exemption, therefore:
+a new `await chrome.` anywhere outside `popup/` and `options/` without a
+`deadline` is a hole in the promise, not a special case.
+
+A second consequence of bounding every await is worth stating so it is not
+re-derived: a timed-out `chrome.debugger.attach` rejects BEFORE it registers the
+tab in the local `attached` set, while Chrome may still complete the attach
+afterwards, and a later `detach()` then returns early and leaves a real debugger
+session (and its infobar) behind. That residue is tolerated, not tracked, because
+it reconciles on the next `cdp()` for the tab: the re-attach is refused with
+"already attached" and `ownAttachment` adopts the surviving session.
 
 ### 5.5 Snapshot and click refs
 
@@ -575,6 +788,10 @@ every wait.
 |---|---|
 | No cmux, no bridge state file / stale heartbeat | Tool **not advertised** (createIf) — the honest absence the current builder documents. |
 | Bridge daemon up, extension never connected / browser closed | `browser extension not connected: the bridge daemon is running but no browser is attached. Ask the user to open their browser (the extension reconnects automatically), or check the extension is enabled.` |
+| Attached, paired, and no longer answering | `extension_unresponsive` — the copy says the browser is attached but cannot be driven, advises ONE retry, and then names the measured cure: ask the user to toggle the extension OFF then ON in `chrome://extensions` (pairing preserved; open tab handles, snapshot refs and pending decisions lost). It never says "open your browser", and the daemon keeps answering this rather than `extension_disconnected` for 60 s after it severs the link, so the advised retry cannot land on the wrong message either. |
+| Daemon's own command budget expired (`internal` + `timeout_s`) | Names the action and its budget (`the browser extension received read but did not answer within 20s`), advises one retry, then the same toggle remedy. Codes and internal verb names stay in `details`, not in the sentence. |
+| One chrome/CDP call exceeded its deadline (`internal` + `stalled`) | `the browser extension stalled on <call> and gave up on this command` + retry, then the same toggle remedy. Names the CALL, which is the useful part when reporting it. |
+| Chrome refuses to debug the tab (`internal` + `undrivable_tab`) | `that tab cannot be driven: it is another extension's page, so Chrome refuses the debugger attachment.` + `open` the URL again. Names no tab: the only handle is the session's opaque capability string. |
 | Daemon up, extension unpaired | `browser bridge not paired: run 'lop browser pair' and enter the code in the extension popup, then retry.` |
 | Daemon died between availability check and call (POST refused) | `browser bridge unreachable: the daemon at 127.0.0.1:<port> is not answering. Run 'lop browser status'; 'lop browser install' starts it.` |
 | Origin denied / prompt timeout | `navigation to <origin> was denied by the user (or the permission prompt went unanswered). Do not retry the same origin; ask the user to allow it from the extension popup if it is needed.` |
@@ -723,6 +940,40 @@ Out of scope v1, and why:
   `PROTO_VERSION` mismatches must show up as the popup's "update needed"
   state and the daemon's 4001 close, not as mystery timeouts. Test the
   mismatch path explicitly before the first protocol bump, not after.
+- **What may change WITHOUT a `PROTO_VERSION` bump** — the rule, because it is
+  not obvious and gets violated by accident: a change is free when the other
+  side's degraded behaviour is "ignores it". That covers additive OPTIONAL
+  fields on `/health` (HTTP, not the WS protocol: the popup's interface is
+  structural TS typing, extra JSON keys are ignored at runtime, and `.get()`
+  returning `None` is exactly how the CLI already handles an older daemon),
+  new daemon→session `ErrorCode`s (the extension never PARSES a code, it only
+  emits one, and an old daemon simply never produces the new value), and
+  anything invisible on the wire (bounding a send). It excludes a new WS
+  **frame type** the peer must act on, and any close code the peer must
+  INTERPRET.
+- **The trap that decides which of those applies**: the daemon is STRICT about
+  frames — `WireModel` is `extra="forbid"` — and a `Response.model_validate`
+  failure is a silent `continue` in the receive loop. So an extension that adds
+a field to an EXISTING frame shape has that frame silently DROPPED by any
+already-released daemon, and the command then times out with no error anywhere.
+New information from the extension must therefore travel as a NEW event type
+(which old daemons ignore through the same drop, harmlessly) — never as a new
+field on `Response`, `TabUpdate` or `Hello`. This is also why an extension-side
+failure must not invent an `ErrorCode`: `ErrorDetail.code` is typed to the enum,
+an unknown value fails validation, and the frame is dropped — strictly worse
+than the `internal` + `data` discriminator it can rely on instead (§4.4).
+- **A wedged worker cannot be woken by the toolbar icon.** The popup is served
+  BY the worker, so an unresponsive worker has no popup to open; a reload via
+  `chrome://extensions` (which preserves pairing) or a browser restart is the
+  only recovery. This matters for support: the standard "click the icon" advice
+  is correct for an idle-SUSPENDED worker and a dead end for a wedged one.
+  The popup still renders the state HONESTLY when it is open — a dedicated card
+  keyed on `/health`'s `extension_unresponsive`, with the toggle remedy, instead
+  of the green "Connected." card that used to be painted over a mute worker —
+  and that is deliberately not the primary signal for this reason: the state can
+  reach an already-open popup (a silent link with the popup up, a worker that
+  wedges while it is open), and a surface that lies is worse than one that is
+  merely unreachable.
 - **Backend precedence surprises**: a cmux user with the extension installed
   gets cmux (7.1). If real usage shows people wanting to prefer the bridge
   inside cmux, add an explicit config knob then — do not guess now.

--- a/docs/design/browser-extension.md
+++ b/docs/design/browser-extension.md
@@ -441,7 +441,11 @@ bounded send (§5.4).
 
 The promotion rule fires when a command exhausted its budget while the link was
 ALSO silent for **1.5 ping intervals** (> 30 s), **or** when a direct, bounded
-liveness solicitation goes unanswered inside that method's own budget.
+liveness solicitation goes unanswered. Bounded, but NOT inside the method's own
+budget: the probe starts after the budget has already expired, so the typed
+answer lands one probe window later — **budget + `PING_PROBE_TIMEOUT_S`**, i.e.
+≤ 25 s on a 20 s method (measured 25.009 s, reproduced 25.007 s; QA Q2-4/Q3-2).
+Size any downstream budget from THAT figure, not from the method's own timeout.
 
 **Why the threshold alone was not enough (recorded from review R2-3 / QA Q2-4).**
 The slack above is the same reasoning the 50 s threshold uses, and it is
@@ -469,8 +473,12 @@ event-loop turn whatever it is doing (§5.4), and the daemon is demonstrably ali
 at the moment it probes — it is running the timeout path — which is precisely the
 ambiguity R1-2 was about. An unanswered SOLICITATION is evidence; an elapsed
 clock is not. The 5 s window is bounded by the same generosity argument as
-`LINK_SEND_TIMEOUT_S`, and it is a magnitude below the smallest method budget,
-which is what "respects each method's budget" has to mean here. The clearly
+`LINK_SEND_TIMEOUT_S`, and it is what makes the rule reachable for the tight
+methods at all — but it is ADDED to their budget rather than fitting inside it.
+This passage claimed the opposite until QA Q3-2 measured the answer at
+**25.009 s on a 20 s `read`** (reproduced 25.007 s): "within the budget plus the
+probe window" is the honest phrasing, and a bound sized from "a magnitude below
+the smallest method budget" would be 5 s short. The clearly
 corroborated case short-circuits on the OR before probing, so a dead peer is
 still severed without the extra wait.
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {

--- a/extension/src/access-grants.ts
+++ b/extension/src/access-grants.ts
@@ -11,11 +11,24 @@ import {
   validHostGrantSchema,
   validSiteGrantSchema,
 } from "./origin-policy";
+import { CHROME_API_DEADLINE_MS, deadline } from "./settle";
 import { withSessionMutation } from "./state";
 
 /** Persistent grants and the session approval queue share one worker-owned
  * mutation chain. The `Locked` helpers exist for approval-store, which already
- * owns that chain while committing the durable grant before queue receipts. */
+ * owns that chain while committing the durable grant before queue receipts.
+ *
+ * EVERY `chrome.storage.local.*` await below is wrapped in `deadline`, and that
+ * is load-bearing rather than defensive: `withSessionMutation` IS
+ * `withStore` (state.ts), i.e. these run on the SAME module-global lane as
+ * `putSurface`/`getSurfaces`/`touchSurface`, so every command of every session
+ * queues behind them. They are also command-reachable — the popup's Allow path
+ * goes `worker.ts` dispatch → `origins.ts` `resolveOrigin` →
+ * `approval-store.ts` `decideAccess` (inside `withSessionMutation`) →
+ * `grantExactOriginLocked`/`grantSiteLocked` here. One hung
+ * `chrome.storage.local.get` therefore parks the whole lane forever, which is
+ * the incident's exact shape on a path a user reaches by clicking a button.
+ * A new `await chrome.` added to this file without a `deadline` re-opens it. */
 
 function validGrant(value: unknown): value is HostGrant {
   return !!value && typeof value === "object" && !Array.isArray(value) &&
@@ -88,16 +101,24 @@ export function normalizedSiteGrants(value: unknown): SiteGrantsState | null {
 
 export async function grantExactOriginLocked(origin: string): Promise<boolean> {
   const url = new URL(origin);
-  const { origins = {}, hostGrants, siteGrants } = await chrome.storage.local.get([
-    "origins",
-    "hostGrants",
-    "siteGrants",
-  ]);
+  const { origins = {}, hostGrants, siteGrants } = (await deadline(
+    chrome.storage.local.get(["origins", "hostGrants", "siteGrants"]),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.local.get(origins, hostGrants, siteGrants)",
+  )) as {
+    origins?: Record<string, string>;
+    hostGrants?: unknown;
+    siteGrants?: unknown;
+  };
   // A broad grant already covers this exact origin. Do not recreate a hidden
   // redundant row after the broad approval compacted it away.
   const covering = matchingGrantScope({}, hostGrants, url, siteGrants);
   if (covering === "loopback_all_ports" || covering === "domain" || covering === "host") return true;
-  await chrome.storage.local.set({ origins: { ...origins, [origin]: "allow" } });
+  await deadline(
+    chrome.storage.local.set({ origins: { ...origins, [origin]: "allow" } }),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.local.set(origins)",
+  );
   return true;
 }
 
@@ -107,10 +128,18 @@ export function grantExactOrigin(origin: string): Promise<boolean> {
 
 export function revokeExactOrigin(origin: string): Promise<boolean> {
   return withSessionMutation(async () => {
-    const { origins = {} } = await chrome.storage.local.get(["origins"]);
+    const { origins = {} } = (await deadline(
+      chrome.storage.local.get(["origins"]),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.local.get(origins)",
+    )) as { origins?: Record<string, string> };
     const next = { ...origins };
     delete next[origin];
-    await chrome.storage.local.set({ origins: next });
+    await deadline(
+      chrome.storage.local.set({ origins: next }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.local.set(origins)",
+    );
     return true;
   });
 }
@@ -126,7 +155,11 @@ export async function grantSiteLocked(url: URL): Promise<boolean> {
   // stored key that no longer derives is tolerated (A2); a NEW one that does
   // not derive would be a bug in broadGrantFor, and is refused here.
   if (!validSiteGrantKey(broad.key, broad.scope)) return false;
-  const { siteGrants, origins = {} } = await chrome.storage.local.get(["siteGrants", "origins"]);
+  const { siteGrants, origins = {} } = (await deadline(
+    chrome.storage.local.get(["siteGrants", "origins"]),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.local.get(siteGrants, origins)",
+  )) as { siteGrants?: unknown; origins?: Record<string, string> };
   if (siteGrants !== undefined && !normalizedSiteGrants(siteGrants)) return false;
   const current = normalizedSiteGrants(siteGrants) ?? { version: 1 as const, grants: {} };
   const remainingOrigins = Object.fromEntries(
@@ -145,13 +178,17 @@ export async function grantSiteLocked(url: URL): Promise<boolean> {
   );
   // One multi-key storage write is the durable transaction: failure cannot
   // report success after cleaning exact grants without storing the broad one.
-  await chrome.storage.local.set({
-    origins: remainingOrigins,
-    siteGrants: {
-      version: 1,
-      grants: { ...current.grants, [broad.key]: { scope: broad.scope, createdAt: Date.now() } },
-    },
-  });
+  await deadline(
+    chrome.storage.local.set({
+      origins: remainingOrigins,
+      siteGrants: {
+        version: 1,
+        grants: { ...current.grants, [broad.key]: { scope: broad.scope, createdAt: Date.now() } },
+      },
+    }),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.local.set(origins, siteGrants)",
+  );
   return true;
 }
 
@@ -161,7 +198,11 @@ export function grantSite(url: URL): Promise<boolean> {
 
 export function revokeSiteGrant(key: string): Promise<boolean> {
   return withSessionMutation(async () => {
-    const { siteGrants } = await chrome.storage.local.get(["siteGrants"]);
+    const { siteGrants } = (await deadline(
+      chrome.storage.local.get(["siteGrants"]),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.local.get(siteGrants)",
+    )) as { siteGrants?: unknown };
     const current = normalizedSiteGrants(siteGrants);
     if (!current) return false;
     // Report failure rather than a false "Removed …" for a key that was never
@@ -169,7 +210,11 @@ export function revokeSiteGrant(key: string): Promise<boolean> {
     if (!(key in current.grants)) return false;
     const grants = { ...current.grants };
     delete grants[key];
-    await chrome.storage.local.set({ siteGrants: { version: 1, grants } });
+    await deadline(
+      chrome.storage.local.set({ siteGrants: { version: 1, grants } }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.local.set(siteGrants)",
+    );
     return true;
   });
 }
@@ -179,12 +224,20 @@ export function revokeSiteGrant(key: string): Promise<boolean> {
  * existing one can still be removed. */
 export function revokeLoopbackHost(canonicalKey: string): Promise<boolean> {
   return withSessionMutation(async () => {
-    const { hostGrants } = await chrome.storage.local.get(["hostGrants"]);
+    const { hostGrants } = (await deadline(
+      chrome.storage.local.get(["hostGrants"]),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.local.get(hostGrants)",
+    )) as { hostGrants?: unknown };
     const current = normalizedHostGrants(hostGrants);
     if (!current) return false;
     const grants = { ...current.grants };
     delete grants[canonicalKey];
-    await chrome.storage.local.set({ hostGrants: { version: 1, grants } });
+    await deadline(
+      chrome.storage.local.set({ hostGrants: { version: 1, grants } }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.local.set(hostGrants)",
+    );
     return true;
   });
 }
@@ -193,7 +246,11 @@ export function clearAllAccessGrants(): Promise<boolean> {
   return withSessionMutation(async () => {
     // Unpairing also drops the all-sites bypass: a browser that is no longer
     // trusted must not come back pre-opened when it is paired again.
-    await chrome.storage.local.remove(["token", "origins", "hostGrants", "siteGrants", "allowAllSites"]);
+    await deadline(
+      chrome.storage.local.remove(["token", "origins", "hostGrants", "siteGrants", "allowAllSites"]),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.local.remove(grants)",
+    );
     return true;
   });
 }

--- a/extension/src/approval-store.ts
+++ b/extension/src/approval-store.ts
@@ -22,6 +22,7 @@ import {
 } from "./access-queue";
 import { grantExactOriginLocked, grantSiteLocked } from "./access-grants";
 import { broadGrantFor } from "./origin-policy";
+import { CHROME_API_DEADLINE_MS, deadline } from "./settle";
 import { getLocal, getSession, withSessionMutation, type SessionState } from "./state";
 
 export interface QueueSnapshot {
@@ -66,9 +67,18 @@ export function nextAccessExpiry(snapshot: QueueSnapshot): number | undefined {
 
 export async function armNextExpiry(snapshot: QueueSnapshot): Promise<void> {
   const when = nextAccessExpiry(snapshot);
+  // `chrome.alarms.clear` is the one storage-class await on this lane that does
+  // not go through state.ts, so it needs the same bound as everything else the
+  // queue sweep awaits: the sweep runs inside the approval-store mutation lane,
+  // and an unbounded await there parks every later approval for every session.
   if (when === undefined) {
-    await chrome.alarms.clear(ACCESS_EXPIRY_ALARM);
+    await deadline(
+      chrome.alarms.clear(ACCESS_EXPIRY_ALARM),
+      CHROME_API_DEADLINE_MS,
+      "chrome.alarms.clear(access expiry)",
+    );
   } else {
+    // create() is synchronous (void), not a promise to await.
     chrome.alarms.create(ACCESS_EXPIRY_ALARM, { when });
   }
 }
@@ -145,25 +155,39 @@ async function normalizedLocked(now: number): Promise<QueueSnapshot> {
     }
   }
   queue.sort((a, b) => a.sequence - b.sequence);
-  await chrome.storage.session.set({
-    accessQueueVersion: ACCESS_QUEUE_VERSION,
-    accessQueue: queue,
-    accessResults: cleanResults(results, now),
-    onceGrants,
-  });
-  if (needsMigration) await chrome.storage.session.remove(["accessRequest", "pendingOrigin"]);
+  await deadline(
+    chrome.storage.session.set({
+      accessQueueVersion: ACCESS_QUEUE_VERSION,
+      accessQueue: queue,
+      accessResults: cleanResults(results, now),
+      onceGrants,
+    }),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.session.set(access queue)",
+  );
+  if (needsMigration) {
+    await deadline(
+      chrome.storage.session.remove(["accessRequest", "pendingOrigin"]),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.remove(legacy access records)",
+    );
+  }
   const snapshot = { queue, results: cleanResults(results, now), onceGrants };
   await armNextExpiry(snapshot);
   return snapshot;
 }
 
 async function persistLocked(snapshot: QueueSnapshot): Promise<void> {
-  await chrome.storage.session.set({
-    accessQueueVersion: ACCESS_QUEUE_VERSION,
-    accessQueue: snapshot.queue,
-    accessResults: snapshot.results,
-    onceGrants: snapshot.onceGrants,
-  });
+  await deadline(
+    chrome.storage.session.set({
+      accessQueueVersion: ACCESS_QUEUE_VERSION,
+      accessQueue: snapshot.queue,
+      accessResults: snapshot.results,
+      onceGrants: snapshot.onceGrants,
+    }),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.session.set(access queue)",
+  );
   await armNextExpiry(snapshot);
 }
 

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -1,16 +1,26 @@
+import { BridgeCommandError } from "./errors";
 import { dropLogCapture } from "./log-capture";
+import { CHROME_API_DEADLINE_MS, CDP_ATTACH_DEADLINE_MS, CDP_DEADLINE_MS, deadline } from "./settle";
 import { getSurfaces, removeSurface, resolveSurfaceToken, touchSurface, type StoredSurface } from "./state";
+
+// Re-exported so the many existing `import { BridgeCommandError } from
+// "./cdp"` sites stay valid; see errors.ts for why the value's home moved.
+export { BridgeCommandError } from "./errors";
 
 const attached = new Set<number>();
 
-export class BridgeCommandError extends Error {
-  constructor(
-    public readonly code: string,
-    message: string,
-    public readonly data: Record<string, unknown> = {},
-  ) {
-    super(message);
-  }
+/**
+ * Whether an error is one of OUR OWN per-call deadlines (`settle.deadline`)
+ * rather than a refusal from Chrome.
+ *
+ * Every `catch` that reads a failure as "the tab is gone, prune the surface"
+ * must discriminate on this first. A stall is a fact about this worker's event
+ * loop, not about the tab: pruning a live surface because one `chrome.tabs.get`
+ * was slow would tell the session its tab had been closed — the same class of
+ * confident misdiagnosis that made the reported wedge expensive.
+ */
+export function isStalled(error: unknown): boolean {
+  return error instanceof BridgeCommandError && Boolean(error.data.stalled);
 }
 
 export async function requireSurface(token: unknown): Promise<StoredSurface> {
@@ -24,8 +34,14 @@ export async function requireSurface(token: unknown): Promise<StoredSurface> {
     throw new BridgeCommandError("tab_closed", "the browser tab handle is stale");
   }
   try {
-    await chrome.tabs.get(surface.tabId);
-  } catch {
+    await deadline(
+      chrome.tabs.get(surface.tabId),
+      CHROME_API_DEADLINE_MS,
+      `chrome.tabs.get(${surface.tabId})`,
+    );
+  } catch (error) {
+    // Our own deadline is not a missing tab (see isStalled).
+    if (isStalled(error)) throw error;
     // The Chrome tab is gone: full prune, identical to the `tabs` prune site
     // (review finding m1) — dropping only the map entry leaked the log ring
     // buffer and left the dead tabId in the `attached` set for the worker's
@@ -53,12 +69,54 @@ export async function pruneSurface(token: string, tabId: number): Promise<void> 
   await removeSurface(token);
 }
 
+/**
+ * Prune every surface bound to one Chrome tab id.
+ *
+ * `attach` is addressed by numeric tab id (that is how CDP works) but a surface
+ * can only be removed by its TOKEN, so a failure that has to retire the surface
+ * must go through the map. Best-effort by construction: this runs on the way to
+ * an error that has already been decided, and a storage failure here must not
+ * replace it with a different one.
+ */
+async function pruneSurfaceByTabId(tabId: number): Promise<void> {
+  try {
+    const surfaces = await getSurfaces();
+    for (const token of Object.keys(surfaces)) {
+      if (surfaces[token]?.tabId === tabId) await pruneSurface(token, tabId);
+    }
+  } catch (error) {
+    console.warn(`could not prune surfaces for tab ${tabId}`, error);
+  }
+}
+
+/** Chrome's refusal to debug a page belonging to a DIFFERENT extension. */
+const DIFFERENT_EXTENSION = "chrome-extension:// URL of different extension";
+
 export async function attach(tabId: number): Promise<void> {
   if (attached.has(tabId)) return;
   try {
-    await chrome.debugger.attach({ tabId }, "1.3");
+    await deadline(
+      chrome.debugger.attach({ tabId }, "1.3"),
+      CDP_ATTACH_DEADLINE_MS,
+      `chrome.debugger.attach(${tabId})`,
+    );
+    // Reached only when the attach RESOLVED. A deadline rejection lands in the
+    // catch below WITHOUT registering the tab here, and the abandoned attach can
+    // still complete in Chrome afterwards — leaving a live debugger session (and
+    // its "…is debugging this browser" infobar) that a later `detach()` skips
+    // because `attached.has(tabId)` is false. That residue is deliberately
+    // tolerated rather than tracked: it reconciles on the next `cdp()` for this
+    // tab, where the re-attach is refused with "already attached" and
+    // `ownAttachment` adopts the surviving session, and until then nothing can
+    // drive the tab anyway (review R1-4). `onDetach` would not cover it even if
+    // we wanted it to, because it does not fire for an attach that never
+    // registered locally.
     attached.add(tabId);
   } catch (error) {
+    // A deadline here is our own bound firing, not a refusal: rethrow it so the
+    // `stalled` discriminator survives instead of being flattened into a
+    // generic internal error by the fallback below.
+    if (isStalled(error)) throw error;
     const message = String(error);
     if (message.includes("Another debugger") || message.includes("already attached")) {
       // The module-global `attached` set does not survive service-worker death,
@@ -74,6 +132,25 @@ export async function attach(tabId: number): Promise<void> {
       }
       throw new BridgeCommandError("debugger_conflict", message);
     }
+    if (message.includes(DIFFERENT_EXTENSION)) {
+      // The tab is (or redirected to) another extension's page, which Chrome
+      // refuses to debug. It is alive but can NEVER be driven, and unlike a
+      // failed `chrome.tabs.get` this refusal used to leave the surface in the
+      // map — so every later command for it failed the same way permanently,
+      // including a fresh `open` (reported from a live session: a `scroll`
+      // timeout, then this message on the retry, then the same on `open`).
+      // Retire the surface so the session's next `open` starts from a clean
+      // map, and say what happened and what to do about it: `internal` plus a
+      // data discriminator is this protocol's pattern for exactly this shape
+      // (`tab_crashed`), and a NEW wire code would be silently dropped by any
+      // already-released daemon that does not know it.
+      await pruneSurfaceByTabId(tabId);
+      throw new BridgeCommandError(
+        "internal",
+        "Chrome refused to debug this tab: it is another extension's page",
+        { undrivable_tab: "different_extension" },
+      );
+    }
     throw new BridgeCommandError("internal", message);
   }
 }
@@ -82,8 +159,17 @@ async function ownAttachment(tabId: number): Promise<boolean> {
   // A tab we can still drive answers a trivial CDP command; a tab held by a
   // foreign debugger rejects it. This distinguishes our surviving attachment
   // from DevTools without a fragile string match on Chrome's error text.
+  //
+  // Bounded, and deliberately still catch-all: a probe that does not answer is
+  // a session we cannot drive, so `false` (⇒ debugger_conflict) is the answer
+  // this function exists to give. A per-call deadline that turned a REAL
+  // conflict into a generic stall would be the worse failure.
   try {
-    await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", { expression: "1" });
+    await deadline(
+      chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", { expression: "1" }),
+      CDP_ATTACH_DEADLINE_MS,
+      `chrome.debugger.sendCommand(Runtime.evaluate probe on ${tabId})`,
+    );
     return true;
   } catch {
     return false;
@@ -93,9 +179,15 @@ async function ownAttachment(tabId: number): Promise<boolean> {
 export async function detach(tabId: number): Promise<void> {
   if (!attached.has(tabId)) return;
   try {
-    await chrome.debugger.detach({ tabId });
+    await deadline(
+      chrome.debugger.detach({ tabId }),
+      CDP_ATTACH_DEADLINE_MS,
+      `chrome.debugger.detach(${tabId})`,
+    );
   } catch {
-    // Close is idempotent; a browser-initiated detach already achieved it.
+    // Close is idempotent; a browser-initiated detach already achieved it. A
+    // deadline lands here too, on purpose: a detach we cannot complete must not
+    // park pruneSurface (and through it the store queue) forever.
   }
   attached.delete(tabId);
 }
@@ -107,8 +199,13 @@ export async function cdp<T>(
 ): Promise<T> {
   await attach(tabId);
   try {
-    return (await chrome.debugger.sendCommand({ tabId }, method, params)) as T;
+    return (await deadline(
+      chrome.debugger.sendCommand({ tabId }, method, params),
+      CDP_DEADLINE_MS,
+      `chrome.debugger.sendCommand(${method})`,
+    )) as T;
   } catch (error) {
+    if (isStalled(error)) throw error;
     throw new BridgeCommandError("internal", String(error));
   }
 }

--- a/extension/src/commands/input.ts
+++ b/extension/src/commands/input.ts
@@ -1,6 +1,6 @@
 import { BridgeCommandError, cdp, requireSurface } from "../cdp";
 import { withOriginGate } from "../origins";
-import { settle } from "../settle";
+import { CHROME_API_DEADLINE_MS, deadline, settle } from "../settle";
 import { getRefs, surfaceToken, type StoredSurface } from "../state";
 
 interface QueryResult { nodeId?: number }
@@ -68,7 +68,13 @@ export async function click(
   requestId: string,
 ): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
-  const before = (await chrome.tabs.get(surface.tabId)).url ?? "";
+  const before = (
+    await deadline(
+      chrome.tabs.get(surface.tabId),
+      CHROME_API_DEADLINE_MS,
+      `chrome.tabs.get(${surface.tabId})`,
+    )
+  ).url ?? "";
   const nodeId = await nodeIdFor(surface, params.selector ?? params.ref);
   await cdp(surface.tabId, "DOM.scrollIntoViewIfNeeded", { nodeId });
   const objectId = await objectIdFor(surface.tabId, nodeId);
@@ -120,7 +126,11 @@ export async function click(
     chrome.webNavigation.onBeforeNavigate.removeListener(onBefore);
     chrome.webNavigation.onHistoryStateUpdated.removeListener(onHistory);
   }
-  const tab = await chrome.tabs.get(surface.tabId);
+  const tab = await deadline(
+    chrome.tabs.get(surface.tabId),
+    CHROME_API_DEADLINE_MS,
+    `chrome.tabs.get(${surface.tabId})`,
+  );
   const navigated = navigationSeen || (tab.url ?? "") !== before;
   return { navigated, url: tab.url ?? "", title: tab.title ?? "" };
 }
@@ -159,6 +169,10 @@ export async function typeText(params: Record<string, unknown>): Promise<Record<
     }`,
     [String(params.text ?? "")],
   );
-  const tab = await chrome.tabs.get(surface.tabId);
+  const tab = await deadline(
+    chrome.tabs.get(surface.tabId),
+    CHROME_API_DEADLINE_MS,
+    `chrome.tabs.get(${surface.tabId})`,
+  );
   return { value: value ?? "", url: tab.url ?? "", title: tab.title ?? "" };
 }

--- a/extension/src/commands/logs.ts
+++ b/extension/src/commands/logs.ts
@@ -1,5 +1,6 @@
 import { requireSurface } from "../cdp";
 import { readLogs } from "../log-capture";
+import { CHROME_API_DEADLINE_MS, deadline } from "../settle";
 
 // Levels the tool filters on. "all" (the default) keeps everything; anything
 // else must match one of these normalized levels, so a typo'd filter returns an
@@ -21,6 +22,10 @@ export async function logs(params: Record<string, unknown>): Promise<Record<stri
   // limit 0/absent means "no cap"; a positive value keeps the most recent n.
   const limit = typeof params.limit === "number" && params.limit > 0 ? Math.floor(params.limit) : 0;
   const entries = readLogs(surface.tabId, level, limit);
-  const tab = await chrome.tabs.get(surface.tabId);
+  const tab = await deadline(
+    chrome.tabs.get(surface.tabId),
+    CHROME_API_DEADLINE_MS,
+    `chrome.tabs.get(${surface.tabId})`,
+  );
   return { entries, level, url: tab.url ?? "", title: tab.title ?? "" };
 }

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -1,4 +1,4 @@
-import { attach, BridgeCommandError, cdp, detach, pruneSurface, requireSurface } from "../cdp";
+import { attach, BridgeCommandError, cdp, detach, isStalled, pruneSurface, requireSurface } from "../cdp";
 import { dropLogCapture, startLogCapture } from "../log-capture";
 import {
   askOrigin,
@@ -7,7 +7,7 @@ import {
   withOriginGate,
   type OriginAdmission,
 } from "../origins";
-import { settle } from "../settle";
+import { CHROME_API_DEADLINE_MS, deadline, settle } from "../settle";
 import { reconcileTabGroup } from "../tab-groups";
 import { recordAllocation } from "../ownership";
 import {
@@ -34,9 +34,17 @@ async function liveSurfaces(): Promise<Record<string, StoredSurface>> {
   const live: Record<string, StoredSurface> = {};
   for (const [token, surface] of Object.entries(surfaces)) {
     try {
-      await chrome.tabs.get(surface.tabId);
+      await deadline(
+        chrome.tabs.get(surface.tabId),
+        CHROME_API_DEADLINE_MS,
+        `chrome.tabs.get(${surface.tabId})`,
+      );
       live[token] = surface;
-    } catch {
+    } catch (error) {
+      // Only a real "no such tab" prunes. A per-call deadline means OUR event
+      // loop stalled, which says nothing about the tab — pruning a live surface
+      // here would retire a tab the session is still driving.
+      if (isStalled(error)) throw error;
       await pruneSurface(token, surface.tabId);
     }
   }
@@ -52,7 +60,11 @@ function sessionRequester(params: Record<string, unknown>): string {
 }
 
 async function page(tabId: number): Promise<{ url: string; title: string }> {
-  const tab = await chrome.tabs.get(tabId);
+  const tab = await deadline(
+    chrome.tabs.get(tabId),
+    CHROME_API_DEADLINE_MS,
+    `chrome.tabs.get(${tabId})`,
+  );
   return { url: tab.url ?? "", title: tab.title ?? "" };
 }
 
@@ -73,7 +85,11 @@ async function navigate(tabId: number, url: URL, requestId: string, admission: O
     requestId,
     async () => {
       const waiting = settle(tabId);
-      await chrome.tabs.update(tabId, { url: url.href });
+      await deadline(
+        chrome.tabs.update(tabId, { url: url.href }),
+        CHROME_API_DEADLINE_MS,
+        `chrome.tabs.update(${tabId})`,
+      );
       await waiting;
       return page(tabId);
     },
@@ -144,7 +160,11 @@ export async function open(params: Record<string, unknown>, requestId: string): 
   // Create about:blank first. Creating directly at the destination starts its
   // redirect chain before a debugger can attach, leaving a race where a second
   // origin could receive cookies before the permission gate exists.
-  const tab = await chrome.tabs.create({ active: false, url: "about:blank" });
+  const tab = await deadline(
+    chrome.tabs.create({ active: false, url: "about:blank" }),
+    CHROME_API_DEADLINE_MS,
+    "chrome.tabs.create",
+  );
   if (tab.id === undefined) throw new BridgeCommandError("internal", "Chrome created no tab id");
   const now = Date.now();
   const surface: StoredSurface = {
@@ -237,7 +257,11 @@ export async function tabs(_params: Record<string, unknown>): Promise<Record<str
   const live: Record<string, unknown>[] = [];
   for (const [token, surface] of Object.entries(surfaces)) {
     try {
-      const tab = await chrome.tabs.get(surface.tabId);
+      const tab = await deadline(
+        chrome.tabs.get(surface.tabId),
+        CHROME_API_DEADLINE_MS,
+        `chrome.tabs.get(${surface.tabId})`,
+      );
       live.push({
         tab: redactToken(token),
         url: tab.url ?? "",
@@ -245,8 +269,10 @@ export async function tabs(_params: Record<string, unknown>): Promise<Record<str
         createdAt: surface.createdAt,
         lastUsedAt: surface.lastUsedAt,
       });
-    } catch {
-      // Closed between the liveness pass and this read — rare; prune now.
+    } catch (error) {
+      // Closed between the liveness pass and this read — rare; prune now. A
+      // per-call deadline is not that (see isStalled).
+      if (isStalled(error)) throw error;
       await pruneSurface(token, surface.tabId);
     }
   }
@@ -258,11 +284,21 @@ async function closeSurface(token: string, surface: StoredSurface): Promise<void
   dropLogCapture(surface.tabId);
   await detach(surface.tabId);
   try {
-    await chrome.tabs.remove(surface.tabId);
+    await deadline(
+      chrome.tabs.remove(surface.tabId),
+      CHROME_API_DEADLINE_MS,
+      `chrome.tabs.remove(${surface.tabId})`,
+    );
   } catch (error) {
     // Only a confirmed missing tab is idempotent success. Policy/debugger or
     // transient failures must leave the capability available for retry.
-    try { await chrome.tabs.get(surface.tabId); } catch (missing) {
+    try {
+      await deadline(
+        chrome.tabs.get(surface.tabId),
+        CHROME_API_DEADLINE_MS,
+        `chrome.tabs.get(${surface.tabId})`,
+      );
+    } catch (missing) {
       if (missing instanceof Error && /No tab with id|Invalid tab ID/i.test(missing.message)) {
         await removeSurface(token);
         return;

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -18,6 +18,7 @@ import {
   redactToken,
   removeSurface,
   surfaceToken,
+  withAdmission,
   type StoredSurface,
 } from "../state";
 
@@ -140,50 +141,68 @@ export async function open(params: Record<string, unknown>, requestId: string): 
     await putSurface(surface);
     return { tab: surfaceToken(surface), ...result };
   }
-  const surfaces = await liveSurfaces();
-  if (atSurfaceCap(surfaces)) {
-    // Typed refusal, not silent reuse: each parallel session opens its own
-    // tab now, so an unbounded map would let an agent fleet spray tabs into
-    // the user's real browser. See MAX_SURFACES for the cap rationale.
-    // Handles are REDACTED: the full token is the drive capability, and an
-    // error surface must not hand one session control of another's tab
-    // (finding M1).
-    throw new BridgeCommandError(
-      "tab_limit",
-      `already driving ${MAX_SURFACES} tabs — close one (action 'close' with its handle) before opening another`,
-      { limit: MAX_SURFACES, tabs: Object.keys(surfaces).map(redactToken) },
+  // ADMISSION: the cap read, the tab creation and the surface write are ONE
+  // atomic window (state.ts's `withAdmission`), and nothing else is. Two owners
+  // admitted concurrently would otherwise both read the last free slot and both
+  // take it — nine tabs against a cap of eight.
+  //
+  // Everything the old (global, whole-handler) lane covered is deliberately
+  // OUTSIDE this window: attach, log capture, grouping, and `navigate()` — which
+  // can park on a redirect's human origin-approval prompt — plus the whole
+  // rollback below. Those are post-admission work on a slot that has already
+  // been consumed, so they cannot change the count except by releasing it (and
+  // release goes through the store queue, which the next cap read observes);
+  // holding them inside is what let one owner's slow navigation delay a
+  // different owner's admission (audit A4).
+  const surface = await withAdmission(async () => {
+    const surfaces = await liveSurfaces();
+    if (atSurfaceCap(surfaces)) {
+      // Typed refusal, not silent reuse: each parallel session opens its own
+      // tab now, so an unbounded map would let an agent fleet spray tabs into
+      // the user's real browser. See MAX_SURFACES for the cap rationale.
+      // Handles are REDACTED: the full token is the drive capability, and an
+      // error surface must not hand one session control of another's tab
+      // (finding M1).
+      throw new BridgeCommandError(
+        "tab_limit",
+        `already driving ${MAX_SURFACES} tabs — close one (action 'close' with its handle) before opening another`,
+        { limit: MAX_SURFACES, tabs: Object.keys(surfaces).map(redactToken) },
+      );
+    }
+    // No separate pre-create gate: ensureTopLevelAccess above already refused a
+    // not-allowed origin, and gating again here would double-consume a once
+    // grant before navigate() (the single consumption point) ran.
+    // Create about:blank first. Creating directly at the destination starts its
+    // redirect chain before a debugger can attach, leaving a race where a second
+    // origin could receive cookies before the permission gate exists.
+    const tab = await deadline(
+      chrome.tabs.create({ active: false, url: "about:blank" }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.tabs.create",
     );
-  }
-  // No separate pre-create gate: ensureTopLevelAccess above already refused a
-  // not-allowed origin, and gating again here would double-consume a once
-  // grant before navigate() (the single consumption point) ran.
-  // Create about:blank first. Creating directly at the destination starts its
-  // redirect chain before a debugger can attach, leaving a race where a second
-  // origin could receive cookies before the permission gate exists.
-  const tab = await deadline(
-    chrome.tabs.create({ active: false, url: "about:blank" }),
-    CHROME_API_DEADLINE_MS,
-    "chrome.tabs.create",
-  );
-  if (tab.id === undefined) throw new BridgeCommandError("internal", "Chrome created no tab id");
-  const now = Date.now();
-  const surface: StoredSurface = {
-    tabId: tab.id,
-    nonce: crypto.randomUUID().replaceAll("-", ""),
-    epoch: 1,
-    allocationId: typeof params.allocation_id === "string" ? params.allocation_id : undefined,
-    createdAt: now,
-    lastUsedAt: now,
-  };
+    if (tab.id === undefined) throw new BridgeCommandError("internal", "Chrome created no tab id");
+    const now = Date.now();
+    const fresh: StoredSurface = {
+      tabId: tab.id,
+      nonce: crypto.randomUUID().replaceAll("-", ""),
+      epoch: 1,
+      allocationId: typeof params.allocation_id === "string" ? params.allocation_id : undefined,
+      createdAt: now,
+      lastUsedAt: now,
+    };
+    // The write that CONSUMES the slot. It must land inside the lane, or a
+    // concurrent admission's cap read cannot see it.
+    await putSurface(fresh);
+    return fresh;
+  });
   try {
-    await putSurface(surface);
     await recordAllocation(params, surfaceToken(surface), "allocated");
-    await attach(tab.id);
+    await attach(surface.tabId);
     // Arm capture and the origin gate before navigation; opening directly at
     // the destination would let a redirect escape permission admission.
-    await startLogCapture(tab.id, cdp);
+    await startLogCapture(surface.tabId, cdp);
     await reconcileTabGroup(surface, params, true);
-    const live = await navigate(tab.id, url, requestId, admission);
+    const live = await navigate(surface.tabId, url, requestId, admission);
     await recordAllocation(params, surfaceToken(surface), "owned");
     return { tab: surfaceToken(surface), ...live };
   } catch (error) {

--- a/extension/src/commands/read.ts
+++ b/extension/src/commands/read.ts
@@ -1,9 +1,12 @@
 import { BridgeCommandError, requireSurface } from "../cdp";
+import { CHROME_API_DEADLINE_MS, SCRIPTING_DEADLINE_MS, deadline } from "../settle";
 
 export async function readPage(params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
   const selector = typeof params.selector === "string" && params.selector ? params.selector : "body";
-  const results = await chrome.scripting.executeScript({
+  // Runs page script, so it shares the CDP risk profile and `read`'s 20 s
+  // daemon budget (settle.ts's deadline table).
+  const results = await deadline(chrome.scripting.executeScript({
     target: { tabId: surface.tabId },
     func: (query: string) => {
       const element = document.querySelector(query);
@@ -16,9 +19,13 @@ export async function readPage(params: Record<string, unknown>): Promise<Record<
         .trim();
     },
     args: [selector],
-  });
+  }), SCRIPTING_DEADLINE_MS, `chrome.scripting.executeScript(${surface.tabId})`);
   const text = results[0]?.result;
   if (text === null) throw new BridgeCommandError("element_not_found", `selector ${selector} matched nothing`);
-  const tab = await chrome.tabs.get(surface.tabId);
+  const tab = await deadline(
+    chrome.tabs.get(surface.tabId),
+    CHROME_API_DEADLINE_MS,
+    `chrome.tabs.get(${surface.tabId})`,
+  );
   return { text: String(text ?? ""), url: tab.url ?? "", title: tab.title ?? "" };
 }

--- a/extension/src/commands/scroll.ts
+++ b/extension/src/commands/scroll.ts
@@ -5,6 +5,7 @@ import {
   SCROLL_INTO_VIEW_FN,
   scrollExpressionFor,
 } from "../scroll-expressions";
+import { CHROME_API_DEADLINE_MS, deadline } from "../settle";
 import { getRefs, surfaceToken, type StoredSurface } from "../state";
 
 interface CallResult { result: { value?: unknown } }
@@ -168,6 +169,10 @@ export async function scroll(params: Record<string, unknown>): Promise<Record<st
   // after; a short settle keeps the reported position and moreBelow honest.
   await new Promise((resolve) => setTimeout(resolve, 150));
   const metrics = await readMetrics(tabId);
-  const tab = await chrome.tabs.get(tabId);
+  const tab = await deadline(
+    chrome.tabs.get(tabId),
+    CHROME_API_DEADLINE_MS,
+    `chrome.tabs.get(${tabId})`,
+  );
   return { ...metrics, url: tab.url ?? "", title: tab.title ?? "" };
 }

--- a/extension/src/commands/shot.ts
+++ b/extension/src/commands/shot.ts
@@ -1,8 +1,13 @@
 import { cdp, requireSurface } from "../cdp";
+import { CHROME_API_DEADLINE_MS, deadline } from "../settle";
 
 export async function screenshot(params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
   const shot = await cdp<{ data: string }>(surface.tabId, "Page.captureScreenshot", { format: "png" });
-  const tab = await chrome.tabs.get(surface.tabId);
+  const tab = await deadline(
+    chrome.tabs.get(surface.tabId),
+    CHROME_API_DEADLINE_MS,
+    `chrome.tabs.get(${surface.tabId})`,
+  );
   return { data: shot.data, url: tab.url ?? "", title: tab.title ?? "" };
 }

--- a/extension/src/commands/snapshot.ts
+++ b/extension/src/commands/snapshot.ts
@@ -3,18 +3,32 @@ import { cdp, requireSurface } from "../cdp";
 import { CHROME_API_DEADLINE_MS, deadline } from "../settle";
 import { setRefs, surfaceToken } from "../state";
 
-// Serializes the enable→read→disable window below. The worker dispatches
-// daemon frames fire-and-forget (worker.ts onmessage), so two concurrent
-// snapshots could otherwise interleave as enable/enable/read/DISABLE/read —
-// the second read then hits a disabled a11y engine and risks a degraded
-// tree. The daemon pipelines commands per tab today, so this is
-// latent, but the extension should not depend on that scheduling promise.
-// A promise chain (not a refcount) keeps it simple: snapshots are rare and
-// heavy, so serializing them costs nothing observable. Failures are swallowed
-// by each link's own try/finally, so the chain can never poison later calls —
-// which holds for a REJECTION, and for a HANG only because the cdps inside
-// `run` are each bounded by settle.ts's deadline.
-let axQueue: Promise<unknown> = Promise.resolve();
+// Serializes the enable→read→disable window below, PER TARGET TAB. The worker
+// dispatches daemon frames fire-and-forget (worker.ts onmessage), so two
+// concurrent snapshots of the SAME tab could otherwise interleave as
+// enable/enable/read/DISABLE/read — the second read then hits a disabled a11y
+// engine and risks a degraded tree.
+//
+// Per TAB, not module-global (audit A3). The hazard above is one a11y engine,
+// and the CDP `Accessibility` domain is per debuggee — two tabs have two
+// engines, so serializing across them protects nothing while costing a
+// DIFFERENT owner its budget: with a global lane, owner A's `getFullAXTree`
+// stalling its full deadline plus its `finally` disable stalling another left
+// owner B's snapshot unable to issue even `Accessibility.enable` until both
+// drained, against B's own 20 s daemon budget. A per-tab map cannot express that
+// wait, and no smaller global ceiling fixes it either: a global lane is only
+// safe if three ceilings fit inside the tightest budget (~5 s), and a healthy
+// heavy `screenshot` was measured at 10.91 s (settle.ts), so the two
+// constraints are incompatible.
+//
+// The eviction idiom (identity check, then delete, on drain) is copied from the
+// per-owner lane in ownership.ts — a second eviction idiom beside that one
+// would be the anti-pattern, and that one is already proven against the "the
+// head may have been replaced while we awaited" race. An idle tab holds no
+// entry, so a closed tab leaves nothing behind and no listener is needed;
+// growth is bounded by that eviction plus MAX_SURFACES (state.ts), since only a
+// driven surface reaches here (requireSurface).
+const axQueues = new Map<number, Promise<unknown>>();
 
 export async function snapshot(params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
@@ -37,7 +51,18 @@ export async function snapshot(params: Record<string, unknown>): Promise<Record<
       await cdp(surface.tabId, "Accessibility.disable").catch(() => {});
     }
   };
-  const result = await (axQueue = axQueue.catch(() => {}).then(run)) as { nodes: AXNode[] };
+  const previous = axQueues.get(surface.tabId) ?? Promise.resolve();
+  // `.catch(() => {})` swallows a predecessor's REJECTION so the chain cannot
+  // poison later calls; a HANG cannot park it either, because the cdps inside
+  // `run` are each bounded by settle.ts's deadline, so every link settles.
+  const chain = previous.catch(() => {}).then(run);
+  axQueues.set(surface.tabId, chain);
+  void chain
+    .finally(() => {
+      if (axQueues.get(surface.tabId) === chain) axQueues.delete(surface.tabId);
+    })
+    .catch(() => {});
+  const result = (await chain) as { nodes: AXNode[] };
   const rendered = compactAX(result.nodes, surface.epoch);
   // Refs are stored under THIS surface's token: with several tabs driven in
   // parallel, a global ref map would let one tab's snapshot silently repoint

--- a/extension/src/commands/snapshot.ts
+++ b/extension/src/commands/snapshot.ts
@@ -1,5 +1,6 @@
 import { compactAX, type AXNode } from "../ax-compact";
 import { cdp, requireSurface } from "../cdp";
+import { CHROME_API_DEADLINE_MS, deadline } from "../settle";
 import { setRefs, surfaceToken } from "../state";
 
 // Serializes the enable→read→disable window below. The worker dispatches
@@ -10,7 +11,9 @@ import { setRefs, surfaceToken } from "../state";
 // latent, but the extension should not depend on that scheduling promise.
 // A promise chain (not a refcount) keeps it simple: snapshots are rare and
 // heavy, so serializing them costs nothing observable. Failures are swallowed
-// by each link's own try/finally, so the chain can never poison later calls.
+// by each link's own try/finally, so the chain can never poison later calls —
+// which holds for a REJECTION, and for a HANG only because the cdps inside
+// `run` are each bounded by settle.ts's deadline.
 let axQueue: Promise<unknown> = Promise.resolve();
 
 export async function snapshot(params: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -40,6 +43,10 @@ export async function snapshot(params: Record<string, unknown>): Promise<Record<
   // parallel, a global ref map would let one tab's snapshot silently repoint
   // another tab's click targets.
   await setRefs(surfaceToken(surface), rendered.refs);
-  const tab = await chrome.tabs.get(surface.tabId);
+  const tab = await deadline(
+    chrome.tabs.get(surface.tabId),
+    CHROME_API_DEADLINE_MS,
+    `chrome.tabs.get(${surface.tabId})`,
+  );
   return { snapshot: rendered.snapshot, url: tab.url ?? "", title: tab.title ?? "" };
 }

--- a/extension/src/errors.ts
+++ b/extension/src/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * The one typed bridge failure, in a module of its own.
+ *
+ * This looks like an unnecessary indirection and is not one. `cdp.ts` owns
+ * `BridgeCommandError` historically, but it also registers a
+ * `chrome.debugger.onDetach` listener at MODULE level, so any module that
+ * imports the class from `./cdp` drags the whole CDP layer into its bundle.
+ * That was invisible until `settle.ts` (the per-call `deadline` helper) and
+ * `state.ts` (which bounds its storage awaits) started needing the class in
+ * common: the resulting `cdp → settle → cdp` cycle reordered module evaluation
+ * and made a storage-only bundle touch `chrome.debugger` — which the pure
+ * storage/grouping unit harnesses do not provide, so they failed at load time
+ * with `Cannot read properties of undefined (reading 'onDetach')`.
+ *
+ * Keeping the error value here breaks the cycle at its root: `errors.ts`
+ * imports nothing, `settle.ts` and `state.ts` reach the class without reaching
+ * `cdp.ts`, and `cdp.ts` still re-exports it so every existing
+ * `from "./cdp"` import site keeps working unchanged.
+ */
+export class BridgeCommandError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly data: Record<string, unknown> = {},
+  ) {
+    super(message);
+  }
+}

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -10,6 +10,7 @@ import {
 } from "./approval-store";
 import { BridgeCommandError, cdp } from "./cdp";
 import { safeHttpUrl, storedOriginAllowed } from "./origin-policy";
+import { CHROME_API_DEADLINE_MS, deadline } from "./settle";
 import { getLocal, getSession, withSessionMutation } from "./state";
 
 export { safeHttpUrl } from "./origin-policy";
@@ -78,7 +79,11 @@ export async function consumeOnceGrant(url: URL, requester: string): Promise<boo
     const grant = grants[key];
     if (!grant || Date.now() >= grant.expiresAt || grant.requester !== requester) return false;
     delete grants[key];
-    await chrome.storage.session.set({ onceGrants: grants });
+    await deadline(
+      chrome.storage.session.set({ onceGrants: grants }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.set(onceGrants)",
+    );
     return true;
   });
   if (consumed) await sweepQueue();
@@ -100,7 +105,11 @@ async function consumeGrantFor(url: URL, sessionRequester: string, commandId: st
     }
     if (!grant || Date.now() >= grant.expiresAt) return false;
     delete grants[key];
-    await chrome.storage.session.set({ onceGrants: grants });
+    await deadline(
+      chrome.storage.session.set({ onceGrants: grants }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.set(onceGrants)",
+    );
     return true;
   });
   if (consumed) await sweepQueue();

--- a/extension/src/ownership.ts
+++ b/extension/src/ownership.ts
@@ -1,4 +1,5 @@
 import { BridgeCommandError } from "./cdp";
+import { CHROME_API_DEADLINE_MS, deadline } from "./settle";
 import { getSurfaces, withSessionMutation } from "./state";
 
 /** A private proof is intentionally separate from ownerKey (tab-group copy).
@@ -21,7 +22,13 @@ const queues = new Map<string, Promise<unknown>>();
 let allocations: Promise<unknown> = Promise.resolve();
 
 async function scopes(): Promise<Record<string, Scope>> {
-  return (await chrome.storage.session.get(["ownerScopes"])).ownerScopes ?? {};
+  return (
+    (await deadline(
+      chrome.storage.session.get(["ownerScopes"]),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.get(ownerScopes)",
+    )).ownerScopes ?? {}
+  );
 }
 function identity(params: Params): [string, string, string] {
   const proof = String(params.owner_proof ?? "");
@@ -42,7 +49,11 @@ async function mutate<T>(params: Params, fn: (scope: Scope) => T, create = false
       throw new BridgeCommandError("owner_refused", "browser owner generation is stale or unresolved");
     }
     const result = fn(scope);
-    await chrome.storage.session.set({ ownerScopes: all });
+    await deadline(
+      chrome.storage.session.set({ ownerScopes: all }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.set(ownerScopes)",
+    );
     return result;
   });
 }
@@ -60,6 +71,13 @@ export async function recordAllocation(params: Params, tab: string, state: strin
  * write. A finish cannot overtake an in-flight allocation and then let its late
  * navigation resurrect the tab. The daemon's deadlines remain bounded; a lost
  * response is replayed by allocation id rather than creating a second tab.
+ *
+ * `queues` is keyed by `owner_proof` and `allocations` is global, and both are
+ * module-level, so a HUNG op here parked `owner_recover` — the recovery path
+ * itself — for every session on that proof. The chains swallow a predecessor's
+ * rejection but not its hang (`.catch()` never runs on a promise that never
+ * settles); every chrome await inside the ops is bounded by `deadline` so the
+ * link always settles.
  */
 export function withOwnership(
   method: string, params: Params, handler: () => Promise<Record<string, unknown>>,
@@ -97,7 +115,11 @@ export function withOwnership(
         // above, so a foreign caller cannot use it to clear someone else's.
         if (scope.generation !== generation || params.resumed_scope === true) delete scope.terminal;
         scope.generation = generation;
-        await chrome.storage.session.set({ ownerScopes: all });
+        await deadline(
+          chrome.storage.session.set({ ownerScopes: all }),
+          CHROME_API_DEADLINE_MS,
+          "chrome.storage.session.set(ownerScopes)",
+        );
         const allocation = scope.allocations[String(params.allocation_id ?? "")];
         const live = allocation?.tab && (await getSurfaces())[allocation.tab];
         const unresolved = allocation && ["allocating", "allocated", "cleanup_pending"].includes(allocation.state);
@@ -120,7 +142,11 @@ export function withOwnership(
         // the recorded capability without navigating/submitting a second time.
         const surface = (await getSurfaces())[existing.tab];
         if (!surface) throw new BridgeCommandError("tab_closed", "browser tab disappeared");
-        const tab = await chrome.tabs.get(surface.tabId);
+        const tab = await deadline(
+          chrome.tabs.get(surface.tabId),
+          CHROME_API_DEADLINE_MS,
+          `chrome.tabs.get(${surface.tabId})`,
+        );
         return { tab: existing.tab, url: tab.url ?? "", title: tab.title ?? "", state: existing.state };
       }
       if (existing && existing.state !== "closed") {

--- a/extension/src/ownership.ts
+++ b/extension/src/ownership.ts
@@ -18,8 +18,22 @@ export interface Scope {
   unknownReservations?: number;
 }
 type Params = Record<string, unknown>;
+// Per-OWNER command lanes, keyed by `owner_proof`.
+//
+// This lane spans a handler deliberately: it is what stops a same-owner
+// `owner_finish` overtaking its own in-flight `open` and letting a late
+// navigation resurrect the tab. It is per proof, so it starves nobody else.
+//
+// It is NOT the pool-admission lane any more. That lane used to live here as a
+// module-global `allocations` chain wrapped around the whole `open` handler —
+// including attach, log capture, grouping and `navigate()` with its redirect /
+// human origin-approval wait — so one owner's slow navigation delayed a
+// DIFFERENT owner's admission (audit A4). Admission is a read-modify-write of
+// the SURFACES map, and that map's own module (`state.ts`) now guards it, as
+// `withAdmission`, in the `open` handler around cap-check → create → putSurface.
+// See the addendum D3 for why the journal writes are NOT the window: nothing
+// counts `ownerScopes.allocations` against MAX_SURFACES; the surfaces map does.
 const queues = new Map<string, Promise<unknown>>();
-let allocations: Promise<unknown> = Promise.resolve();
 
 async function scopes(): Promise<Record<string, Scope>> {
   return (
@@ -67,17 +81,17 @@ export async function recordAllocation(params: Params, tab: string, state: strin
   });
 }
 
-/** Serialize owner commands through the entire side effect, not just the map
- * write. A finish cannot overtake an in-flight allocation and then let its late
- * navigation resurrect the tab. The daemon's deadlines remain bounded; a lost
- * response is replayed by allocation id rather than creating a second tab.
+/** Serialize owner commands per owner through the entire side effect, not just
+ * the map write. A finish cannot overtake an in-flight allocation and then let
+ * its late navigation resurrect the tab. The daemon's deadlines remain bounded;
+ * a lost response is replayed by allocation id rather than creating a second
+ * tab. POOL ADMISSION IS NOT THIS LANE — see the map's declaration above.
  *
- * `queues` is keyed by `owner_proof` and `allocations` is global, and both are
- * module-level, so a HUNG op here parked `owner_recover` — the recovery path
- * itself — for every session on that proof. The chains swallow a predecessor's
- * rejection but not its hang (`.catch()` never runs on a promise that never
- * settles); every chrome await inside the ops is bounded by `deadline` so the
- * link always settles.
+ * `queues` is keyed by `owner_proof` and is module-level, so a HUNG op here
+ * parked `owner_recover` — the recovery path itself — for every session on that
+ * proof. The chain swallows a predecessor's rejection but not its hang
+ * (`.catch()` never runs on a promise that never settles); every chrome await
+ * inside the ops is bounded by `deadline` so the link always settles.
  */
 export function withOwnership(
   method: string, params: Params, handler: () => Promise<Record<string, unknown>>,
@@ -196,14 +210,7 @@ export function withOwnership(
     }
     return handler();
   };
-  const run = previous.catch(() => {}).then(() => {
-    if (method !== "open") return operate();
-    // Pool admission spans create+persist, including legacy callers. Sharing
-    // the allocation lane avoids two owners both observing the last free slot.
-    const allocation = allocations.catch(() => {}).then(operate);
-    allocations = allocation;
-    return allocation;
-  });
+  const run = previous.catch(() => {}).then(operate);
   queues.set(key, run);
   void run.finally(() => { if (queues.get(key) === run) queues.delete(key); }).catch(() => {});
   return run;

--- a/extension/src/popup/first-paint.js
+++ b/extension/src/popup/first-paint.js
@@ -27,23 +27,39 @@
  * the duplication of both is the price of running before the module system.
  */
 (function () {
-  // Keep in sync with PAIRED_HINT_KEY and applyPendingPin() in popup.ts.
-  var KEY = "lop:paired-hint";
-  var PAIRED_PIN = "86px";
-  var UNPAIRED_PIN = "219px";
-  var paired = false;
+  // Keep in sync with PIN_HINT_KEY, PIN_CONNECTED/PIN_PAIRING/PIN_UNRESPONSIVE
+  // and show() in popup.ts.
+  //
+  // A PIN PER STATE, not a boolean. Two of the three states this can land on
+  // cannot be told apart by a boolean, and the one a boolean has to collapse is
+  // the wedged-but-paired card this popup exists for: pinned to the connected
+  // height it opened 167.8px short of the card it settled on (design D3-1).
+  // popup.ts writes the pin for the card it just rendered, and this script
+  // reproduces that height before the module runs.
+  var KEY = "lop:pin-hint";
+  // The boolean key the previous revision wrote. Read once as a fallback so the
+  // rename does not cost an existing paired browser a resize; "1" meant the
+  // connected card. Mirrors the same fallback in popup.ts.
+  var LEGACY_KEY = "lop:paired-hint";
+  var PIN_CONNECTED = "86px";
+  var PIN_PAIRING = "219px";
+  var PIN_UNRESPONSIVE = "254px";
+  var PINS = [PIN_CONNECTED, PIN_PAIRING, PIN_UNRESPONSIVE];
+  var pin = null;
   try {
-    paired = localStorage.getItem(KEY) === "1";
+    var stored = localStorage.getItem(KEY);
+    if (stored !== null && PINS.indexOf(stored) !== -1) pin = stored;
+    else if (localStorage.getItem(LEGACY_KEY) === "1") pin = PIN_CONNECTED;
   } catch (error) {
-    // Storage unavailable (disabled, quota, partitioned). The unpaired pin is
-    // the safe default: it is the state a browser we cannot identify is most
-    // likely to be in on its first open.
+    // Storage unavailable (disabled, quota, partitioned). No hint is the safe
+    // answer: it is the behaviour before this file existed, and it is what a
+    // browser we cannot identify must get.
   }
   // <head> runs before <body> exists, so the pin is applied as a stylesheet
   // rule rather than by reaching for the element. This also keeps it out of the
   // element's inline style, leaving popup.ts's own applyPendingPin() — which
   // runs later and sets an inline style — able to override it without a fight.
   var style = document.createElement("style");
-  style.textContent = "#pending{min-height:" + (paired ? PAIRED_PIN : UNPAIRED_PIN) + "}";
+  style.textContent = "#pending{min-height:" + (pin || PIN_PAIRING) + "}";
   document.documentElement.appendChild(style);
 })();

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -422,13 +422,17 @@ input:disabled {
  * EVERY open — the resize it causes is unconditional, and only its duration
  * depends on how slow /health is.
  *
- * The pin is therefore chosen per user, from a synchronous localStorage hint:
- * 219px for a browser that has never paired (it becomes the 340px pairing form)
- * and 86px for one that has (it becomes the 207px connected card). A single pin
- * cannot serve both — pinning to the form costs the already-paired user, who
- * opens this popup for the rest of the product's life, a 133px settle; pinning
- * to the tallest state would leave a permanent band of empty card under
- * `connected` for everyone.
+ * The pin is therefore chosen per state, from a synchronous localStorage hint
+ * holding the pin show() recorded for the card it last rendered:
+ *
+ *   86px  -> the connected card (211.2px)
+ *   219px -> the pairing form (344.0px)
+ *   254px -> the unresponsive card (378.8px)
+ *
+ * Three values rather than a paired/unpaired boolean (design D3-1): a boolean
+ * cannot name the third state, and the one it has to collapse — the wedged but
+ * paired worker this popup exists for — is the one a user reopens from the
+ * recovery copy, where a wrong pin cost a measured 167.8px reflow.
  *
  * That choice is applied by first-paint.js, a CLASSIC script in <head>, NOT by
  * popup.ts. popup.js is a deferred module, so an inline style it sets arrives
@@ -439,8 +443,8 @@ input:disabled {
  *
  * All four numbers are measured at 300x600 and move together — the card's
  * height depends on the pairing form, which depends on the reserved error slot
- * below. Re-measure BOTH pins if any of them changes; a stale pin is a resize,
- * which is the defect this whole block exists to prevent. */
+ * below. Re-measure ALL THREE pins if any of them changes; a stale pin is a
+ * resize, which is the defect this whole block exists to prevent. */
 #pending {
   min-height: 219px;
 }

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -153,6 +153,29 @@
           </div>
         </section>
 
+        <!-- The honest rendering of a wedged worker, and the state that used to
+             be a LIE: the browser is open and paired and the daemon is
+             reachable, but the extension has stopped answering, so nothing can
+             be driven. Before this section the popup showed the GREEN connected
+             card in exactly that state (health.extension_unresponsive was in
+             its type and never read), i.e. the incident's own symptom on the
+             one surface the GUIDE sends the user to (design D4).
+             The remedy is the measured one, and the wording is matched to the
+             CLI/error copy so the user meets one instruction rather than three
+             spellings of it: toggle OFF then ON (pairing survives). -->
+        <section id="unresponsive" class="state hidden">
+          <h1 class="title">Extension stopped answering.</h1>
+          <p class="sub">
+            This browser is paired, but the Local Operator extension has stopped responding, so
+            the agent can't drive it. Toggle the extension OFF then ON in
+            <code>chrome://extensions</code> to reload it — pairing is kept, so there is no new
+            code to enter, but open tabs the agent was driving are lost.
+          </p>
+          <div class="actions">
+            <button id="retry-unresponsive" class="btn block">Check again</button>
+          </div>
+        </section>
+
         <!-- Origin-decision acknowledgement, shown from the click alone
              (popup.ts): session storage and /health echo the prompt until the
              worker round-trip lands, and a prompt left up with live buttons

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -162,14 +162,20 @@
              one surface the GUIDE sends the user to (design D4).
              The remedy is the measured one, and the wording is matched to the
              CLI/error copy so the user meets one instruction rather than three
-             spellings of it: toggle OFF then ON (pairing survives). -->
+             spellings of it: toggle OFF then ON (pairing survives). The list of
+             what the reload costs is the ERROR COPY's list verbatim — an earlier
+             draft said only "open tabs the agent was driving are lost", so a user
+             who read this surface alone would re-`open` and then be surprised by
+             the snapshot refs and pending site decisions going with the worker
+             (design D2-2). -->
         <section id="unresponsive" class="state hidden">
           <h1 class="title">Extension stopped answering.</h1>
           <p class="sub">
             This browser is paired, but the Local Operator extension has stopped responding, so
             the agent can't drive it. Toggle the extension OFF then ON in
             <code>chrome://extensions</code> to reload it — pairing is kept, so there is no new
-            code to enter, but open tabs the agent was driving are lost.
+            code to enter, but open tab handles, snapshot refs and pending site decisions are
+            lost, so re-open and re-snapshot afterwards.
           </p>
           <div class="actions">
             <button id="retry-unresponsive" class="btn block">Check again</button>

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -110,6 +110,13 @@ let scopeBuiltForEntryId: string | undefined;
 const repeatAskByOrigin = new Map<string, DecidedOrigin>();
 
 interface Health {
+  /** The daemon's liveness bit for the socket. DECLARATIVE ONLY: the card choice
+   * below reads `paired` and `extension_unresponsive` instead, because "the
+   * socket is open" is not the question the user is asking (a paired,
+   * not-attached link — Chrome up, worker between dials — is `false` here and
+   * still renders the connected card; see the recorded D2-4 follow-up). Kept in
+   * the type because /health is the wire contract, not because this module
+   * consumes it. */
   extension_connected: boolean;
   /** The socket is attached but the worker has stopped answering — either
    * still attached and mute, or severed by the daemon for silence within its
@@ -451,19 +458,33 @@ async function renderOnce(): Promise<void> {
   }
   // /health is the authority on whether this browser is paired, so it is what
   // the first-paint layout hint is mirrored from — in BOTH directions, so an
-  // unpair shrinks the next first paint back to the form's height.
-  writePairedHint(health.paired);
+  // unpair shrinks the next first paint back to the form's height. The ONE
+  // state that inverts this is a wedged-but-paired link: it renders the honest
+  // card below, NOT the pairing form, so pinning the form's height for it would
+  // open on a resize. (`extension_unresponsive` is exactly "the daemon says a
+  // pairing exists and the worker is not answering".)
+  writePairedHint(health.paired || health.extension_unresponsive === true);
+  // The worker is wedgeable in a way the socket does not show: attached, paired,
+  // and answering nothing. Say so instead of painting the green "Connected."
+  // card over a browser the agent cannot drive — that card is exactly what the
+  // incident looked like from this popup (design D4). One render after the state
+  // clears, the card returns to normal, because this reads /health on every
+  // render like everything else here.
+  //
+  // Read BEFORE the `paired` gate, deliberately. `paired` here is link-derived
+  // (`daemon.py`: it is false once the daemon has severed the link), while the
+  // daemon's own `paired:` line — and the pairing on disk — are still true. So a
+  // gate on `paired` made this card unreachable in exactly the half of its
+  // window it exists for: the post-drop cooling-off period, where the popup fell
+  // through to the PAIRING FORM ("Enter the code shown in Local Operator") for a
+  // browser that is paired on disk and about to re-dial (QA Q2-3 / review R2-5).
+  // Keyed on the latch, which is the daemon's statement about the link, not on
+  // the link's own copy of `paired`.
+  if (health.extension_unresponsive === true) {
+    show("unresponsive");
+    return;
+  }
   if (health.paired) {
-    // The worker is wedgeable in a way the socket does not show: attached,
-    // paired, and answering nothing. Say so instead of painting the green
-    // "Connected." card over a browser the agent cannot drive — that card is
-    // exactly what the incident looked like from this popup (design D4). One
-    // render after the state clears, the card returns to normal, because this
-    // reads /health on every render like everything else here.
-    if (health.extension_unresponsive === true) {
-      show("unresponsive");
-      return;
-    }
     // Handoff complete: the worker holds the new token and health confirms it,
     // so the pairing latch has done its job. Clearing it here means a LATER
     // unpair (daemon revoke → close 4003) renders the form again instead of a

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -25,6 +25,7 @@ type State =
   | "pairing"
   | "disconnected"
   | "incompatible"
+  | "unresponsive"
   | "origin"
   | "origin-ack"
   // The neutral pre-render placeholder. Never shown BY render() — it is the
@@ -36,6 +37,7 @@ const sections = [
   "pairing",
   "disconnected",
   "incompatible",
+  "unresponsive",
   "origin",
   "origin-ack",
   "pending",
@@ -109,6 +111,15 @@ const repeatAskByOrigin = new Map<string, DecidedOrigin>();
 
 interface Health {
   extension_connected: boolean;
+  /** The socket is attached but the worker has stopped answering — either
+   * still attached and mute, or severed by the daemon for silence within its
+   * cooling-off window (`LINK_DROP_TTL_S`). The daemon reports it so this card
+   * can stop claiming the agent can drive when it cannot (design D4). Optional
+   * in the type because an older daemon simply does not send it. */
+  extension_unresponsive?: boolean;
+  /** Whether a link is attached right now; not the same as healthy. Paired
+   * with the flag above so a render can say what it actually observes. */
+  link_attached?: boolean;
   paired: boolean;
   browser: string;
   current_url?: string;
@@ -127,6 +138,10 @@ const TONE: Record<State, string> = {
   pairing: "var(--hairline-strong)",
   disconnected: "var(--hairline-strong)",
   incompatible: "var(--danger)",
+  // Danger, like `incompatible`: the user must recover this themselves and the
+  // agent cannot do it for them. It is emphatically NOT success — a green card
+  // over a mute worker is the symptom the incident was made of.
+  unresponsive: "var(--danger)",
   origin: "var(--hairline-strong)",
   // Placeholder only: the ack's real tone is per-decision (success for allow,
   // neutral for deny) and showOriginAck overrides it right after show().
@@ -439,6 +454,16 @@ async function renderOnce(): Promise<void> {
   // unpair shrinks the next first paint back to the form's height.
   writePairedHint(health.paired);
   if (health.paired) {
+    // The worker is wedgeable in a way the socket does not show: attached,
+    // paired, and answering nothing. Say so instead of painting the green
+    // "Connected." card over a browser the agent cannot drive — that card is
+    // exactly what the incident looked like from this popup (design D4). One
+    // render after the state clears, the card returns to normal, because this
+    // reads /health on every render like everything else here.
+    if (health.extension_unresponsive === true) {
+      show("unresponsive");
+      return;
+    }
     // Handoff complete: the worker holds the new token and health confirms it,
     // so the pairing latch has done its job. Clearing it here means a LATER
     // unpair (daemon revoke → close 4003) renders the form again instead of a
@@ -648,6 +673,7 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
 
 document.getElementById("retry")?.addEventListener("click", () => void render());
 document.getElementById("retry-incompatible")?.addEventListener("click", () => void render());
+document.getElementById("retry-unresponsive")?.addEventListener("click", () => void render());
 // Allow sends whatever scope the select holds; the select's value set is
 // exactly scopeOptions' values, so no other decision can be minted here.
 document.getElementById("origin-allow")?.addEventListener("click", () => {

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -172,39 +172,82 @@ let pairingShown = false;
 // because renders are serialised — see daemonHealth().
 const HEALTH_TIMEOUT_MS = 3000;
 
-// The last known pairing outcome, mirrored into localStorage so the FIRST
-// PAINT can size itself.
+// The pinned #pending height this browser last settled on, mirrored into
+// localStorage so the FIRST PAINT can size itself.
 //
 // #pending is the only section shipping visible, so it paints on every open,
 // before render()'s awaits resolve. Its pinned height therefore decides how far
-// the card travels when the real state arrives. Pinned to the pairing form the
-// first-run user settles with no motion but the already-paired user — who opens
-// this popup for the rest of the product's life — falls ~121px. chrome.storage
+// the card travels when the real state arrives — pinned to the pairing form the
+// first-run user settles with no motion but the already-paired user, who opens
+// this popup for the rest of the product's life, falls ~121px. chrome.storage
 // is async and so cannot inform a synchronous first paint; localStorage on an
-// extension page is synchronous, so the bit is mirrored there purely as a
-// LAYOUT HINT.
+// extension page is synchronous, so the pinned height is mirrored there purely
+// as a LAYOUT HINT.
+//
+// It records the PIN rather than a boolean derived from /health (design D3-1).
+// A boolean could only ever name two of the three measured states, so a browser
+// in the third — the wedged-but-paired worker this PR exists for — opened at
+// whichever of the two the boolean happened to collapse to and then grew the
+// difference: measured 86px → 378.8px, a 167.8px reflow in the state whose copy
+// sends the user to "Check again". The pin is written by show(), i.e. for the
+// card that was actually rendered, so a repeated open reproduces the height
+// already on screen.
 //
 // It is a hint and nothing else: it never gates behaviour, and render() paints
-// whatever /health actually reports. A stale or absent bit costs one resize,
+// whatever /health actually reports. A stale or absent pin costs one resize,
 // which is exactly the behaviour without it — so there is nothing to fail
-// closed about, and no security surface (it records that a pairing happened,
-// never a credential).
-const PAIRED_HINT_KEY = "lop:paired-hint";
+// closed about, and no security surface (it records a card height, never a
+// credential).
+const PIN_HINT_KEY = "lop:pin-hint";
+// The previous revision stored a BOOLEAN under its own key. It is read once, as
+// a fallback, so an already-paired browser's first open after the rename does
+// not pay a resize for it: "1" meant the connected card. Nothing writes the old
+// key again, and a stale "0" is indistinguishable from absent — both mean "no
+// hint", which falls back to the tall pin.
+const LEGACY_PAIRED_HINT_KEY = "lop:paired-hint";
 
-function readPairedHint(): boolean {
+// The pin that belongs to each state, measured at 300x600 against the card this
+// popup renders. The pin is `#pending`'s min-height and the card's own chrome
+// (padding, the driven-URL trough, the actions row) is the constant between
+// them, so a pin is the state's total card height minus that chrome:
+//
+//   connected card      211.2px  ->  86px
+//   pairing form        344.0px  -> 219px
+//   unresponsive card   378.8px  -> 254px
+//
+// A state with no entry keeps the last hint. That is deliberate: only these
+// three were measured in a real render, and a pin for the rest would be a pixel
+// guess no frame backs — while an unmeasured state costs exactly the one
+// resize a browser with no hint at all gets. Re-measure all three together when
+// any of them moves: a stale pin IS the resize this whole block exists to
+// prevent (popup.css carries the same numbers).
+const PIN_CONNECTED = "86px";
+const PIN_PAIRING = "219px";
+const PIN_UNRESPONSIVE = "254px";
+const PINS: readonly string[] = [PIN_CONNECTED, PIN_PAIRING, PIN_UNRESPONSIVE];
+const PIN_BY_STATE: Partial<Record<State, string>> = {
+  connected: PIN_CONNECTED,
+  pairing: PIN_PAIRING,
+  unresponsive: PIN_UNRESPONSIVE,
+};
+
+/** The pinned height this browser last settled on, or null for "no hint". */
+function readPinHint(): string | null {
   try {
-    return localStorage.getItem(PAIRED_HINT_KEY) === "1";
+    const stored = localStorage.getItem(PIN_HINT_KEY);
+    if (stored !== null && PINS.includes(stored)) return stored;
+    return localStorage.getItem(LEGACY_PAIRED_HINT_KEY) === "1" ? PIN_CONNECTED : null;
   } catch {
-    // Storage can be unavailable (disabled, quota, partitioned context). The
-    // unpaired pin is the safe default: it is the state a user who cannot be
-    // identified is most likely to be in on their first open.
-    return false;
+    // Storage can be unavailable (disabled, quota, partitioned context). No
+    // hint is the safe answer: it is the behaviour this popup had before the
+    // hint existed, and it is what a browser we cannot identify must get.
+    return null;
   }
 }
 
-function writePairedHint(paired: boolean): void {
+function writePinHint(pin: string): void {
   try {
-    localStorage.setItem(PAIRED_HINT_KEY, paired ? "1" : "0");
+    localStorage.setItem(PIN_HINT_KEY, pin);
   } catch {
     // A hint that cannot be stored simply is not used next time.
   }
@@ -212,20 +255,25 @@ function writePairedHint(paired: boolean): void {
 
 /** Size the pre-render placeholder to the state it is most likely to become,
  * so the first paint settles without moving the popup window. Called inline at
- * module scope, before the first paint, and again whenever the hint changes. */
+ * module scope — before the first paint — and again from show(), which is where
+ * the hint is learned. */
 function applyPendingPin(): void {
   const pending = document.getElementById("pending");
   if (!pending) return;
-  // Measured at 300x600 against THIS card: 86px lands the card on connected's
-  // height (207px), 219px on the pairing form's (340px). Re-measure both if the
-  // pairing form or the error slot changes height — a stale pin is a resize.
-  pending.style.minHeight = readPairedHint() ? "86px" : "219px";
+  pending.style.minHeight = readPinHint() ?? PIN_PAIRING;
 }
 applyPendingPin();
 
 function show(state: State): void {
   for (const section of sections) section?.classList.toggle("hidden", section.id !== state);
   document.getElementById("card")?.style.setProperty("--tone", TONE[state]);
+  // Record the pin for the card being painted, so the NEXT open starts at the
+  // height this one settles on (design D3-1). Here rather than at the call
+  // sites because show() is the single point that decides which card is on
+  // screen — every render path funnels through it, and one of them picking the
+  // wrong pin is exactly the defect this replaced.
+  const pin = PIN_BY_STATE[state];
+  if (pin) writePinHint(pin);
   if (state === "pairing") {
     const input = document.getElementById("pair-code") as HTMLInputElement | null;
     // Focus only a form the user has NOT been looking at. `pairingShown` is
@@ -456,14 +504,14 @@ async function renderOnce(): Promise<void> {
     show("incompatible");
     return;
   }
-  // /health is the authority on whether this browser is paired, so it is what
-  // the first-paint layout hint is mirrored from — in BOTH directions, so an
-  // unpair shrinks the next first paint back to the form's height. The ONE
-  // state that inverts this is a wedged-but-paired link: it renders the honest
-  // card below, NOT the pairing form, so pinning the form's height for it would
-  // open on a resize. (`extension_unresponsive` is exactly "the daemon says a
-  // pairing exists and the worker is not answering".)
-  writePairedHint(health.paired || health.extension_unresponsive === true);
+  // /health is the authority on whether this browser is paired, and the two
+  // cards below are what decide which pin show() records for the next open.
+  // Nothing is mirrored from /health here: the previous revision derived a
+  // BOOLEAN from `paired || extension_unresponsive` and the wedge state — which
+  // renders the honest card below, not the pairing form — is precisely the one
+  // the boolean could not express, so every reopen of it started at the
+  // connected card's height and grew 167.8px into this card (design D3-1,
+  // measured 86px → 378.8px). show() records the pin per card instead.
   // The worker is wedgeable in a way the socket does not show: attached, paired,
   // and answering nothing. Say so instead of painting the green "Connected."
   // card over a browser the agent cannot drive — that card is exactly what the

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -221,6 +221,17 @@ const LEGACY_PAIRED_HINT_KEY = "lop:paired-hint";
 // resize a browser with no hint at all gets. Re-measure all three together when
 // any of them moves: a stale pin IS the resize this whole block exists to
 // prevent (popup.css carries the same numbers).
+//
+// The `connected` figure is the card with an EMPTY driven-URL trough. The same
+// state is taller once a URL is in it — a settled 257.3px (and 292.1px for the
+// long-URL variant) against this table's 211.2px, +47.3px / +82.1px of reopen
+// growth. That residual is a KNOWN, RECORDED DEFERRAL, not an oversight, and it
+// was measured identical across the pre-PR base and both remediation heads: the
+// hint records the height the browser last SETTLED on, so a card whose text
+// changes between opens pays one resize either way, and a per-state constant
+// cannot express a height that depends on the URL. Do not add one here; the
+// provenance lives in PR #996's D3-1 note. Re-measuring `connected` with a URL
+// present will therefore read ~257px and is not a contradiction of this table.
 const PIN_CONNECTED = "86px";
 const PIN_PAIRING = "219px";
 const PIN_UNRESPONSIVE = "254px";

--- a/extension/src/protocol.gen.ts
+++ b/extension/src/protocol.gen.ts
@@ -22,6 +22,7 @@ export enum ErrorCode {
   BUSY = 'busy',
   PROTO_MISMATCH = 'proto_mismatch',
   OWNER_REFUSED = 'owner_refused',
+  EXTENSION_UNRESPONSIVE = 'extension_unresponsive',
   INTERNAL = 'internal',
 }
 

--- a/extension/src/settle.ts
+++ b/extension/src/settle.ts
@@ -76,6 +76,52 @@ export const SCRIPTING_DEADLINE_MS = 15_000;
  * (the re-attach is refused with "already attached" and `ownAttachment` adopts
  * it) — see `attach`.
  *
+ * THE POLICY, stated once because it is what every call site is judged against
+ * (contention-scoping addendum D4): a deadline guarantees that the OP SETTLES
+ * — so the queue link drains and the next command runs — and guarantees NOTHING
+ * about the mutation, which may land afterwards. The corollary is why this
+ * paragraph is longer than one sentence: every `chrome.storage.*.set` inside a
+ * `deadline()` is a write that may commit after its caller gave up, and since
+ * each set is a whole-key overwrite of a value read before the stall, a late set
+ * can revert a newer write. Per call class, that is either already reconciled —
+ * with the mechanism named — or it is not and the cost is stated:
+ *
+ *   - surfaces map (`state.ts` putSurface/removeSurface/touchSurface): a
+ *     resurrected dead entry is pruned by `liveSurfaces` on the next
+ *     open/tabs/status; a lost entry stops resolving, which is a typed
+ *     `tab_closed`, and the tab stays journaled so `owner_recover` reports it.
+ *   - `ownerScopes` (`ownership.ts` `mutate`): every read validates session +
+ *     generation and refuses, so a stale write surfaces as a typed
+ *     `owner_refused` rather than being honoured.
+ *   - access queue/receipts (`approval-store.ts`): liveness is computed on read
+ *     (`expiresAt` re-tested) and re-derived by the sweep, so a revived entry
+ *     reads as absent.
+ *   - snapshot refs (`state.ts` setRefs): already closed — refs carry an `epoch`
+ *     and consumers refuse a mismatch. This is the model the others are measured
+ *     against.
+ *   - log buffers (`log-capture.ts`): nothing to do — in-memory only, no storage
+ *     write in the path, and the enables are idempotent behind a tabId guard.
+ *   - CDP commands and `attach`: covered above.
+ *   - one-shot grants (`origins.ts` consumeOnceGrant/consumeGrantFor): the ONE
+ *     genuine residue, and it is deliberately NOT closed here. Two existing
+ *     properties bound it — the grant is requester-bound and TTL-bounded (10
+ *     min) — so the worst case is one requester spending its own grant twice
+ *     inside its own TTL, not a cross-owner consent hole. Deferred because the
+ *     closing move (a monotonic per-key spend counter, or a read-back verify
+ *     inside `withSessionMutation`) is a consent-surface change that wants its
+ *     own review round and its own repro. What WOULD promote it into scope: a
+ *     repro where a late set restores a grant for a DIFFERENT requester or a
+ *     different origin.
+ *
+ * The related ordering hypothesis — a delayed `storage.set` letting a stale
+ * write overwrite a newer one (the surfaces-map row above) — is a mechanically
+ * plausible consequence of the whole-key overwrite, and it is UNPROVEN: nothing
+ * in this change measures it, in a fault-injected or in a native-Chrome run, so
+ * nothing here claims native storage reordering. The fix it would justify
+ * (epoch-guarded map writes) is out of scope. The fixture that would settle it
+ * is named in the addendum: a whole-map write from a stalled caller that
+ * resolves after a peer's set has already committed.
+ *
  * Do NOT wrap the queue itself with this. Timing out a chain head while the op
  * still holds a half-read copy of `surfaces` is a lost update or a double-spent
  * one-shot grant (state.ts documents the reproduced double-spend); bound the

--- a/extension/src/settle.ts
+++ b/extension/src/settle.ts
@@ -1,4 +1,116 @@
-import { BridgeCommandError } from "./cdp";
+import { BridgeCommandError } from "./errors";
+
+// Per-call deadlines for chrome API awaits. The numbers are CATASTROPHE
+// CEILINGS ("this operation is milliseconds when healthy"), not measured
+// distributions, and they are deliberately collected here rather than spelled
+// at each call site so the timeout-chain invariant stays readable as one table:
+//
+//   extension per-call deadline (5-15 s)
+//     < extension nav settle (30 s, below - unchanged)
+//     < daemon COMMAND_TIMEOUTS (20-30 s, protocol.py)
+//     < daemon awaiting_origin extension (+65 s)
+//     < session client timeout (base + 65 + 5)
+//
+// The innermost deadline must fire first so the daemon always receives a TYPED
+// answer instead of timing out blind.
+
+/** One `chrome.debugger.sendCommand`. Must fit under the tightest daemon budget
+ * that reaches CDP: read/snapshot/screenshot are 20 s (protocol.py).
+ *
+ * 15 s, not 10 s. The record originally set this from the "milliseconds when
+ * healthy" premise and flagged it as the weakest number in the table, with the
+ * rule "raise it if real measurements land within 2× of it". They did: on a
+ * real-Chrome rig a legitimate (not SIGSTOPped) `read` took **7.49 s** and a
+ * heavy `screenshot` **10.91 s** — the second EXCEEDS the old bound, so a
+ * 10 s ceiling kills work the daemon's own 20 s budget would have accepted
+ * (QA A8), and the load A/B showed the fixed head 9/16 where the pre-fix
+ * extension, which had no inner bound at all, was 14/16 over the same sequence
+ * in the same load band (both 16/16 at normal load, so this is insurance for a
+ * starved host, not a fix for a normal-load bug).
+ *
+ * 15 s is the most the nesting invariant allows for the tightest budget it
+ * must stay inside: 20 s (read/snapshot/screenshot) minus 5 s for the handler
+ * to build and send its answer. It still fires strictly before the daemon's
+ * deadline, and it still makes a HUNG call settle — the property the whole
+ * helper exists for. Growth is bounded by the invariant, not by taste: raise
+ * this only with a fresh measurement and re-derive the table below. */
+export const CDP_DEADLINE_MS = 15_000;
+/** `chrome.debugger.attach`/`detach`, and the trivial `Runtime.evaluate` probe
+ * `ownAttachment` uses to tell our surviving attachment from DevTools. Attach is
+ * a local browser operation with no page involvement: milliseconds or broken.
+ * If the PROBE does not answer in this window the session is dead, which is
+ * exactly the answer `ownAttachment` wants. */
+export const CDP_ATTACH_DEADLINE_MS = 5_000;
+/** `chrome.tabs.*`, `chrome.tabGroups.*`, and `chrome.storage.*`: browser-process
+ * IPC with no page script on the path (for `session` storage, no disk either).
+ * Seconds here means the browser or the storage layer is wedged. */
+export const CHROME_API_DEADLINE_MS = 5_000;
+/** `chrome.scripting.executeScript` runs page script, so it shares the CDP
+ * risk profile and the same 20 s `read` budget - hence the same bound and the
+ * same reason to raise it from 10 s (see `CDP_DEADLINE_MS`; QA measured a real
+ * `read` at 7.49 s). */
+export const SCRIPTING_DEADLINE_MS = 15_000;
+
+/**
+ * Bound one chrome API await.
+ *
+ * A HANG IS NOT AN ERROR, and that single sentence is the whole reason this
+ * exists. Every serialized queue in this extension is built as
+ * `queue.catch(() => {}).then(op)` so that "each link swallows its
+ * predecessor's failure so the chain cannot poison later calls". That is true
+ * for a REJECTION and false for a HANG: `.catch()` never runs on a promise that
+ * never settles, so one stuck op parks every later command behind it — for
+ * every session, because the queues are module-global, not per-session. This is
+ * the only thing that makes those chains self-draining: the op SETTLES (with a
+ * typed, retryable error) so the chain's `.catch` moves on to the next link.
+ *
+ * Note the op is ABANDONED, not cancelled — `chrome.debugger.sendCommand` has
+ * no cancellation — so a stuck call may still complete later into nothing. That
+ * is safe: its result is discarded and the attach state is reconciled by
+ * `chrome.debugger.onDetach` and by pruneSurface. One residue is NOT covered by
+ * either, and is reconciled by `attach`'s own adopt path instead: a timed-out
+ * `chrome.debugger.attach` rejects before it registers the tab in the local
+ * `attached` set, so Chrome can still complete the attach afterwards, and a
+ * later `detach()` then returns early on `!attached.has(tabId)` and leaves a
+ * real debugger session behind. It self-heals on the next `cdp()` for that tab
+ * (the re-attach is refused with "already attached" and `ownAttachment` adopts
+ * it) — see `attach`.
+ *
+ * Do NOT wrap the queue itself with this. Timing out a chain head while the op
+ * still holds a half-read copy of `surfaces` is a lost update or a double-spent
+ * one-shot grant (state.ts documents the reproduced double-spend); bound the
+ * awaits INSIDE the ops instead, which is what this does.
+ *
+ * Rejects with code `internal` and `data.stalled = <what>`, deliberately not a
+ * new wire code: an already-released daemon validates `ErrorDetail.code`
+ * against its own ErrorCode enum, so an unknown value fails
+ * `Response.model_validate` and the frame is SILENTLY DROPPED — the command
+ * then times out, strictly worse than an `internal` it understands.
+ */
+export function deadline<T>(op: Promise<T>, ms: number, what: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new BridgeCommandError("internal", `${what} did not respond within ${ms}ms`, {
+          stalled: what,
+        }),
+      );
+    }, ms);
+    // Both arms clear the timer, and both are attached immediately: the
+    // abandoned op's eventual rejection must be HANDLED here or it would
+    // surface as an uncaught rejection in the worker.
+    op.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
 
 /**
  * Resolve when the tab's main frame finishes its next navigation.

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -1,3 +1,5 @@
+import { CHROME_API_DEADLINE_MS, deadline } from "./settle";
+
 export const DEFAULT_PORT = 4099;
 
 // Hard ceiling on concurrently-driven tabs. Parallel sessions each open their
@@ -85,25 +87,40 @@ export interface SessionState {
 }
 
 export async function getLocal(): Promise<LocalState> {
-  return chrome.storage.local.get(["token", "port", "origins", "hostGrants", "siteGrants", "allowAllSites"]);
+  // Bounded like every other chrome API await a serialized chain or the
+  // connect() path depends on: a stalled storage read used to leave `connect`
+  // unable to decide and the store queue parked behind it.
+  return deadline(
+    chrome.storage.local.get(["token", "port", "origins", "hostGrants", "siteGrants", "allowAllSites"]),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.local.get(local state)",
+  );
 }
 
 export async function getSession(): Promise<SessionState> {
-  return chrome.storage.session.get([
-    "surfaces",
-    "refs",
-    "pendingOrigin",
-    "accessRequest",
-    "accessTombstones",
-    "accessQueueVersion",
-    "accessQueue",
-    "accessResults",
-    "onceGrants",
-  ]);
+  return deadline(
+    chrome.storage.session.get([
+      "surfaces",
+      "refs",
+      "pendingOrigin",
+      "accessRequest",
+      "accessTombstones",
+      "accessQueueVersion",
+      "accessQueue",
+      "accessResults",
+      "onceGrants",
+    ]),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.session.get(session state)",
+  );
 }
 
 export async function getSurfaces(): Promise<Record<string, StoredSurface>> {
-  const { surfaces = {} } = (await chrome.storage.session.get(["surfaces"])) as SessionState;
+  const { surfaces = {} } = (await deadline(
+    chrome.storage.session.get(["surfaces"]),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.session.get(surfaces)",
+  )) as SessionState;
   return surfaces;
 }
 
@@ -114,6 +131,21 @@ export async function getSurfaces(): Promise<Record<string, StoredSurface>> {
 // had to face). Same promise-chain pattern as snapshot's axQueue: mutations
 // are rare and tiny, and each link swallows its predecessor's failure so the
 // chain cannot poison later calls.
+//
+// "Swallows its predecessor's failure" is true for a REJECTION and false for a
+// HANG — `.catch()` never runs on a promise that never settles. The chain is
+// self-draining only because every chrome API await INSIDE these ops carries a
+// `deadline` (settle.ts), so an op always settles. That includes this file's
+// ops AND the grant helpers in access-grants.ts, which reach this same lane
+// through `withSessionMutation`: `grep -rn 'await chrome\.' extension/src
+// --include=*.ts | grep -v '/popup/\|/options/'` is the closed inventory, and
+// anything it returns without a `deadline` is a hole in this promise rather
+// than an exemption (review R1-3 — that grep used to return 11 bare awaits in
+// access-grants.ts, command-reachable from the popup's Allow path). Do not
+// "fix" a wedge by resetting the chain head instead: `withStore` is the
+// atomicity mechanism for these read-modify-write sequences, and abandoning an
+// op mid-read while the next one reads the pre-mutation state loses an update
+// or double-spends a one-shot grant (see withSessionMutation below).
 let storeQueue: Promise<unknown> = Promise.resolve();
 function withStore<T>(op: () => Promise<T>): Promise<T> {
   const run = storeQueue.catch(() => {}).then(op);
@@ -138,20 +170,29 @@ export function putSurface(surface: StoredSurface): Promise<void> {
   return withStore(async () => {
     const surfaces = await getSurfaces();
     surfaces[surfaceToken(surface)] = surface;
-    await chrome.storage.session.set({ surfaces });
+    await deadline(
+      chrome.storage.session.set({ surfaces }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.set(surfaces)",
+    );
   });
 }
 
 /** Remove one surface and its snapshot refs; other surfaces are untouched. */
 export function removeSurface(token: string): Promise<void> {
   return withStore(async () => {
-    const { surfaces = {}, refs = {} } = (await chrome.storage.session.get([
-      "surfaces",
-      "refs",
-    ])) as SessionState;
+    const { surfaces = {}, refs = {} } = (await deadline(
+      chrome.storage.session.get(["surfaces", "refs"]),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.get(surfaces, refs)",
+    )) as SessionState;
     delete surfaces[token];
     delete refs[token];
-    await chrome.storage.session.set({ surfaces, refs });
+    await deadline(
+      chrome.storage.session.set({ surfaces, refs }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.set(surfaces, refs)",
+    );
   });
 }
 
@@ -170,20 +211,36 @@ export function touchSurface(token: string, at: number): Promise<void> {
     const surface = surfaces[token];
     if (!surface) return;
     surface.lastUsedAt = at;
-    await chrome.storage.session.set({ surfaces });
+    await deadline(
+      chrome.storage.session.set({ surfaces }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.set(surfaces)",
+    );
   });
 }
 
 export function setRefs(token: string, forSurface: Record<string, SnapshotRef>): Promise<void> {
   return withStore(async () => {
-    const { refs = {} } = (await chrome.storage.session.get(["refs"])) as SessionState;
+    const { refs = {} } = (await deadline(
+      chrome.storage.session.get(["refs"]),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.get(refs)",
+    )) as SessionState;
     refs[token] = forSurface;
-    await chrome.storage.session.set({ refs });
+    await deadline(
+      chrome.storage.session.set({ refs }),
+      CHROME_API_DEADLINE_MS,
+      "chrome.storage.session.set(refs)",
+    );
   });
 }
 
 export async function getRefs(token: string): Promise<Record<string, SnapshotRef>> {
-  const { refs = {} } = (await chrome.storage.session.get(["refs"])) as SessionState;
+  const { refs = {} } = (await deadline(
+    chrome.storage.session.get(["refs"]),
+    CHROME_API_DEADLINE_MS,
+    "chrome.storage.session.get(refs)",
+  )) as SessionState;
   return refs[token] ?? {};
 }
 

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -166,6 +166,45 @@ export function withSessionMutation<T>(op: () => Promise<T>): Promise<T> {
   return withStore(op);
 }
 
+/**
+ * POOL ADMISSION: the read-modify-write boundary for the eight-surface cap.
+ *
+ * The cap is a READ of the surfaces map (`liveSurfaces` + `atSurfaceCap`, both
+ * in the `open` handler) followed by a WRITE to it (`putSurface` after
+ * `chrome.tabs.create`), so two owners admitted concurrently both observe the
+ * last free slot and both take it — nine tabs against a cap of eight. This lane
+ * makes that pair atomic, exactly as `storeQueue` does for individual map
+ * entries, and it lives here because this module owns `MAX_SURFACES`, the map
+ * and `storeQueue`.
+ *
+ * It is deliberately NARROWER than the lane it replaces. The old lane was in
+ * ownership.ts and spanned the ENTIRE `open` handler — attach, log capture,
+ * grouping, and `navigate()` including a redirect that parks on a human
+ * origin-approval prompt — for the global `allocations` chain. One owner's slow
+ * or human-blocked navigation therefore delayed a DIFFERENT owner's admission
+ * (audit A4). Admission is now one `chrome.tabs.create` plus one storage write
+ * (worst case 2 x CHROME_API_DEADLINE_MS, versus the old whole-handler hold),
+ * and everything after `putSurface` runs outside it.
+ *
+ * NESTING IS ACYCLIC and must stay so: `withAdmission` -> `withStore` (via
+ * `putSurface`), never the reverse. A `withStore` op that reached for admission
+ * would deadlock against its own lane.
+ *
+ * Known cost, flagged rather than hidden (addendum D5): the cap read calls
+ * `liveSurfaces`, which loops up to MAX_SURFACES x `chrome.tabs.get` at
+ * CHROME_API_DEADLINE_MS each — so a pathological browser can hold admission for
+ * ~40 s, and a concurrent `open` waits that long before its own budget starts.
+ * The loop cannot move outside the lane without reintroducing the race, and
+ * bounding it is a separate change with pruning-semantics questions (a stalled
+ * get must NOT prune a live surface).
+ */
+let admissionQueue: Promise<unknown> = Promise.resolve();
+export function withAdmission<T>(op: () => Promise<T>): Promise<T> {
+  const run = admissionQueue.catch(() => {}).then(op);
+  admissionQueue = run;
+  return run;
+}
+
 export function putSurface(surface: StoredSurface): Promise<void> {
   return withStore(async () => {
     const surfaces = await getSurfaces();

--- a/extension/src/tab-groups.ts
+++ b/extension/src/tab-groups.ts
@@ -1,3 +1,4 @@
+import { CHROME_API_DEADLINE_MS, deadline } from "./settle";
 import { getSurfaces, putSurface, resolveSurfaceToken, type StoredSurface } from "./state";
 
 const GROUP_PREFIX = "LO · ";
@@ -6,7 +7,12 @@ const MAX_LABEL_CLUSTERS = 30;
 const NO_GROUP = -1;
 
 /** Browser grouping is presentation only: every failure is swallowed so a
- * missing, partial, or policy-disabled Chromium API can never block browsing. */
+ * missing, partial, or policy-disabled Chromium API can never block browsing.
+ *
+ * That swallow is why each chrome call below is BOUNDED: a rejected op would
+ * drain the chain, but a hung one would not — `.catch()` never runs on a
+ * promise that never settles — and this queue is module-global, so one stuck
+ * `chrome.tabGroups.get` would park every later command for every session. */
 let groupQueue: Promise<unknown> = Promise.resolve();
 function serialize<T>(op: () => Promise<T>): Promise<T> {
   const run = groupQueue.catch(() => {}).then(op);
@@ -47,13 +53,23 @@ function appliedTitle(base: string, ordinal: number): string {
 }
 
 async function tabOrUndefined(tabId: number): Promise<chrome.tabs.Tab | undefined> {
-  try { return await chrome.tabs.get(tabId); } catch { return undefined; }
+  try {
+    return await deadline(
+      chrome.tabs.get(tabId),
+      CHROME_API_DEADLINE_MS,
+      `chrome.tabs.get(${tabId})`,
+    );
+  } catch { return undefined; }
 }
 
 async function isAppliedGroup(surface: StoredSurface, groupId: number): Promise<boolean> {
   if (surface.appliedGroupId !== groupId || !surface.groupAppliedLabel) return false;
   try {
-    const group = await chrome.tabGroups.get(groupId);
+    const group = await deadline(
+      chrome.tabGroups.get(groupId),
+      CHROME_API_DEADLINE_MS,
+      `chrome.tabGroups.get(${groupId})`,
+    );
     // IDs can be recycled after browser/worker churn. Matching the exact title
     // and colour LO last applied prevents a recycled personal group with the
     // same numeric ID from becoming writable through stale session storage.
@@ -217,17 +233,29 @@ export function reconcileTabGroup(
       if (groupId === undefined) {
         const sibling = await existingSiblingGroup(surface, ownerKey, tab.windowId);
         groupId = sibling === undefined
-          ? await chrome.tabs.group({ tabIds: [surface.tabId] })
-          : await chrome.tabs.group({ groupId: sibling, tabIds: [surface.tabId] });
+          ? await deadline(
+            chrome.tabs.group({ tabIds: [surface.tabId] }),
+            CHROME_API_DEADLINE_MS,
+            `chrome.tabs.group(${surface.tabId})`,
+          )
+          : await deadline(
+            chrome.tabs.group({ groupId: sibling, tabIds: [surface.tabId] }),
+            CHROME_API_DEADLINE_MS,
+            `chrome.tabs.group(${surface.tabId} into ${sibling})`,
+          );
         created = sibling === undefined;
       }
 
       // Omitting `collapsed` on updates preserves a user's collapsed group.
-      await chrome.tabGroups.update(groupId, {
-        title: allocation.title,
-        color: "cyan",
-        ...(created ? { collapsed: false } : {}),
-      });
+      await deadline(
+        chrome.tabGroups.update(groupId, {
+          title: allocation.title,
+          color: "cyan",
+          ...(created ? { collapsed: false } : {}),
+        }),
+        CHROME_API_DEADLINE_MS,
+        `chrome.tabGroups.update(${groupId})`,
+      );
       surface.groupAppliedLabel = allocation.title;
       surface.appliedGroupId = groupId;
       await putSurface(surface);

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -74,7 +74,33 @@ let alive = false;
 // over — nothing may depend on it firing.
 let fastPathTimer: ReturnType<typeof setTimeout> | undefined;
 
-function send(frame: object): void {
+//: Monotonic id of the CURRENT wire, bumped by every dial.
+//
+// The socket alone cannot fence anything here, because `dispatch` is fired
+// fire-and-forget: a handler that finishes after a reconnect would otherwise
+// write its response — and its `tab_update` — to `socket`, which by then is the
+// REPLACEMENT connection. That is not a cosmetic misdelivery: the daemon
+// matches a response to the request IT sent on the OLD socket, so the new socket
+// receives a frame it never asked for and the daemon's own
+// "nothing is replayed on a new socket" contract (see `respond`) is broken from
+// the other side. Reproduced by the concurrency audit by bundling this file,
+// gating one handler, replacing the wire through the reconnect alarm and then
+// releasing the handler — the NEW wire received
+// `oldResponseOnNewWire=[tab_update bridge:1:old, {id: old-request, ok:true}]`.
+//
+// So every send that belongs to a REQUEST carries the generation of the wire the
+// request arrived on, and anything that would land on a different wire is
+// dropped with a log instead of being delivered.
+let wireGeneration = 0;
+
+function send(frame: object, generation: number = wireGeneration): void {
+  if (generation !== wireGeneration) {
+    // An event produced by a superseded request. Dropping it is the point: the
+    // daemon that asked has already failed that request's future, and the live
+    // connection has its own records to keep.
+    console.warn("dropped an event from a superseded connection", frame);
+    return;
+  }
   if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(frame));
 }
 
@@ -190,7 +216,18 @@ async function daemonPort(): Promise<number> {
   return port ?? DEFAULT_PORT;
 }
 
-async function respond(response: Response): Promise<void> {
+async function respond(response: Response, generation: number): Promise<void> {
+  if (generation !== wireGeneration) {
+    // The request this answers arrived on a connection that has since been
+    // replaced. `worker.ts`'s own contract (see the note below) is that a stale
+    // result must never be replayed onto a new socket — and the daemon has
+    // already failed this request's future when it accepted the replacement, so
+    // there is nothing left to answer. Say so rather than misdelivering it.
+    console.warn(
+      `dropped response for ${response.id}: it belongs to a superseded connection`,
+    );
+    return;
+  }
   if (socket?.readyState === WebSocket.OPEN) {
     socket.send(JSON.stringify(response));
     return;
@@ -206,10 +243,13 @@ async function respond(response: Response): Promise<void> {
   console.warn(`dropped response for ${response.id}: the extension socket is not open`);
 }
 
-async function dispatch(request: { id: string; method: string; params: Record<string, unknown> }): Promise<void> {
+async function dispatch(
+  request: { id: string; method: string; params: Record<string, unknown> },
+  generation: number,
+): Promise<void> {
   const handler = HANDLERS[request.method];
   if (!handler) {
-    await respond({ id: request.id, ok: false, error: { code: ErrorCode.INTERNAL, message: `unknown method ${request.method}`, data: {} } });
+    await respond({ id: request.id, ok: false, error: { code: ErrorCode.INTERNAL, message: `unknown method ${request.method}`, data: {} } }, generation);
     return;
   }
   try {
@@ -240,7 +280,7 @@ async function dispatch(request: { id: string; method: string; params: Record<st
       // of forking one.
       const raw = typeof result.tab === "string" ? result.tab : String(request.params.tab ?? "");
       const handle = isRedactedToken(raw) ? "" : raw;
-      send({ event: "tab_update", tab: handle, url: result.url, title: String(result.title ?? "") });
+      send({ event: "tab_update", tab: handle, url: result.url, title: String(result.title ?? "") }, generation);
     }
     // An explicit `close` retires the surface, so tell the daemon now rather
     // than relying on the onRemoved listener: chrome.tabs.remove fires
@@ -254,14 +294,14 @@ async function dispatch(request: { id: string; method: string; params: Record<st
     // so it says so and the daemon drops precisely that one.
     if (request.method === "close") {
       const closed = typeof result.closed === "string" ? result.closed : String(request.params.tab ?? "");
-      send({ event: "tab_closed", tab: isRedactedToken(closed) ? "" : closed });
+      send({ event: "tab_closed", tab: isRedactedToken(closed) ? "" : closed }, generation);
     }
-    await respond({ id: request.id, ok: true, result });
+    await respond({ id: request.id, ok: true, result }, generation);
   } catch (error) {
     if (error instanceof BridgeCommandError) {
-      await respond({ id: request.id, ok: false, error: { code: codeFor(error.code), message: error.message, data: error.data } });
+      await respond({ id: request.id, ok: false, error: { code: codeFor(error.code), message: error.message, data: error.data } }, generation);
     } else {
-      await respond({ id: request.id, ok: false, error: { code: ErrorCode.INTERNAL, message: String(error), data: {} } });
+      await respond({ id: request.id, ok: false, error: { code: ErrorCode.INTERNAL, message: String(error), data: {} } }, generation);
     }
   }
 }
@@ -300,6 +340,11 @@ async function connect(): Promise<void> {
 
   const wire = new WebSocket(`ws://127.0.0.1:${port}/extension`);
   socket = wire;
+  // This dial's identity. Everything asynchronous that belongs to it — the
+  // handshake writes, the frames it carries, and every response a handler it
+  // dispatched eventually produces — is scoped to this number, so a later dial
+  // cannot be written to by an earlier one (see `wireGeneration`).
+  const generation = ++wireGeneration;
 
   // Explicit dial deadline: if a dead loopback handshake neither opens nor
   // fires onerror/onclose, `connecting` would otherwise stay true forever and
@@ -328,6 +373,17 @@ async function connect(): Promise<void> {
 
   wire.onopen = () => {
     clearDialTimer();
+    if (socket !== wire) {
+      // A later dial already owns the worker; this one must not claim
+      // `connected`, must not send its own `hello` (two handshakes race for the
+      // daemon's single authority), and must not be left dangling.
+      try {
+        wire.close();
+      } catch {
+        // Already closing.
+      }
+      return;
+    }
     connected = true;
     connecting = false;
     attempt = 0;
@@ -335,8 +391,9 @@ async function connect(): Promise<void> {
     wire.send(JSON.stringify(hello));
   };
   wire.onmessage = (message) => {
+    if (socket !== wire) return; // a superseded socket's frames are not ours
     const frame = JSON.parse(String(message.data)) as DaemonMessage;
-    if ("method" in frame) void dispatch(frame);
+    if ("method" in frame) void dispatch(frame, generation);
     else if (frame.event === "ping") wire.send(JSON.stringify({ event: "pong" }));
     else if (frame.event === "hello_ack") {
       paired = frame.paired;
@@ -350,6 +407,13 @@ async function connect(): Promise<void> {
   };
   const teardown = (event?: CloseEvent) => {
     clearDialTimer();
+    if (socket !== wire) {
+      // A superseded socket finishing its close, long after a replacement dial
+      // took over. Resetting the live connection's flags here — or publishing a
+      // `connState` from it — would tear down the socket that is actually up:
+      // the delayed-onclose half of the same defect class as a stale response.
+      return;
+    }
     connected = false;
     connecting = false;
     paired = false;

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -78,6 +78,23 @@ function send(frame: object): void {
   if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(frame));
 }
 
+/**
+ * Fire-and-forget chrome API call whose rejection nobody can act on.
+ *
+ * A floating promise that rejects surfaces in an MV3 worker as
+ * `Uncaught (in promise) Error: …`, captured from the operator's own console
+ * as "Could not establish connection. Receiving end does not exist." from
+ * `chrome.runtime.sendMessage` when no popup was open to receive the frame.
+ * None of these call sites has a caller who could act on a failure, so the only
+ * correct handling is to record it and move on — but a fire-and-forget that can
+ * surface as an uncaught error is a defect whether or not the rejection is
+ * expected, and an uncaught error in the worker is indistinguishable from a
+ * crash when someone is reading the console to diagnose a bridge fault.
+ */
+function fireAndForget(op: Promise<unknown> | undefined | void, what: string): void {
+  void Promise.resolve(op).catch((error) => console.warn(`${what} failed`, error));
+}
+
 // Raise a system notification when a site decision is pending (finding U2).
 // BEST-EFFORT ONLY: on macOS this banner frequently never reaches the user —
 // Chrome needs its own Notification Center authorization (System Settings →
@@ -174,7 +191,19 @@ async function daemonPort(): Promise<number> {
 }
 
 async function respond(response: Response): Promise<void> {
-  if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(response));
+  if (socket?.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(response));
+    return;
+  }
+  // A completed command whose socket is no longer OPEN: the daemon evicted it
+  // ("later connection wins") mid-command, and this is the extension's side of
+  // the resulting `RuntimeError('extension disconnected')` the daemon logs.
+  // There is no correct place to DELIVER the frame — the socket is gone, the
+  // daemon has already failed every pending future, and a response queue would
+  // replay a stale result onto a NEW socket that never asked for it. So do not
+  // pretend it was sent: say so, which is what makes those daemon-side
+  // disconnects attributable to a dropped answer rather than a mystery timeout.
+  console.warn(`dropped response for ${response.id}: the extension socket is not open`);
 }
 
 async function dispatch(request: { id: string; method: string; params: Record<string, unknown> }): Promise<void> {
@@ -311,8 +340,13 @@ async function connect(): Promise<void> {
     else if (frame.event === "ping") wire.send(JSON.stringify({ event: "pong" }));
     else if (frame.event === "hello_ack") {
       paired = frame.paired;
-      void chrome.storage.session.set({ connState: frame.paired ? "connected" : "pairing" });
-    } else if (frame.event === "pair_result" && frame.ok) chrome.storage.local.set({ token: frame.token });
+      fireAndForget(
+        chrome.storage.session.set({ connState: frame.paired ? "connected" : "pairing" }),
+        "connState write",
+      );
+    } else if (frame.event === "pair_result" && frame.ok) {
+      fireAndForget(chrome.storage.local.set({ token: frame.token }), "token write");
+    }
   };
   const teardown = (event?: CloseEvent) => {
     clearDialTimer();
@@ -323,8 +357,8 @@ async function connect(): Promise<void> {
     // Preserve the close code so the popup can distinguish a protocol mismatch
     // (4001 — "update needed", which pairing cannot fix) from an ordinary
     // disconnect (finding D2). 4003 is an unpair/revoke.
-    if (event?.code === 4001) void chrome.storage.session.set({ connState: "incompatible" });
-    else if (event?.code === 4003) void chrome.storage.session.set({ connState: "pairing" });
+    if (event?.code === 4001) fireAndForget(chrome.storage.session.set({ connState: "incompatible" }), "connState write");
+    else if (event?.code === 4003) fireAndForget(chrome.storage.session.set({ connState: "pairing" }), "connState write");
     // 4000 is the daemon's later-connection-wins eviction (daemon.py), which the
     // POPUP's own pairing socket triggers on every pair attempt. It is not a
     // loss of connectivity, so publishing "disconnected" here drove the popup's
@@ -338,7 +372,7 @@ async function connect(): Promise<void> {
     // Drive authority is enforced daemon-side by link.paired (a second socket
     // arrives paired:false and its RPCs are refused not_paired), never by this
     // storage key, so suppressing the write grants nothing.
-    else if (event?.code !== 4000) void chrome.storage.session.set({ connState: "disconnected" });
+    else if (event?.code !== 4000) fireAndForget(chrome.storage.session.set({ connState: "disconnected" }), "connState write");
     scheduleReconnect();
   };
   wire.onclose = (event) => teardown(event);
@@ -446,7 +480,15 @@ chrome.tabs.onReplaced.addListener((_addedTabId, removedTabId) => {
 
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === "session" && changes.accessQueue) {
-    void chrome.runtime.sendMessage({ event: "origin_prompt", queue: changes.accessQueue.newValue });
+    // With no popup open there is no receiver for this message, and MV3 rejects
+    // the send with "Could not establish connection. Receiving end does not
+    // exist." — an EXPECTED outcome for a background-only delivery attempt, not
+    // an error, so it must not surface as an uncaught rejection in the worker
+    // console (captured live from the operator's own hands).
+    fireAndForget(
+      chrome.runtime.sendMessage({ event: "origin_prompt", queue: changes.accessQueue.newValue }),
+      "origin_prompt broadcast",
+    );
   }
   // The all-sites switch is written by the options page directly (never by
   // a message to this worker or a daemon RPC: there is deliberately no such

--- a/extension/tests/bridge-wedge.integration.test.mjs
+++ b/extension/tests/bridge-wedge.integration.test.mjs
@@ -642,3 +642,102 @@ test("E7 a hung chrome.storage.LOCAL read in the grant lane drains like any othe
     delete globalThis.chrome;
   }
 });
+
+// --- Audit A3 / scoping D1: the AX lane is per target -----------------------
+
+test("A3 a snapshot stalled on one tab does not hold another tab's lane (D1)", async () => {
+  // The lane exists because two snapshots of the SAME tab could interleave an
+  // enable/read/disable window against one a11y engine. It was module-global, so
+  // a stalled `getFullAXTree` (plus the `finally` disable, both inside `run`)
+  // also held a DIFFERENT owner's unrelated tab: that owner could not issue even
+  // `Accessibility.enable` before its own 20 s daemon budget expired. The hazard
+  // is one engine, and the CDP `Accessibility` domain is per debuggee (`cdp()` is
+  // addressed by tabId), so per-target is the correct scope — not merely a
+  // smaller one.
+  //
+  // The assertion is ORDERING, not a duration: with a per-tab lane owner B's
+  // first CDP call must fall INSIDE owner A's stalled window (A's enable and its
+  // `finally` disable bracket one another around B's work); with a global lane
+  // every one of A's calls completes first and B's can only start after A's
+  // chain drains. Neither a timeout nor a stopwatch is involved, so the row is
+  // not sensitive to how long the aliased ceilings are.
+  const calls = [];
+  const { store } = installChrome({
+    overrides: {
+      debugger: {
+        sendCommand: async (target, method) => {
+          calls.push([target.tabId, method]);
+          // Owner A's AX READ answers nothing, so A's chain is stalled inside
+          // its window: `Accessibility.getFullAXTree` never resolves and the
+          // `finally` disable is therefore still ahead of it. (Parking the
+          // enable instead would abort `run` before the window even opens, and
+          // then there would be no window for B to interleave with — which is
+          // exactly what made an earlier version of this row pass against the
+          // defective build.)
+          if (target.tabId === SURFACE_A.tabId && method === "Accessibility.getFullAXTree") {
+            await new Promise(() => {});
+          }
+          return { nodes: [] };
+        },
+      },
+    },
+  });
+  store.surfaces = {
+    "bridge:101:aaaa": clone(SURFACE_A),
+    "bridge:102:bbbb": clone(SURFACE_B),
+  };
+  const snap = await load(`export * from ${JSON.stringify(join(SRC, "commands", "snapshot.ts"))};`);
+  try {
+    const parked = snap.loaded.snapshot({ tab: "bridge:101:aaaa" });
+    const parkedSettled = parked.then(
+      () => "resolved",
+      () => "stalled",
+    );
+    for (let i = 0; i < 40 && !calls.some(([tab, method]) => tab === SURFACE_A.tabId && method === "Accessibility.getFullAXTree"); i++) {
+      await tick(5);
+    }
+    assert.ok(
+      calls.some(([tab, method]) => tab === SURFACE_A.tabId && method === "Accessibility.getFullAXTree"),
+      "precondition: owner A's AX read is in flight",
+    );
+
+    const other = await within(
+      snap.loaded.snapshot({ tab: "bridge:102:bbbb" }),
+      2_000,
+      "owner B's snapshot behind owner A's stalled one",
+    );
+    assert.ok(other.snapshot !== undefined, "owner B's snapshot answered");
+    // Snapshot the CDP trace at the INSTANT B answered. Under a global lane B's
+    // chain cannot start until A's whole chain drains — and A's chain includes
+    // its `finally` `Accessibility.disable` — so A's disable appears here only
+    // if B waited for it. No stopwatch: the presence of that one call IS the
+    // ordering.
+    const whileBAnswered = [...calls];
+    assert.ok(
+      whileBAnswered.some(
+        ([tab, method]) => tab === SURFACE_A.tabId && method === "Accessibility.getFullAXTree",
+      ),
+      "precondition: owner A's stalled AX read is still in flight while B answers",
+    );
+    assert.equal(
+      whileBAnswered.some(([tab, method]) => tab === SURFACE_A.tabId && method === "Accessibility.disable"),
+      false,
+      `owner B's CDP work must interleave with owner A's stalled window, not queue behind its chain (calls: ${JSON.stringify(whileBAnswered)})`,
+    );
+    // A's own snapshot is bounded and typed — the stall settles rather than
+    // parking its lane forever, which is what lets the LAST assertion below
+    // finish.
+    assert.equal(await parkedSettled, "stalled");
+
+    // A drained lane leaves nothing behind: a fresh snapshot runs.
+    const third = await within(
+      snap.loaded.snapshot({ tab: "bridge:102:bbbb" }),
+      2_000,
+      "a later snapshot after the stalled chain drained",
+    );
+    assert.ok(third.snapshot !== undefined);
+  } finally {
+    await snap.close();
+    delete globalThis.chrome;
+  }
+});

--- a/extension/tests/bridge-wedge.integration.test.mjs
+++ b/extension/tests/bridge-wedge.integration.test.mjs
@@ -1,0 +1,644 @@
+/* Coverage for the browser-bridge wedge on the EXTENSION side (design record
+ * §8.2), plus two smaller live defects from the same family.
+ *
+ * The wedge: every module-level serialized queue in the worker is built as
+ * `queue.catch(() => {}).then(op)` so "each link swallows its predecessor's
+ * failure so the chain cannot poison later calls". That is true for a
+ * REJECTION and false for a HANG — `.catch()` never runs on a promise that
+ * never settles — so one stuck chrome/CDP call parked every later command for
+ * every session. Reproduced on real hardware: a driven tab whose renderer
+ * stopped answering made `read` and then `tabs` time out at 20.0 s each, with
+ * the poison held in the per-OWNER lane, and `/health` reporting "connected"
+ * for all 42 samples of the window.
+ *
+ * Every test here therefore asserts the STRUCTURAL consequence the design
+ * rests on — the chain DRAINED and the next command answered — never a
+ * duration (AGENTS.md, "Timing, flakes, and how to assert that something is
+ * fast"). Deadlines are shortened through a fixture alias so a bounded failure
+ * arrives in tens of milliseconds; the real values live in `src/settle.ts` and
+ * are pinned there as one table.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { build } from "esbuild";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "..", "src");
+const REAL_SETTLE = join(SRC, "settle.ts");
+const REAL_TAB_GROUPS = join(SRC, "tab-groups.ts");
+
+const tick = (n = 4) => new Promise((r) => setTimeout(r, n));
+const clone = (value) => structuredClone(value);
+
+/** Fail rather than hang when a chain is parked. The budget is far above the
+ * fixture's 40 ms deadline and far below "forever", so a parked chain produces
+ * a failure that NAMES the defect instead of a node:test timeout. */
+function within(promise, ms, what) {
+  let timer;
+  const guard = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${what}: chain is parked, not slow (no settle in ${ms}ms)`)),
+      ms,
+    );
+    timer.unref?.();
+  });
+  return Promise.race([promise, guard]).finally(() => clearTimeout(timer));
+}
+
+/** Bundle a synthetic entry module against isolated chrome fixtures. */
+async function load(entrySource, { aliasTabGroups = null } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), "lop-bridge-wedge-it-"));
+  const entry = join(dir, "entry.mjs");
+  await writeFile(entry, entrySource);
+  const fixture = {
+    // The real helper with the real per-call semantics, and CATASTROPHE
+    // CEILINGS shrunk from seconds to tens of milliseconds so a bounded
+    // failure is observable without a suite that sleeps.
+    settle: `export { settle, deadline } from ${JSON.stringify(REAL_SETTLE)};
+      export const CDP_DEADLINE_MS = 40;
+      export const CDP_ATTACH_DEADLINE_MS = 40;
+      export const CHROME_API_DEADLINE_MS = 40;
+      export const SCRIPTING_DEADLINE_MS = 40;`,
+  };
+  if (aliasTabGroups) fixture["tab-groups"] = aliasTabGroups;
+  const outfile = join(dir, "bundle.mjs");
+  await build({
+    entryPoints: [entry],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile,
+    plugins: [
+      {
+        name: "isolated-transport",
+        setup(b) {
+          b.onResolve({ filter: /^\.\.?\/(settle|tab-groups)$/ }, (a) => {
+            const name = a.path.split("/").at(-1);
+            return fixture[name] ? { path: name, namespace: "fixture" } : undefined;
+          });
+          b.onLoad({ filter: /.*/, namespace: "fixture" }, (a) => ({
+            contents: fixture[a.path],
+            loader: "js",
+            resolveDir: SRC,
+          }));
+        },
+      },
+    ],
+  });
+  const loaded = await import(pathToFileURL(outfile) + `?${Date.now()}`);
+  return { loaded, close: () => rm(dir, { recursive: true, force: true }) };
+}
+
+/** Isolated chrome surface. `overrides` replace individual APIs by namespace;
+ * `hangFirstSessionGet` parks the first storage read, which is how the
+ * pre-deadline wedge is simulated. */
+function installChrome({ overrides = {}, hangFirstSessionGet = false } = {}) {
+  const store = {};
+  const log = { tabsGet: [], group: [], groupsUpdate: [], attach: [], sendCommand: [], set: [] };
+  const area = (target) => ({
+    get: async (keys) => {
+      const out = {};
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        if (key in target) out[key] = clone(target[key]);
+      }
+      return out;
+    },
+    set: async (value) => {
+      log.set.push(clone(value));
+      Object.assign(target, clone(value));
+    },
+    remove: async (keys) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) delete target[key];
+    },
+    onChanged: { addListener: () => {} },
+  });
+  const base = {
+    storage: { session: area(store), local: area({}), onChanged: { addListener: () => {} } },
+    tabs: {
+      get: async (tabId) => {
+        log.tabsGet.push(tabId);
+        return { id: tabId, windowId: 1, groupId: -1, url: "https://example.test/", title: "T" };
+      },
+      group: async () => {
+        log.group.push(1);
+        return 10;
+      },
+      remove: async () => {},
+      create: async () => ({ id: 1 }),
+      update: async () => {},
+      query: async () => [],
+      onRemoved: { addListener: () => {} },
+      onReplaced: { addListener: () => {} },
+      onUpdated: { addListener: () => {} },
+    },
+    tabGroups: {
+      get: async (groupId) => ({ id: groupId, title: "LO · A", collapsed: false }),
+      update: async (...args) => {
+        log.groupsUpdate.push(args);
+      },
+    },
+    debugger: {
+      attach: async (...args) => {
+        log.attach.push(args);
+      },
+      detach: async () => {},
+      sendCommand: async (...args) => {
+        log.sendCommand.push(args);
+        return {};
+      },
+      onEvent: { addListener: () => {} },
+      onDetach: { addListener: () => {} },
+    },
+    scripting: { executeScript: async () => [] },
+    webNavigation: {
+      onCompleted: { addListener: () => {}, removeListener: () => {} },
+      onErrorOccurred: { addListener: () => {}, removeListener: () => {} },
+      onBeforeNavigate: { addListener: () => {}, removeListener: () => {} },
+      onHistoryStateUpdated: { addListener: () => {}, removeListener: () => {} },
+    },
+    alarms: { create: () => {}, clear: async () => {}, onAlarm: { addListener: () => {} } },
+    notifications: { create: async () => {}, clear: async () => {}, onClicked: { addListener: () => {} } },
+    windows: { get: async () => ({ id: 1 }), getCurrent: async () => ({ id: 1 }) },
+    action: Object.fromEntries(
+      ["setBadgeBackgroundColor", "setBadgeTextColor", "setBadgeText", "setTitle"].map((m) => [
+        m,
+        async () => {},
+      ]),
+    ),
+    runtime: {
+      getURL: (path) => `chrome-extension://test/${path}`,
+      getManifest: () => ({ version: "0.1.10" }),
+      onStartup: { addListener: () => {} },
+      onInstalled: { addListener: () => {} },
+      onMessage: { addListener: () => {} },
+      sendMessage: async () => {},
+    },
+  };
+  for (const [namespace, patch] of Object.entries(overrides)) {
+    base[namespace] = { ...base[namespace], ...patch };
+  }
+  if (hangFirstSessionGet) {
+    let calls = 0;
+    const realGet = base.storage.session.get;
+    base.storage.session.get = async (keys) => {
+      calls += 1;
+      if (calls === 1) return new Promise(() => {});
+      return realGet(keys);
+    };
+  }
+  globalThis.chrome = base;
+  return { store, log, chrome: base };
+}
+
+const SURFACE_A = {
+  tabId: 101,
+  nonce: "aaaa",
+  epoch: 0,
+  createdAt: 0,
+  lastUsedAt: 0,
+  ownerKey: "session:s1",
+  groupBaseLabel: "LO · A",
+  groupOrdinal: 1,
+};
+const SURFACE_B = { ...SURFACE_A, tabId: 102, nonce: "bbbb", ownerKey: "session:s2" };
+
+// --- E1: the store queue drains -------------------------------------------
+
+test("E1 deadline drains the store queue", async () => {
+  // The first storage read never settles. `withStore` chains the SECOND op onto
+  // it with `.catch(() => {}).then(op)`, and `.catch` never runs on a promise
+  // that never settles — so pre-fix the second putSurface never runs at all.
+  const { store } = installChrome({ hangFirstSessionGet: true });
+  const state = await load(`export * from ${JSON.stringify(join(SRC, "state.ts"))};`);
+  try {
+    const stalled = state.loaded.putSurface(SURFACE_A);
+    const stalledSettled = assert.rejects(
+      stalled,
+      (error) => error.code === "internal" && String(error.data.stalled).includes("surfaces"),
+    );
+    await within(state.loaded.putSurface(SURFACE_B), 2_000, "the second putSurface");
+    await stalledSettled;
+    assert.ok(
+      store.surfaces?.["bridge:102:bbbb"],
+      "the second putSurface really ran rather than resolving without writing",
+    );
+  } finally {
+    await state.close();
+    delete globalThis.chrome;
+  }
+});
+
+// --- E2: the group queue drains, across surfaces --------------------------
+
+test("E2 deadline drains the group queue, and one session's stuck tab does not park another's", async () => {
+  const { store, log } = installChrome({
+    overrides: {
+      tabs: {
+        get: async (tabId) => {
+          log.tabsGet.push(tabId);
+          // The reported incident's exact shape: one driven tab whose renderer
+          // stopped answering. Everything else is healthy.
+          if (tabId === SURFACE_A.tabId) return new Promise(() => {});
+          return { id: tabId, windowId: 1, groupId: -1, url: "https://example.test/", title: "T" };
+        },
+      },
+    },
+  });
+  store.surfaces = {
+    "bridge:101:aaaa": clone(SURFACE_A),
+    "bridge:102:bbbb": clone(SURFACE_B),
+  };
+  const groups = await load(`export * from ${JSON.stringify(join(SRC, "tab-groups.ts"))};`);
+  try {
+    const owner = (label) => ({ requester: "session:s1", session_label: label });
+    const first = groups.loaded.reconcileCommandTab({ tab: "bridge:101:aaaa", ...owner("A") });
+    const second = groups.loaded.reconcileCommandTab({ tab: "bridge:102:bbbb", ...owner("B") });
+    await within(second, 2_000, "session B's grouping behind session A's stuck tab");
+    assert.ok(
+      log.tabsGet.includes(SURFACE_B.tabId),
+      "session B's op entered and ran — it was not queued behind the wedge",
+    );
+    // The first one is bounded too: it settles (as a rejection or a bail-out),
+    // rather than parking the module-global queue for the worker's lifetime.
+    await within(Promise.allSettled([first]), 2_000, "session A's own op");
+  } finally {
+    await groups.close();
+    delete globalThis.chrome;
+  }
+});
+
+// --- E3: the per-owner lane drains ---------------------------------------
+
+test("E3 deadline drains the ownership lane so owner_recover still answers", async () => {
+  // The reporting session's own path: an op parked in owner 1's lane, and
+  // `owner_recover` — the one command whose job is recovery — queued behind it
+  // and reported as a version mismatch. The hang is a chrome await INSIDE the
+  // op (the replay path's tabs.get), which is what the per-call deadline
+  // bounds: the op settles, the lane drains, the next owner command answers.
+  const proof = "a".repeat(40);
+  const params = {
+    owner_proof: proof,
+    requester: "session:s1",
+    owner_generation: "g1",
+    allocation_id: "a1",
+  };
+  let firstTabsGet = true;
+  const { store } = installChrome({
+    overrides: {
+      tabs: {
+        get: async (tabId) => {
+          if (firstTabsGet) {
+            firstTabsGet = false;
+            return new Promise(() => {});
+          }
+          return { id: tabId, windowId: 1, groupId: -1, url: "https://example.test/", title: "T" };
+        },
+      },
+    },
+  });
+  store.ownerScopes = {
+    [proof]: {
+      session: "session:s1",
+      generation: "g1",
+      allocations: { a1: { tab: "bridge:101:aaaa", state: "allocated" } },
+    },
+  };
+  store.surfaces = { "bridge:101:aaaa": clone(SURFACE_A) };
+  const ownership = await load(`export * from ${JSON.stringify(join(SRC, "ownership.ts"))};`);
+  try {
+    // `open` WITHOUT a tab param replays the journaled allocation, which reads
+    // the live tab: that read is the one that hangs.
+    const parked = ownership.loaded.withOwnership(
+      "open",
+      params,
+      async () => ({ tab: "bridge:101:aaaa", url: "u", title: "t" }),
+      async () => ({}),
+    );
+    const parkedSettled = parked.then(
+      () => "resolved",
+      (error) => (error?.data?.stalled ? "bounded" : "rejected"),
+    );
+    const recovered = await within(
+      ownership.loaded.withOwnership(
+        "owner_recover",
+        params,
+        async () => ({}),
+        async () => ({}),
+      ),
+      2_000,
+      "owner_recover behind a parked op on the SAME owner proof",
+    );
+    assert.equal(await parkedSettled, "bounded", "the parked op settled on its deadline");
+    assert.equal(recovered.state, "allocated");
+    assert.equal(recovered.tab, "bridge:101:aaaa");
+  } finally {
+    await ownership.close();
+    delete globalThis.chrome;
+  }
+});
+
+// --- E4 / E5 / X1: CDP ------------------------------------------------------
+
+test("E4 a CDP command deadline is typed and retryable", async () => {
+  const { log } = installChrome({
+    overrides: {
+      debugger: {
+        sendCommand: async (_target, method) => {
+          log.sendCommand.push(method);
+          if (method === "Page.captureScreenshot") return new Promise(() => {});
+          return { ok: true };
+        },
+      },
+    },
+  });
+  const cdp = await load(`export * from ${JSON.stringify(join(SRC, "cdp.ts"))};`);
+  try {
+    await assert.rejects(
+      within(
+        cdp.loaded.cdp(101, "Page.captureScreenshot", { format: "png" }),
+        2_000,
+        "the CDP command",
+      ),
+      (error) =>
+        error.code === "internal" &&
+        error.data.stalled === "chrome.debugger.sendCommand(Page.captureScreenshot)",
+    );
+    // Nothing global was poisoned: a different CDP call on the same worker
+    // still answers.
+    assert.deepEqual(await cdp.loaded.cdp(101, "Runtime.evaluate", {}), { ok: true });
+  } finally {
+    await cdp.close();
+    delete globalThis.chrome;
+  }
+});
+
+test("E5 the attach deadline does not mask a real debugger conflict", async () => {
+  // "Verify it still refuses where it should": the 5 s bound on
+  // `ownAttachment`'s trivial probe must not convert DevTools' real conflict
+  // into a generic stall.
+  installChrome({
+    overrides: {
+      debugger: {
+        attach: async () => {
+          throw new Error("Another debugger is already attached to the tab with id: 101.");
+        },
+        sendCommand: async () => new Promise(() => {}),
+      },
+    },
+  });
+  const cdp = await load(`export * from ${JSON.stringify(join(SRC, "cdp.ts"))};`);
+  try {
+    await assert.rejects(cdp.loaded.attach(101), (error) => error.code === "debugger_conflict");
+  } finally {
+    await cdp.close();
+    delete globalThis.chrome;
+  }
+});
+
+test("X1 an undrivable page is a typed, actionable failure AND prunes the surface", async () => {
+  // Live sighting from the reporter's browser (NOT reproduced in our own rig —
+  // Chrome 153 let a second extension's attach succeed alongside ours, so this
+  // path is untested there rather than refuted): Chrome refuses to debug
+  // another extension's page, and — unlike a failed `chrome.tabs.get` — the
+  // refusal used to leave the surface in the map, so every later command for
+  // it failed the same way, including a fresh `open`.
+  const { store } = installChrome({
+    overrides: {
+      debugger: {
+        attach: async () => {
+          throw new Error(
+            "Cannot access a chrome-extension:// URL of different extension",
+          );
+        },
+      },
+    },
+  });
+  store.surfaces = { "bridge:101:aaaa": clone(SURFACE_A) };
+  const cdp = await load(
+    `export * from ${JSON.stringify(join(SRC, "cdp.ts"))};
+     export * from ${JSON.stringify(join(SRC, "state.ts"))};`,
+  );
+  try {
+    await assert.rejects(
+      cdp.loaded.attach(SURFACE_A.tabId),
+      (error) =>
+        error.code === "internal" && error.data.undrivable_tab === "different_extension",
+    );
+    assert.deepEqual(
+      Object.keys(store.surfaces ?? {}),
+      [],
+      "the surface must be retired so the session's next open starts clean",
+    );
+  } finally {
+    await cdp.close();
+    delete globalThis.chrome;
+  }
+});
+
+// --- Worker-level rows: E6, E8, X2 ----------------------------------------
+
+/** Load worker.ts against a fake socket the test can drive. */
+async function loadWorker({ sendMessage, aliasTabGroups = null } = {}) {
+  const handles = installChrome({
+    overrides: {
+      runtime: {
+        getURL: (path) => `chrome-extension://test/${path}`,
+        getManifest: () => ({ version: "0.1.10" }),
+        onStartup: { addListener: () => {} },
+        onInstalled: { addListener: () => {} },
+        onMessage: { addListener: () => {} },
+        sendMessage: sendMessage ?? (async () => {}),
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: "node-test" },
+    configurable: true,
+    writable: true,
+  });
+  const sent = [];
+  const storageListeners = [];
+  handles.chrome.storage.onChanged.addListener = (fn) => storageListeners.push(fn);
+  let socket;
+  globalThis.WebSocket = class {
+    static OPEN = 1;
+    readyState = 1;
+    constructor() {
+      socket = this;
+      queueMicrotask(() => this.onopen?.());
+    }
+    send(data) {
+      sent.push(JSON.parse(String(data)));
+    }
+    close() {}
+  };
+  const worker = await load(
+    `export * from ${JSON.stringify(join(SRC, "worker.ts"))};`,
+    { aliasTabGroups },
+  );
+  for (let i = 0; i < 60 && !socket; i++) await tick();
+  assert.ok(socket, "the worker opened a socket");
+  await tick(20);
+  return {
+    sent,
+    storageListeners,
+    handles,
+    get socket() {
+      return socket;
+    },
+    deliver: (frame) => socket.onmessage?.({ data: JSON.stringify(frame) }),
+    close: worker.close,
+  };
+}
+
+test("E6 a healthy worker pongs without entering any queue", async () => {
+  // The structural fact the whole daemon-side detector rests on: the pong is
+  // answered in the socket's own onmessage handler, off every serialized
+  // queue. If a future refactor routes `ping` through a queue, a quiet-but-busy
+  // worker stops ponging and the daemon tears down a perfectly healthy link.
+  //
+  // CHARACTERISATION, not a pre-fix guard: this is already true today. Proving
+  // it can fail means moving the ping branch behind the queue and watching the
+  // assertion go red (recorded in the PR).
+  const worker = await loadWorker({
+    // Park EVERY command inside the module-global group queue — the wedge.
+    aliasTabGroups: `export * from ${JSON.stringify(REAL_TAB_GROUPS)};
+      export const reconcileCommandTab = () => new Promise(() => {});`,
+  });
+  try {
+    worker.deliver({ id: "r-parked", method: "status", params: {} });
+    await tick(20);
+    worker.deliver({ event: "ping" });
+    await tick(20);
+    assert.deepEqual(
+      worker.sent.filter((frame) => frame.event === "pong"),
+      [{ event: "pong" }],
+      "a worker with a command parked in a queue must still pong",
+    );
+  } finally {
+    await worker.close();
+    delete globalThis.chrome;
+  }
+});
+
+test("E8 a response the socket can no longer carry is logged, not silently dropped", async () => {
+  const worker = await loadWorker();
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    // The daemon evicted this socket mid-command ("later connection wins",
+    // close 4000): the answer is computed and has nowhere to go. There is no
+    // correct place to deliver it, so the fix is observability — the 23
+    // `extension disconnected` events in the operator's live log are this path.
+    worker.socket.readyState = 3;
+    worker.deliver({ id: "r-dropped", method: "retitle", params: { tab: "bridge:1:n" } });
+    await tick(40);
+    assert.ok(
+      warnings.some((line) => line.includes("dropped response for r-dropped")),
+      `expected a drop warning, got ${JSON.stringify(warnings)}`,
+    );
+  } finally {
+    console.warn = realWarn;
+    await worker.close();
+    delete globalThis.chrome;
+  }
+});
+
+test("X2 a runtime.sendMessage with no receiver cannot surface as an uncaught error", async () => {
+  // Captured from the operator's hands: with no popup open there is no
+  // receiver, so the origin_prompt broadcast rejects with "Could not establish
+  // connection. Receiving end does not exist." and the worker console shows
+  // `Uncaught (in promise)` — which is indistinguishable from a crash to
+  // anyone reading the console to diagnose a bridge fault.
+  const rejections = [];
+  const onRejection = (error) => rejections.push(error);
+  process.on("unhandledRejection", onRejection);
+  const worker = await loadWorker({
+    sendMessage: async () => {
+      throw new Error("Could not establish connection. Receiving end does not exist.");
+    },
+  });
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    assert.equal(worker.storageListeners.length, 1, "the worker registers one storage listener");
+    worker.storageListeners[0](
+      { accessQueue: { newValue: { queue: [], results: {}, onceGrants: {} } } },
+      "session",
+    );
+    await tick(60);
+    assert.deepEqual(rejections, [], "the rejection escaped as an unhandled rejection");
+    assert.ok(
+      warnings.some((line) => line.includes("origin_prompt broadcast")),
+      `expected the rejection to be recorded, got ${JSON.stringify(warnings)}`,
+    );
+  } finally {
+    process.off("unhandledRejection", onRejection);
+    console.warn = realWarn;
+    await worker.close();
+    delete globalThis.chrome;
+  }
+});
+
+// --- E7: the grant lane is bounded too (review R1-3) ----------------------
+
+test("E7 a hung chrome.storage.LOCAL read in the grant lane drains like any other", async () => {
+  // The popup's Allow path — worker dispatch → origins.resolveOrigin →
+  // approval-store.decideAccess → access-grants.grantExactOriginLocked — runs
+  // inside `withSessionMutation`, which IS `withStore` (state.ts). One bare
+  // `chrome.storage.local.get` here therefore parks EVERY command of EVERY
+  // session: the incident's exact shape, reached by clicking a button rather
+  // than by a stalled page. Eleven such awaits lived in this file; this pins the
+  // class so the grep in state.ts's comment stays true.
+  let reads = 0;
+  const local = {};
+  const localArea = {
+    get: async (keys) => {
+      reads += 1;
+      if (reads === 1) return new Promise(() => {});
+      const out = {};
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        if (key in local) out[key] = clone(local[key]);
+      }
+      return out;
+    },
+    set: async (value) => Object.assign(local, clone(value)),
+    remove: async (keys) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) delete local[key];
+    },
+    onChanged: { addListener: () => {} },
+  };
+  installChrome({ overrides: { storage: { local: localArea } } });
+  const grants = await load(
+    `export { grantExactOrigin } from ${JSON.stringify(join(SRC, "access-grants.ts"))};`,
+  );
+  try {
+    const parked = grants.loaded.grantExactOrigin("https://first.test/");
+    const parkedSettled = assert.rejects(
+      parked,
+      (error) =>
+        error.code === "internal" &&
+        String(error.data.stalled).includes("chrome.storage.local.get"),
+    );
+    await within(
+      grants.loaded.grantExactOrigin("https://second.test/"),
+      2_000,
+      "the grant after the parked one",
+    );
+    await parkedSettled;
+    assert.equal(
+      local.origins?.["https://second.test/"],
+      "allow",
+      "the next grant really ran rather than resolving without writing",
+    );
+  } finally {
+    await grants.close();
+    delete globalThis.chrome;
+  }
+});

--- a/extension/tests/fixtures/ownership.mjs
+++ b/extension/tests/fixtures/ownership.mjs
@@ -10,8 +10,13 @@ export async function fixture() {
   const dir = await mkdtemp(join(tmpdir(), "lop-ownership-"));
   let store = {}; let next = 100;
   const tabs = new Map(); const removed = [];
-  const faults = { navigation: false, remove: false, attach: false, capture: false };
+  const faults = { navigation: false, remove: false, attach: false, capture: false, navigationGate: null };
   globalThis.ownershipFaults = faults;
+  // Counts `chrome.tabs.update` calls so `navigationGate` can park exactly ONE
+  // navigation — the first one, i.e. whichever owner was admitted first. The
+  // admission tests need the first owner parked indefinitely while a second
+  // owner runs to completion, so "holds every navigation" would prove nothing.
+  let navigations = 0;
   globalThis.chrome = {
     storage: { session: {
       get: async () => structuredClone(store),
@@ -20,7 +25,12 @@ export async function fixture() {
     tabs: {
       create: async options => { const tab = { id: next++, ...options }; tabs.set(tab.id, tab); return tab; },
       get: async id => { if (!tabs.has(id)) throw Error(`No tab with id: ${id}`); return tabs.get(id); },
-      update: async (id, options) => { if (faults.navigation) throw Error("net::ERR_CONNECTION_REFUSED"); Object.assign(tabs.get(id), options); return tabs.get(id); },
+      update: async (id, options) => {
+        if (faults.navigation) throw Error("net::ERR_CONNECTION_REFUSED");
+        navigations += 1;
+        if (faults.navigationGate && navigations === 1) await faults.navigationGate;
+        Object.assign(tabs.get(id), options); return tabs.get(id);
+      },
       remove: async id => { if (faults.remove) throw Error("policy denied removal"); removed.push(id); tabs.delete(id); },
     },
   };

--- a/extension/tests/fixtures/ownership.mjs
+++ b/extension/tests/fixtures/ownership.mjs
@@ -29,10 +29,16 @@ export async function fixture() {
   const mocks = {
     cdp: `import {getSurfaces,removeSurface} from ${JSON.stringify(resolve("src/state.ts"))};
       export class BridgeCommandError extends Error {constructor(code,message,data={}){super(message);this.code=code;this.data=data}}
+      export const isStalled=()=>false;
       export const attach=async()=>{if(globalThis.ownershipFaults.attach)throw Error('attach failed')},detach=async()=>{},cdp=async()=>({result:{value:JSON.stringify({url:'https://example.test/',title:'fixture'})}}),pruneSurface=async(t)=>removeSurface(t),requireSurface=async(t)=>{const s=(await getSurfaces())[t];if(!s)throw new BridgeCommandError('tab_closed','gone');await chrome.tabs.get(s.tabId);return s};`,
     "log-capture": `export const dropLogCapture=()=>{},startLogCapture=async()=>{if(globalThis.ownershipFaults.capture)throw Error('capture failed')};`,
     origins: `export const safeHttpUrl=v=>new URL(v),ensureTopLevelAccess=async()=>({allowed:true}),askOrigin=async()=>true,withOriginGate=async(t,r,fn)=>fn();`,
-    settle: `export const settle=async()=>{};`,
+    // The real helper and its constants are pass-throughs in this harness: the
+    // modules under test still import them by NAME, so the fixture has to
+    // export them or esbuild fails the build ("No matching export in
+    // fixture:settle"). Handing back the op unchanged keeps the harness's
+    // fault injection (which rejects) exactly as it was.
+    settle: `export const settle=async()=>{};export const CHROME_API_DEADLINE_MS=5000;export const deadline=(op)=>op;`,
     "tab-groups": `export const reconcileTabGroup=async()=>{};`,
   };
   const outfile = join(dir, "bundle.mjs");

--- a/extension/tests/ownership.integration.test.mjs
+++ b/extension/tests/ownership.integration.test.mjs
@@ -99,3 +99,113 @@ test("completion queued during allocation leaves no late tab", async () => {
   try { const opening=f.call("open"); const finishing=f.call("owner_finish",{...f.owner,outcome:"completed"}); await opening; assert.equal((await finishing).state,"closed"); assert.equal(f.tabs.size,0); }
   finally { await f.close(); }
 });
+
+// --- Audit A4 / scoping D3: the admission window -----------------------------
+
+/** Wait until `predicate` holds, without asserting a duration. */
+async function until(predicate, ms = 1000) {
+  const started = Date.now();
+  while (Date.now() - started < ms) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return predicate();
+}
+
+test("the cap read and the slot write are one admission window (D3)", async () => {
+  // The defect is the classic read-then-write race: two owners at 7 surfaces
+  // both read "one slot free" and both take it. The lane that used to prevent
+  // it spanned the WHOLE open handler (and with it another owner's navigation);
+  // it now spans exactly cap-read -> create -> putSurface.
+  const f = await fixture();
+  try {
+    for (let i = 0; i < 7; i++) {
+      await f.call("open", {
+        ...f.owner,
+        owner_proof: String(i).repeat(40),
+        requester: `session:synthetic-${i}`,
+      });
+    }
+    assert.equal(Object.keys(f.store().surfaces).length, 7, "precondition: one slot left");
+
+    const results = await Promise.allSettled([
+      f.call("open", { ...f.owner, owner_proof: "x".repeat(40), requester: "session:x" }),
+      f.call("open", { ...f.owner, owner_proof: "y".repeat(40), requester: "session:y" }),
+    ]);
+
+    assert.equal(results.filter((r) => r.status === "fulfilled").length, 1, "exactly one open wins");
+    assert.equal(
+      results.filter((r) => r.status === "rejected" && r.reason.code === "tab_limit").length,
+      1,
+      "the loser gets a typed refusal, not a silent ninth tab",
+    );
+    assert.equal(Object.keys(f.store().surfaces).length, 8);
+    assert.equal(f.tabs.size, 8);
+  } finally {
+    await f.close();
+  }
+});
+
+test("a parked owner's open does not block another owner's admission (D3)", async () => {
+  // The audit's repro, inverted: owner A is parked INSIDE its navigation (a
+  // slow page or a human origin prompt), which under the old whole-handler
+  // global lane also held admission. Owner B must complete while A is still
+  // parked, which cannot happen if B is queued behind A.
+  const f = await fixture();
+  try {
+    let release;
+    f.faults.navigationGate = new Promise((r) => {
+      release = r;
+    });
+    const parked = f.call("open");
+    assert.ok(
+      await until(() => Object.keys(f.store().surfaces ?? {}).length === 1),
+      "owner A consumed its slot and is now parked in navigate",
+    );
+
+    const other = await Promise.race([
+      f.call("open", { ...f.owner, owner_proof: "b".repeat(40), requester: "session:b" }),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("owner B's open is parked behind owner A's navigation")), 750),
+      ),
+    ]);
+    assert.ok(other.tab, "owner B was admitted and finished while A was parked");
+
+    release();
+    await parked;
+    assert.equal(f.tabs.size, 2);
+  } finally {
+    f.faults.navigationGate = null;
+    await f.close();
+  }
+});
+
+test("a same-owner finish cannot overtake its own parked open (D3)", async () => {
+  // The per-owner lane must survive the narrowing: `owner_finish` racing its own
+  // in-flight `open` would otherwise let a late navigation resurrect a tab the
+  // session has already retired.
+  const f = await fixture();
+  try {
+    let release;
+    f.faults.navigationGate = new Promise((r) => {
+      release = r;
+    });
+    const opening = f.call("open");
+    assert.ok(await until(() => Object.keys(f.store().surfaces ?? {}).length === 1));
+
+    const finishing = f.call("owner_finish", { ...f.owner, outcome: "completed" });
+    const overtook = await Promise.race([
+      finishing.then(() => true),
+      new Promise((r) => setTimeout(() => r(false), 150)),
+    ]);
+    assert.equal(overtook, false, "owner_finish overtook its own open");
+
+    release();
+    await opening;
+    assert.equal((await finishing).state, "closed");
+    assert.equal(f.tabs.size, 0);
+  } finally {
+    f.faults.navigationGate = null;
+    await f.close();
+  }
+});

--- a/extension/tests/popup-pairing-jitter.integration.test.mjs
+++ b/extension/tests/popup-pairing-jitter.integration.test.mjs
@@ -26,6 +26,10 @@ const HERE = dirname(fileURLToPath(import.meta.url));
  * than one that fails when an id is renamed. */
 const IDS = [
   "connected", "paired", "pairing", "disconnected", "incompatible", "origin", "origin-ack",
+  // The wedge card and its retry: popup.ts paints the section and wires the
+  // button, and the D3-1 pin row asserts on the section's visibility, so a
+  // missing stub node would make that assertion vacuous.
+  "unresponsive", "retry-unresponsive",
   "pending", "origin-host", "origin-again", "origin-scope", "origin-scope-detail",
   "origin-position", "origin-waiting", "origin-allow", "origin-deny", "origin-previous",
   "origin-next", "origin-ack-title", "origin-ack-sub", "origin-ack-check", "card", "retry",
@@ -243,7 +247,7 @@ async function loadPopup() {
 /** A reachable daemon whose /health answer and LATENCY are both controllable.
  * Latency is what puts two renders in flight at once, which is the whole of
  * the ordering defect. */
-function installFetchStub(paired, delayMs = () => 0) {
+function installFetchStub(paired, delayMs = () => 0, extra = {}) {
   globalThis.fetch = async () => {
     const wait = delayMs();
     // The answer is snapshotted when the request STARTS, exactly as a real
@@ -260,6 +264,7 @@ function installFetchStub(paired, delayMs = () => 0) {
         extension_connected: true,
         protocol_version: 1,
         pending_origin: undefined,
+        ...extra,
       }),
     };
   };
@@ -458,16 +463,19 @@ test("the error sits above the button that produced it (D2)", async () => {
   );
 });
 
-test("the first paint is pinned to the state this browser will actually reach (D1)", async () => {
+test("the first paint is pinned to the state this browser will actually reach (D1/D3-1)", async () => {
   // #pending paints on EVERY open, before render()'s awaits resolve, so its
-  // pinned height decides how far the card travels. One pin cannot serve both
-  // populations: the pairing form is 360.5px and the connected card 239.9px.
+  // pinned height decides how far the card travels. THREE pins now, not a
+  // boolean: the unresponsive card was unreachable from a paired/unpaired
+  // choice, so the wedge state opened 167.8px short of the card it settled on
+  // (design D3-1, measured in Chrome). The pin recorded is the one for the card
+  // show() last rendered.
   const nodes = installDomStub();
   const { areas } = installChromeStub();
 
   // An already-paired browser. The hint is synchronous (localStorage), because
   // chrome.storage cannot inform a first paint.
-  globalThis.localStorage.setItem("lop:paired-hint", "1");
+  globalThis.localStorage.setItem("lop:pin-hint", "86px");
   installFetchStub(() => true);
   let bundle = await loadPopup();
   try {
@@ -491,7 +499,7 @@ test("the first paint is pinned to the state this browser will actually reach (D
   // A browser that has never paired.
   const fresh = installDomStub();
   const second = installChromeStub();
-  globalThis.localStorage.removeItem("lop:paired-hint");
+  globalThis.localStorage.removeItem("lop:pin-hint");
   installFetchStub(() => false);
   bundle = await loadPopup();
   try {
@@ -556,24 +564,46 @@ test("the pin is applied BEFORE the first paint, not by the deferred module (Q4)
   // duplicated because nothing can be shared with code that runs this early,
   // and a silent divergence is a resize for one of the two populations.
   const popup = await readFile(join(HERE, "..", "src", "popup", "popup.ts"), "utf8");
-  const owned = /readPairedHint\(\) \? "(\d+)px" : "(\d+)px"/.exec(popup);
-  assert.ok(owned, "popup.ts must still own the measured pins");
-  const early = /paired \? PAIRED_PIN : UNPAIRED_PIN/.test(source) && {
-    paired: /PAIRED_PIN = "(\d+)px"/.exec(source)?.[1],
-    unpaired: /UNPAIRED_PIN = "(\d+)px"/.exec(source)?.[1],
-  };
-  assert.ok(early, "first-paint.js must choose between a paired and an unpaired pin");
-  assert.equal(early.paired, owned[1], "the paired pin must match popup.ts");
-  assert.equal(early.unpaired, owned[2], "the unpaired pin must match popup.ts");
+  const owned = Object.fromEntries(
+    [...popup.matchAll(/const PIN_(\w+) = "(\d+)px"/g)].map((m) => [m[1], m[2]]),
+  );
+  assert.deepEqual(
+    Object.keys(owned).sort(),
+    ["CONNECTED", "PAIRING", "UNRESPONSIVE"],
+    "popup.ts must own the three measured pins (design D3-1) — a state with no pin of its own reopens at the wrong height",
+  );
+  const early = Object.fromEntries(
+    [...source.matchAll(/var PIN_(\w+) = "(\d+)px"/g)].map((m) => [m[1], m[2]]),
+  );
+  for (const [name, px] of Object.entries(owned)) {
+    assert.equal(
+      early[name],
+      px,
+      `first-paint.js must carry popup.ts's PIN_${name} (${px}px); a divergence is a resize for whoever holds that hint`,
+    );
+  }
+  // And the script must actually CONSULT the stored pin rather than pick one of
+  // the three by a rule of its own: that is what D3-1 was.
+  assert.match(
+    source,
+    /PINS\.indexOf\(stored\)/,
+    "first-paint.js must accept only a recorded pin, so a stale value falls back rather than pinning something unmeasured",
+  );
 
-  const key = /PAIRED_HINT_KEY = "([^"]+)"/.exec(popup)?.[1];
+  const key = /PIN_HINT_KEY = "([^"]+)"/.exec(popup)?.[1];
+  assert.ok(key, "popup.ts must own the hint's storage key");
   assert.ok(source.includes(`"${key}"`), `first-paint.js must read the same key (${key}) popup.ts writes`);
+  // The boolean key the previous revision wrote: read once so the rename does
+  // not cost an existing paired browser a resize. Both files, or the pre-paint
+  // and the module disagree for exactly one open.
+  assert.match(popup, /LEGACY_PAIRED_HINT_KEY = "lop:paired-hint"/, "popup.ts must keep the legacy-key fallback");
+  assert.match(source, /LEGACY_KEY = "lop:paired-hint"/, "first-paint.js must keep the legacy-key fallback");
 
-  // And the CSS fallback must be the unpaired pin: it is what a browser whose
+  // And the CSS fallback must be the pairing pin: it is what a browser whose
   // hint cannot be read at all gets.
   const css = await readFile(join(HERE, "..", "src", "popup", "popup.css"), "utf8");
   const fallback = /#pending\s*\{[^}]*min-height:\s*(\d+)px/.exec(css);
-  assert.equal(fallback?.[1], owned[2], "the CSS fallback must be the unpaired pin");
+  assert.equal(fallback?.[1], owned.PAIRING, "the CSS fallback must be the pairing pin");
 
   // The store package is an explicit allowlist; an unlisted file ships a popup
   // whose <head> references a 404 and whose pin is never applied.
@@ -584,29 +614,55 @@ test("the pin is applied BEFORE the first paint, not by the deferred module (Q4)
   );
 });
 
-test("the paired hint follows /health in both directions (D1)", async () => {
-  // The hint is a layout guess and must never drift from reality: an unpair has
-  // to shrink the next first paint back, or the returning user gets the resize
-  // the pin exists to remove.
+test("the pin follows the card that was rendered, in both directions (D1/D3-1)", async () => {
+  // The hint is a layout guess and must never drift from what the popup paints:
+  // an unpair has to shrink the next first paint back, and the wedge state —
+  // which is neither paired nor unpaired — has to reopen at ITS OWN height, or
+  // the reopen lands 167.8px short (design D3-1).
   const nodes = installDomStub();
   const { areas } = installChromeStub();
+  globalThis.localStorage.removeItem("lop:pin-hint");
   globalThis.localStorage.removeItem("lop:paired-hint");
-  let paired = true;
-  installFetchStub(() => paired);
+  let health = { paired: true, extension_unresponsive: false };
+  installFetchStub(() => health.paired, () => 0, { extension_unresponsive: false });
   const bundle = await loadPopup();
   try {
     areas.local.set("port", 4099);
     await bundle.import();
     await tick(30);
-    assert.equal(globalThis.localStorage.getItem("lop:paired-hint"), "1", "pairing must record the hint");
+    assert.equal(
+      globalThis.localStorage.getItem("lop:pin-hint"),
+      "86px",
+      "the connected card must record its own pin",
+    );
 
-    paired = false;
+    // An unpair: the next open must be pinned to the form, not to a card this
+    // browser will not reach.
+    health = { paired: false, extension_unresponsive: false };
+    globalThis.fetch = async () => ({ ok: true, json: async () => health });
     await chrome.storage.session.set({ connState: "pairing" });
     await tick(30);
     assert.equal(
-      globalThis.localStorage.getItem("lop:paired-hint"),
-      "0",
-      "an unpair must clear the hint, or the next first paint is pinned to the wrong state",
+      globalThis.localStorage.getItem("lop:pin-hint"),
+      "219px",
+      "an unpair must record the form's pin, or the next first paint is the wrong height",
+    );
+
+    // The wedge: neither paired nor unpaired. THIS is the case a boolean hint
+    // could not express, and the one the recovery copy sends the user back into
+    // ("Check again").
+    health = { paired: false, extension_unresponsive: true };
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(30);
+    assert.equal(
+      nodes.get("unresponsive").classList.contains("hidden"),
+      false,
+      "precondition: the wedge state really does render the unresponsive card",
+    );
+    assert.equal(
+      globalThis.localStorage.getItem("lop:pin-hint"),
+      "254px",
+      "the wedge card must record ITS OWN pin, or every reopen grows into it (D3-1)",
     );
   } finally {
     await bundle.close();

--- a/extension/tests/popup-render.integration.test.mjs
+++ b/extension/tests/popup-render.integration.test.mjs
@@ -28,11 +28,13 @@ import { pathToFileURL } from "node:url";
  * silently stops covering an element because the parse missed it is worse
  * than one that fails when an id is renamed. */
 const IDS = [
-  "connected", "paired", "pairing", "disconnected", "incompatible", "origin", "origin-ack",
+  "connected", "paired", "pairing", "disconnected", "incompatible", "unresponsive",
+  "origin", "origin-ack",
   "origin-host", "origin-again", "origin-scope", "origin-scope-detail", "origin-position",
   "origin-waiting", "origin-allow", "origin-deny", "origin-previous", "origin-next",
   "origin-ack-title", "origin-ack-sub", "origin-ack-check", "card", "retry",
-  "retry-incompatible", "connected-all-sites", "connected-all-sites-off", "pair-form",
+  "retry-incompatible", "retry-unresponsive", "connected-all-sites", "connected-all-sites-off",
+  "pair-form",
   "pair-code", "pair-error", "port", "port-row",
 ];
 
@@ -423,6 +425,49 @@ test("a deny re-ask does not claim the answer was used (U11)", async () => {
       /already been used/,
       "nothing was used: the agent did not visit the site",
     );
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("a wedged worker is not painted as connected (D4)", async () => {
+  const nodes = installDomStub();
+  installChromeStub();
+  // A live daemon that reports the state this whole change exists for: paired,
+  // socket attached, nothing answered. `extension_unresponsive` is the field the
+  // popup must CONSUME — it was in the Health type and never read, so the green
+  // card claimed the agent could drive while no command could be answered.
+  let health = { paired: true, extension_connected: true, protocol_version: 1, pending_origin: undefined };
+  globalThis.fetch = async () => ({ ok: true, json: async () => health });
+  const bundle = await loadPopup();
+  try {
+    await bundle.import();
+    await tick(20);
+    assert.equal(nodes.get("connected").classList.contains("hidden"), false, "precondition: healthy renders the connected card");
+    assert.equal(nodes.get("unresponsive").classList.contains("hidden"), true, "precondition: no wedge, no wedge card");
+
+    // The worker goes mute. /health keeps `paired: true` (and so does the LINK),
+    // which is exactly why the connected card used to stay up.
+    health = { ...health, extension_connected: false, extension_unresponsive: true, link_attached: true };
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(20);
+    assert.equal(nodes.get("unresponsive").classList.contains("hidden"), false, "a wedged worker must not render as connected");
+    assert.equal(nodes.get("connected").classList.contains("hidden"), true, "the success card must be REPLACED, not merely annotated");
+
+    // RENDER N+1: the same state, one more storage event. Every defect in this
+    // class is correct on render N and wrong on N+1.
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(20);
+    assert.equal(nodes.get("unresponsive").classList.contains("hidden"), false, "must survive a later render");
+    assert.equal(nodes.get("connected").classList.contains("hidden"), true);
+
+    // The link comes back: the card must recover, or the fix would be its own
+    // sticky lie.
+    health = { ...health, extension_connected: true, extension_unresponsive: false };
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(20);
+    assert.equal(nodes.get("connected").classList.contains("hidden"), false, "must recover to the connected card");
+    assert.equal(nodes.get("unresponsive").classList.contains("hidden"), true);
   } finally {
     await bundle.close();
   }

--- a/extension/tests/popup-render.integration.test.mjs
+++ b/extension/tests/popup-render.integration.test.mjs
@@ -468,6 +468,29 @@ test("a wedged worker is not painted as connected (D4)", async () => {
     await tick(20);
     assert.equal(nodes.get("connected").classList.contains("hidden"), false, "must recover to the connected card");
     assert.equal(nodes.get("unresponsive").classList.contains("hidden"), true);
+
+    // THE OTHER HALF OF THE WINDOW, and the reason this card exists at all: the
+    // post-drop cooling-off period, where the daemon has severed the link so
+    // `/health` reports `paired: false` (it is link-derived) while the pairing on
+    // disk — and the daemon's own `paired:` line — are still true. The card used
+    // to be gated on `paired`, so this exact payload rendered the PAIRING FORM
+    // for a paired browser that is about to re-dial (QA Q2-3 / review R2-5).
+    health = {
+      ...health,
+      paired: false,
+      extension_connected: false,
+      extension_unresponsive: true,
+      link_attached: false,
+    };
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(20);
+    assert.equal(
+      nodes.get("unresponsive").classList.contains("hidden"),
+      false,
+      "the latched half of the window must show the honest card, not the pairing form",
+    );
+    assert.equal(nodes.get("pairing").classList.contains("hidden"), true, "a paired browser must not be asked for a code");
+    assert.equal(nodes.get("connected").classList.contains("hidden"), true);
   } finally {
     await bundle.close();
   }

--- a/extension/tests/worker-pairing-eviction.integration.test.mjs
+++ b/extension/tests/worker-pairing-eviction.integration.test.mjs
@@ -212,3 +212,66 @@ test("protocol and unpair close codes keep their own states (J4 regression guard
     }
   }
 });
+
+/** Load one source module on its own, for the pure helpers. */
+async function loadModule(relative) {
+  const dir = await mkdtemp(join(tmpdir(), "lop-worker-evict-mod-"));
+  const outfile = join(dir, "module.mjs");
+  await build({
+    entryPoints: [join(HERE, "..", relative)],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile,
+  });
+  return import(pathToFileURL(outfile) + `?${Date.now()}`);
+}
+
+test("a post-onopen 4000 close re-dials on the attempt-0 fast path, not the alarm floor", async () => {
+  // The design's §4.2 claim — "the replacement registered in ~1 s" — pinned as
+  // a STRUCTURAL fact about the delay the worker ASKS for, not as a measurement
+  // of how long anything took (AGENTS.md: wait on the event, never on the
+  // clock). `onopen` resets `attempt` to 0, so a close that arrives after a
+  // successful open must arm `backoffDelayMs(0)`. If the reset were dropped,
+  // the requested delay would be 2000 and this fails.
+  const reconnect = await loadModule("src/reconnect.ts");
+  assert.equal(reconnect.backoffDelayMs(0), 1_000, "attempt 0 is the ~1 s fast path");
+  assert.equal(reconnect.backoffDelayMs(1), 2_000, "and attempt 1 doubles it");
+
+  const worker = await loadWorker();
+  const realSetTimeout = globalThis.setTimeout;
+  const requested = [];
+  globalThis.setTimeout = (fn, delay, ...rest) => {
+    requested.push(delay);
+    return realSetTimeout(fn, delay, ...rest);
+  };
+  try {
+    const first = await worker.evict(4000);
+    assert.equal(first.reconnectScheduled, true, "the worker must still re-dial after a 4000 eviction");
+    assert.ok(
+      requested.includes(1_000),
+      `expected the attempt-0 fast path, got delays ${JSON.stringify(requested)}`,
+    );
+    assert.ok(!requested.includes(2_000), "a post-onopen close must not be armed as attempt 1");
+
+    // Round 2 is what makes the RESET observable. The first close cannot
+    // distinguish "onopen reset attempt" from "attempt was never incremented",
+    // because it starts at 0 — so close a SECOND time, after a successful
+    // re-dial whose onopen should have reset the backoff. Without that reset
+    // the second close is armed as backoffDelayMs(1) = 2000.
+    requested.length = 0;
+    const second = await worker.evict(4000);
+    assert.equal(second.reconnectScheduled, true, "the re-dial must be repeatable");
+    assert.ok(
+      requested.includes(1_000),
+      `expected attempt-0 again after a successful re-dial, got ${JSON.stringify(requested)}`,
+    );
+    assert.ok(
+      !requested.includes(2_000),
+      "the backoff was not reset by the successful re-dial",
+    );
+  } finally {
+    globalThis.setTimeout = realSetTimeout;
+    await worker.close();
+  }
+});

--- a/extension/tests/worker-wire-generation.integration.test.mjs
+++ b/extension/tests/worker-wire-generation.integration.test.mjs
@@ -1,0 +1,250 @@
+/* Coverage for the worker's connection GENERATION (audit A1, extension half).
+ *
+ * `dispatch` is fired fire-and-forget from the socket's onmessage handler, so a
+ * handler that finishes after a reconnect writes its response — and the
+ * `tab_update` that precedes it — to the module-global `socket`, which by then
+ * is the REPLACEMENT connection. The daemon matches a response to the request it
+ * sent on the OLD socket, so the new socket receives a frame it never asked for,
+ * and the worker's own promise ("nothing is replayed on a new socket") is broken
+ * from the worker's side. Reproduced by the concurrency audit by bundling this
+ * file, gating one handler, replacing the wire, then releasing the handler:
+ *
+ *   oldResponseOnNewWire=[tab_update bridge:1:old,
+ *                         {id: old-request, ok: true, tab: bridge:1:old}]
+ *
+ * Two rows: the stale response must be dropped, and — the other half, because a
+ * fence that dropped everything would also pass the first — a request that
+ * arrives on the CURRENT wire must still be answered.
+ *
+ * Separate file from worker-pairing-eviction.integration.test.mjs on purpose:
+ * this row needs a gated handler (via a `tab-groups` alias, the same technique
+ * bridge-wedge.integration.test.mjs uses) and per-socket frame injection, which
+ * that file's harness deliberately does not have.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "..", "src");
+const tick = (n = 4) => new Promise((r) => setTimeout(r, n));
+
+/** Load worker.ts with `tab-groups` aliased, a recordable fake WebSocket, and a
+ * controllable `retitle` gate. */
+async function loadWorker() {
+  const session = new Map();
+  const local = new Map([
+    ["token", "tok"],
+    ["port", 4099],
+  ]);
+  const wires = [];
+  const warnings = [];
+  let release = () => {};
+  const gate = new Promise((r) => {
+    release = r;
+  });
+
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: "node-test" },
+    configurable: true,
+    writable: true,
+  });
+  globalThis.WebSocket = class {
+    static OPEN = 1;
+    static CLOSED = 3;
+    readyState = 1;
+    sent = [];
+    constructor() {
+      wires.push(this);
+      queueMicrotask(() => this.onopen?.());
+    }
+    send(data) {
+      this.sent.push(JSON.parse(String(data)));
+    }
+    close() {
+      this.readyState = 3;
+      queueMicrotask(() => this.onclose?.({ code: 1000 }));
+    }
+  };
+  const realWarn = console.warn;
+  console.warn = (...args) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  const area = (map) => ({
+    get: async (keys) => {
+      const out = {};
+      for (const k of Array.isArray(keys) ? keys : [keys]) if (map.has(k)) out[k] = map.get(k);
+      return out;
+    },
+    set: async (obj) => {
+      for (const [k, v] of Object.entries(obj)) map.set(k, v);
+    },
+    remove: async (keys) => {
+      for (const k of Array.isArray(keys) ? keys : [keys]) map.delete(k);
+    },
+  });
+  globalThis.chrome = {
+    storage: { session: area(session), local: area(local), onChanged: { addListener: () => {} } },
+    alarms: { create: () => {}, clear: async () => {}, onAlarm: { addListener: () => {} } },
+    action: Object.fromEntries(
+      ["setBadgeBackgroundColor", "setBadgeTextColor", "setBadgeText", "setTitle"].map((m) => [
+        m,
+        async () => {},
+      ]),
+    ),
+    debugger: {
+      attach: async () => {},
+      detach: async () => {},
+      sendCommand: async () => ({}),
+      onEvent: { addListener: () => {} },
+      onDetach: { addListener: () => {} },
+    },
+    tabs: {
+      get: async (tabId) => ({ id: tabId, url: "https://example.com/live", title: "Live" }),
+      remove: async () => {},
+      query: async () => [],
+      onRemoved: { addListener: () => {} },
+      onReplaced: { addListener: () => {} },
+      onUpdated: { addListener: () => {} },
+    },
+    tabGroups: undefined,
+    notifications: {
+      create: async () => {},
+      clear: async () => {},
+      onClicked: { addListener: () => {} },
+    },
+    windows: { get: async () => ({ id: 1 }), getCurrent: async () => ({ id: 1 }) },
+    runtime: {
+      getURL: (p) => `chrome-extension://test/${p}`,
+      getManifest: () => ({ version: "0.1.11" }),
+      onStartup: { addListener: () => {} },
+      onInstalled: { addListener: () => {} },
+      onMessage: { addListener: () => {} },
+      sendMessage: async () => {},
+    },
+  };
+
+  const dir = await mkdtemp(join(tmpdir(), "lop-worker-gen-"));
+  const fixture = join(dir, "tab-groups.mjs");
+  // The gate IS the test's instrument: `retitle` reaches this fixture's promise
+  // and nothing resolves it until the test says so, which is how a handler is
+  // held open across the reconnect.
+  await writeFile(
+    fixture,
+    [
+      "export const reconcileCommandTab = async () => undefined;",
+      "export const retitle = async () => {",
+      "  await gatePromise;",
+      "  return { tab: 'bridge:1:old', url: 'https://old-request.test', title: 'OLD' };",
+      "};",
+    ].join("\n"),
+  );
+  const outfile = join(dir, "worker.mjs");
+  await build({
+    entryPoints: [join(SRC, "worker.ts")],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile,
+    plugins: [
+      {
+        name: "gated-tab-groups",
+        setup(b) {
+          b.onResolve({ filter: /^\.\/tab-groups$/ }, () => ({ path: "tab-groups", namespace: "g" }));
+          b.onLoad({ filter: /.*/, namespace: "g" }, () => ({
+            contents: `const gatePromise = globalThis.__lopGate;\nexport const reconcileCommandTab = async () => undefined;\nexport const retitle = async () => {\n  await gatePromise;\n  return { tab: "bridge:1:old", url: "https://old-request.test", title: "OLD" };\n};\n`,
+            loader: "js",
+          }));
+        },
+      },
+    ],
+  });
+  globalThis.__lopGate = gate;
+  await import(pathToFileURL(outfile) + `?${Date.now()}`);
+  for (let i = 0; i < 60 && !wires.length; i++) await tick();
+  assert.ok(wires.length, "the worker opened a socket");
+  await tick(20);
+
+  return {
+    gate: { release },
+    wires,
+    warnings,
+    /** Deliver a daemon frame to a specific socket, as that socket's peer. */
+    deliver: (wire, frame) => wire.onmessage?.({ data: JSON.stringify(frame) }),
+    /** Wait for a NEW socket to appear — the reconnect fast path (~1 s). */
+    waitForDial: async (count, ms = 4000) => {
+      const started = Date.now();
+      while (wires.length < count && Date.now() - started < ms) await tick(20);
+      assert.equal(wires.length >= count, true, `the worker re-dialled (saw ${wires.length})`);
+      await tick(20);
+    },
+    close: async () => {
+      console.warn = realWarn;
+      delete globalThis.__lopGate;
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("a response to a request from a superseded connection is not replayed (A1)", async () => {
+  const worker = await loadWorker();
+  try {
+    const [first] = worker.wires;
+    worker.deliver(first, { id: "old-request", method: "retitle", params: { title: "OLD" } });
+    await tick(20);
+
+    // The wire goes away while the handler is still parked — exactly what a
+    // reconnect does to an in-flight command.
+    first.onclose?.({ code: 1006 });
+    await worker.waitForDial(2);
+    const second = worker.wires[1];
+    assert.notEqual(second, first, "a new socket is the live one");
+    const secondSentBefore = second.sent.length;
+
+    worker.gate.release();
+    await tick(40);
+
+    const replayed = second.sent
+      .slice(secondSentBefore)
+      .filter((f) => f.id === "old-request" || f.event === "tab_update");
+    assert.deepEqual(
+      replayed,
+      [],
+      "the old request's response and tab_update must not land on the new wire",
+    );
+    // The drop is observable, not silent: an agent reading the worker console
+    // should be able to see WHY a response never went out.
+    assert.ok(
+      worker.warnings.some((w) => w.includes("old-request")),
+      `the dropped response was logged (warnings: ${JSON.stringify(worker.warnings)})`,
+    );
+    assert.equal(first.sent.filter((f) => f.id === "old-request").length, 0);
+  } finally {
+    await worker.close();
+  }
+});
+
+test("a request on the current wire is still answered, and still pushes its tab (A1, inverse)", async () => {
+  const worker = await loadWorker();
+  try {
+    const [first] = worker.wires;
+    worker.gate.release();
+    worker.deliver(first, { id: "fresh-request", method: "retitle", params: { title: "NEW" } });
+    await tick(40);
+
+    const response = first.sent.find((f) => f.id === "fresh-request");
+    assert.ok(response, "a live request must still be answered");
+    assert.equal(response.ok, true);
+    assert.ok(
+      first.sent.some((f) => f.event === "tab_update" && f.tab === "bridge:1:old"),
+      "a live request must still push its driven tab",
+    );
+    assert.deepEqual(worker.warnings, [], "nothing was dropped on a live wire");
+  } finally {
+    await worker.close();
+  }
+});

--- a/local_operator/browser_bridge/backend.py
+++ b/local_operator/browser_bridge/backend.py
@@ -73,6 +73,22 @@ ERROR_MESSAGES = {
 }
 
 
+#: The one `extension_disconnected` shape that is NOT "no browser is attached":
+#: the daemon's wire fence detected that the extension REPLACED its connection
+#: while a command was in flight (see `daemon.py`'s `_admit`/`_complete` send and
+#: response fences). The browser is open and the worker has already re-dialled,
+#: so "ask the user to open their browser" names an action that does not apply
+#: and `lop browser install` is not even in scope — it resolves itself in about a
+#: second (design D3-3). Selected by the `phase` the daemon carries, because the
+#: code alone cannot tell this apart from a genuinely absent browser.
+REPLACED_PHASE = "replaced"
+REPLACED_PHASE_MESSAGE = (
+    "the browser extension replaced its connection while this command was in flight, so the "
+    "command was never answered. The browser is open and reconnected — retry the action; no "
+    "user action is needed."
+)
+
+
 class BridgeError(RuntimeError):
     def __init__(self, code: ErrorCode, message: str, data: dict[str, Any] | None = None) -> None:
         super().__init__(message)
@@ -185,6 +201,11 @@ def _origin(value: str) -> str:
 
 def format_error(error: BridgeError, *, action: str = "", surface: str = "") -> str:
     """Map every wire error to one actionable model-facing diagnostic."""
+    # Checked BEFORE the table: this code's own copy is the "no browser is
+    # attached" one, and it is exactly wrong for a replaced wire — the browser is
+    # open, mid-reconnect, and the command may simply be retried (design D3-3).
+    if error.code == ErrorCode.EXTENSION_DISCONNECTED and error.data.get("phase") == REPLACED_PHASE:
+        return REPLACED_PHASE_MESSAGE
     if error.code in ERROR_MESSAGES:
         return ERROR_MESSAGES[error.code]
     if error.code == ErrorCode.TAB_CLOSED:

--- a/local_operator/browser_bridge/backend.py
+++ b/local_operator/browser_bridge/backend.py
@@ -40,6 +40,32 @@ ERROR_MESSAGES = {
         "user to close DevTools on that tab."
     ),
     ErrorCode.BUSY: "the browser bridge is busy with another command; retry this action once.",
+    ErrorCode.EXTENSION_UNRESPONSIVE: (
+        # Every clause names an action that measurably works. The remedy it leads
+        # to is the one with a measurement behind it: toggling the extension OFF
+        # then ON in `chrome://extensions` reloads the wedged worker and
+        # PRESERVES pairing (verified on real hardware — GUIDE, "failure UX").
+        #
+        # The previous text sent the reader to "retry in a few seconds", which
+        # landed on EXTENSION_DISCONNECTED — "no browser is attached… ask the
+        # user to open their browser" — for a browser that is open, i.e. the
+        # exact misdirection class this code exists to remove (design D1). The
+        # daemon no longer answers with that string during the cooling-off
+        # window either (see `_drop_unproven_link` / `LINK_DROP_TTL_S`), so a
+        # retry now lands here or on a live link.
+        #
+        # "toggle … OFF then ON" rather than "reload": chrome://extensions also
+        # offers Update and Remove right there, and only the toggle has a
+        # measurement attached (design D7).
+        #
+        # Deliberately NOT reusing EXTENSION_DISCONNECTED's copy.
+        "the browser extension is attached and paired but has stopped answering, so the "
+        "browser cannot be driven. Retry once in a few seconds. If the same action fails "
+        "again the worker is wedged and only a reload clears it: ask the user to toggle "
+        "the Local Operator extension OFF then ON in chrome://extensions — pairing is "
+        "preserved, but open tab handles, snapshot refs and pending site decisions are "
+        "lost, so re-'open' and re-'snapshot' afterwards. A daemon restart does not help."
+    ),
     ErrorCode.PROTO_MISMATCH: (
         "browser bridge protocol mismatch: update Local Operator and the browser extension, "
         "then restart the bridge daemon."
@@ -220,6 +246,48 @@ def format_error(error: BridgeError, *, action: str = "", surface: str = "") -> 
         return (
             f"the browser tab crashed while {action or 'the action'} was running. "
             "'open' the URL again to recover."
+        )
+    if error.code == ErrorCode.INTERNAL and error.data.get("stalled"):
+        # An extension-side per-call deadline fired: the op SETTLED rather than
+        # hung, which is what drains the extension's serialized chains and lets
+        # the next command run. Retry is genuinely correct here, unlike for
+        # EXTENSION_UNRESPONSIVE.
+        return (
+            f"the browser extension stalled on {error.data['stalled']} and gave up on this "
+            "command. Retry; if it repeats, ask the user to toggle the Local Operator "
+            "extension OFF then ON in chrome://extensions (pairing is preserved)."
+        )
+    if error.code == ErrorCode.INTERNAL and error.data.get("undrivable_tab"):
+        # Chrome refuses to attach the debugger to another extension's page
+        # ("Cannot access a chrome-extension:// URL of different extension").
+        # The tab is alive but can never be driven, and the extension has
+        # already pruned the surface, so the session's only move is a new tab.
+        #
+        # No tab is named: the only handle available here is the session's own
+        # opaque `bridge:<tabId>:<nonce>` capability string, and interpolating
+        # it (or a literal `(unknown)` when there is none) puts a useless token
+        # in the middle of prose (design D6).
+        return (
+            "that tab cannot be driven: it is another extension's page, so Chrome refuses "
+            "the debugger attachment. The handle was dropped; use 'open' with a URL to get "
+            "a new tab."
+        )
+    if error.code == ErrorCode.INTERNAL and "timeout_s" in error.data:
+        # The daemon's own budget expired with no typed answer from the
+        # extension. P3 correctly stopped this reading as a version mismatch,
+        # but left it on the generic fallback: a raw internal code and the
+        # daemon's internal verb name for `owner_recover`, with NO remedy, on
+        # the one command whose entire job is recovery (design D5). Name the
+        # action the model took and give the remedy that measurably clears a
+        # wedged worker; the code and the budget stay in details, out of the
+        # sentence.
+        seconds = error.data.get("timeout_s")
+        budget = f" within {seconds:g}s" if isinstance(seconds, (int, float)) else ""
+        return (
+            f"the browser extension received {action or 'the command'} but did not answer"
+            f"{budget}. Retry once; if it repeats, the browser side is unhealthy rather "
+            "than slow — ask the user to toggle the Local Operator extension OFF then ON "
+            "in chrome://extensions (pairing is preserved)."
         )
     return f"browser bridge error ({error.code.value}): {error.message}"
 

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -49,6 +49,52 @@ from local_operator.paths import config_dir
 logger = logging.getLogger(__name__)
 DEFAULT_PORT = 4099
 PING_INTERVAL_S = 20.0
+#: How long the daemon tolerates TOTAL silence — no frame of any kind — from a
+#: TCP-connected extension before it declares the link unproven. Two missed
+#: pings plus one interval of slack: the ping loop is `await sleep(20)` then
+#: send, so tick spacing drifts with loop load, and the supervisor can add its
+#: first 1 s of backoff after a failure.
+#:
+#: A healthy worker pongs in microseconds from the socket's own onmessage
+#: handler (`worker.ts`, `frame.event === "ping"`) — NOT behind any of the
+#: extension's serialized queues — and emits nothing else while idle, so its
+#: longest legitimate silence is one ping interval. That is the bound that sets
+#: this number, and 50 s leaves 2.5x headroom against it.
+#:
+#: Cross-checked against the client's patience so the session always gets this
+#: typed error rather than an HTTP timeout: the tightest session budget is the
+#: base command timeout + ORIGIN_PROMPT_WINDOW_S + margin (90 s for `read`).
+LINK_SILENCE_TIMEOUT_S = 50.0
+#: How long the daemon keeps reporting a link it severed as *unresponsive*
+#: rather than absent, once the socket is gone.
+#:
+#: The teardown ANSWERS with the honest state and nulls the socket in the same
+#: breath, so without a latched reason the two facts a session most needs to
+#: tell apart — "the browser is open but mute" and "no browser is attached" —
+#: become byte-identical one command later, and the second one tells the
+#: operator to open a browser that is already open. That is the misdiagnosis
+#: this change exists to remove (design D2/R1-5, QA Q1). The latch is what lets
+#: the CLI, `/health`, the popup and the next RPC answer honestly for as long as
+#: the observation is still true.
+#:
+#: Sized to the slowest real recovery so it outlives the state it describes:
+#: after a signal-4000 close the worker re-dials on its ~1 s fast path, but a
+#: worker that suspends inside that window returns on the alarm floor —
+#: measured at 58.21 s on real hardware (§5.2). 60 s covers it. A genuinely
+#: wedged worker that never re-dials stays honest only for this window, then
+#: correctly reads as absent (by then nothing is attached, and it is not).
+LINK_DROP_TTL_S = 60.0
+#: Ceiling on one write to the extension socket. A loopback `send_json` of a
+#: small frame is sub-millisecond; seconds here means a peer that has stopped
+#: draining its TCP receive buffer, which is already fatal. Generous enough
+#: that a GC pause or a momentarily full buffer cannot trip it, and short
+#: enough to be invisible inside a 20-30 s command budget.
+#:
+#: This wraps `ExtensionLink.send` INCLUDING its lock acquisition, which is what
+#: makes a *stuck lock holder* bounded rather than merely a stuck `send_json`.
+#: Note `wait_for` cancels the waiter, not the holder — the teardown that
+#: follows is what deals with the holder.
+LINK_SEND_TIMEOUT_S = 5.0
 #: How often the daemon re-reads the pairing file to notice an out-of-process
 #: revoke. Short enough that "Unpair" feels immediate, cheap enough to poll.
 REVOKE_WATCH_S = 3.0
@@ -201,6 +247,85 @@ class ExtensionLink:
         # makes closing one tab clear exactly that tab.
         self.driven: dict[str, DrivenTab] = {}
         self.send_lock = asyncio.Lock()
+        # Monotonic timestamp of the last frame received from the extension —
+        # ANY frame, before any dispatch on its type, so an older extension's
+        # frames count too. Set when the socket is accepted (the peer has just
+        # spoken: it sent `hello`) and on every frame of the receive loop; reset
+        # by `disconnect`. This is the only thing that can tell a healthy idle
+        # extension from a mute one, and without it `status` advertised a wedged
+        # bridge as connected while every session hung.
+        self.last_frame_at = 0.0
+        # Why the daemon last severed an attached link, and the silence it had
+        # measured when it did. Read as a LATCHED fact that outlives the socket
+        # for LINK_DROP_TTL_S, because `disconnect()` (the same teardown used
+        # for an ordinary peer close) nulls the socket as part of ANSWERING
+        # with the unresponsive state. See LINK_DROP_TTL_S for the whole
+        # reasoning; `silent_drop_*` is set only by `_drop_unproven_link`, so a
+        # browser that was simply closed never reads as "attached but mute".
+        self.silent_drop_at = 0.0
+        self.silent_drop_silence_s = 0.0
+
+    @property
+    def proven(self) -> bool:
+        """Whether the connected socket has recently proven it is listening.
+
+        ``websocket is not None`` is true whenever TCP is up and the peer has
+        not closed, so a peer that completes `hello`, pairs, and then never
+        speaks again is indistinguishable from a healthy idle one. Never trust
+        the bare socket object: a silent link must fail sessions fast and be
+        dropped, not be advertised as connected.
+        """
+        if self.websocket is None or self.last_frame_at <= 0.0:
+            return False
+        return (time.monotonic() - self.last_frame_at) <= LINK_SILENCE_TIMEOUT_S
+
+    def silent_for(self) -> float:
+        """Seconds since the extension last said anything; 0.0 if it never has.
+
+        Read by the promotion rule in ``_dispatch_locked``: a command that
+        consumed its whole budget while the link was ALSO silent for 1.5 ping
+        intervals is corroborated as a dead peer rather than a slow page.
+        """
+        if self.last_frame_at <= 0.0:
+            return 0.0
+        return max(0.0, time.monotonic() - self.last_frame_at)
+
+    def note_unproven_drop(self, silence_s: float) -> None:
+        """Latch WHY the link was severed, for as long as that stays true."""
+        self.silent_drop_at = time.monotonic()
+        self.silent_drop_silence_s = silence_s
+
+    def clear_unproven_drop(self) -> None:
+        """Forget the latched reason: a link this daemon did not sever.
+
+        Called when the socket ends for any ordinary reason (the worker died,
+        the browser closed, the peer was evicted) and when a NEW socket becomes
+        authoritative, so the latch can never make a freshly connected bridge
+        look mute.
+        """
+        self.silent_drop_at = 0.0
+        self.silent_drop_silence_s = 0.0
+
+    def recent_drop_silence(self) -> float:
+        """The silence measured at the last unproven drop, while the latch is live.
+
+        0.0 when no such drop happened or the window has expired. It can also be
+        0.0 while the latch IS live (a `link.send` deadline can fire with the peer
+        still ponging), so "is it latched" is a separate question — see
+        `dropped_unproven`.
+        """
+        return self.silent_drop_silence_s if self.dropped_unproven() else 0.0
+
+    def dropped_unproven(self) -> bool:
+        """Whether "this daemon severed an attached link" is still the truth.
+
+        The discriminator that keeps "attached but not answering" from
+        outliving the state it describes: it expires after `LINK_DROP_TTL_S`,
+        and every path that ends the link for another reason clears it.
+        """
+        if self.silent_drop_at <= 0.0:
+            return False
+        return (time.monotonic() - self.silent_drop_at) <= LINK_DROP_TTL_S
 
     @property
     def current_url(self) -> str:
@@ -311,6 +436,7 @@ class ExtensionLink:
     def disconnect(self) -> None:
         self.websocket = None
         self.paired = False
+        self.last_frame_at = 0.0
         for future in self.pending.values():
             if not future.done():
                 future.set_exception(RuntimeError("extension disconnected"))
@@ -350,7 +476,12 @@ class BridgeService:
         self._tab_locks: dict[str, asyncio.Lock] = {}
 
     def publish(self) -> None:
-        self.state.extension_connected = self.link.websocket is not None
+        # `proven`, never `websocket is not None` (see ExtensionLink.proven).
+        # Every downstream consumer reads this ONE bit: state.liveness() turns
+        # it into ABSENT, which makes available()/advertisable() false, which is
+        # what stops sessions hanging on a mute peer and falls them back to cmux
+        # (or to a typed diagnostic) instead.
+        self.state.extension_connected = self.link.proven
         self.state.paired = self.link.paired
         self.state.extension_id = self.link.extension_id
         self.state.browser_name = self.link.browser
@@ -452,11 +583,64 @@ class BridgeService:
 
     async def _ping_tick(self) -> None:
         await asyncio.sleep(PING_INTERVAL_S)
-        if self.link.websocket is not None:
-            try:
-                await self.link.send({"event": "ping"})
-            except Exception:  # noqa: BLE001 - receive loop owns teardown
-                logger.debug("browser extension ping failed", exc_info=True)
+        if self.link.websocket is None:
+            return
+        if not self.link.proven:
+            # Total silence for two ping intervals: not a slow peer, a dead
+            # one. The check lives HERE because this loop already ticks every
+            # PING_INTERVAL_S whether or not a session is active, so an idle
+            # bridge still notices instead of waiting for the next command.
+            await self._drop_unproven_link(
+                f"no frame for {self.link.silent_for():.0f}s "
+                f"(deadline {LINK_SILENCE_TIMEOUT_S:.0f}s)"
+            )
+            return
+        try:
+            # Bounded for the same reason as every other send: a ping that
+            # parks silently disarms the very detector this design rests on.
+            await asyncio.wait_for(self.link.send({"event": "ping"}), timeout=LINK_SEND_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            await self._drop_unproven_link("ping send exceeded its deadline")
+        except Exception:  # noqa: BLE001 - receive loop owns teardown
+            logger.debug("browser extension ping failed", exc_info=True)
+
+    async def _drop_unproven_link(self, reason: str) -> None:
+        """Sever a link the daemon no longer trusts, and say why ONCE.
+
+        Deliberately the SAME teardown the ordinary disconnect path uses
+        (``link.disconnect()``), with a new trigger rather than a new mechanism:
+        every pending future is failed with ``extension disconnected`` (which
+        the dispatch site turns into a typed EXTENSION_DISCONNECTED response),
+        and ``awaiting_origin``/``driven`` are cleared — so every waiting
+        session gets a typed answer now instead of timing out.
+
+        Close code 4000 is the whole wire-compatibility story: an
+        already-installed worker handles 4000 explicitly, so it resets its
+        state and arms its ~1 s fast-path reconnect rather than reading the
+        close as a lost pairing. A code the old worker does not understand
+        would be treated as an ordinary close (which is why 4000, already
+        meaningful to every released build, is the right one).
+        """
+        websocket = self.link.websocket
+        logger.warning("browser bridge dropped an unresponsive extension: %s", reason)
+        # Latch WHY, and how long the peer had been quiet, BEFORE the teardown
+        # nulls the socket: this is the answer `_drop_unproven_link` is about to
+        # give, and without the latch it would be gone by the time anyone (the
+        # next RPC, `/health`, the CLI or the popup) could read it.
+        self.link.note_unproven_drop(self.link.silent_for())
+        # Clear the link BEFORE the close, not after. `disconnect()` is what
+        # fails every pending future, i.e. what turns three waiting sessions into
+        # three typed answers; `websocket.close()` is a SEND, so it can block on
+        # a peer that has stopped draining — the same hazard as any other
+        # unbounded write on this socket. Ordering the close first would make the
+        # teardown itself the next thing that can hang, which is the class of bug
+        # this whole change exists to remove. The close still goes out, and a
+        # peer that never sees it is already the disconnected path.
+        self.link.disconnect()
+        self.publish_safely()
+        if websocket is not None:
+            with suppress(Exception):
+                await websocket.close(code=4000)
 
     async def _heartbeat(self) -> None:
         await self._supervise("heartbeat", self._heartbeat_tick)
@@ -486,6 +670,9 @@ class BridgeService:
         """
         reset_pairing(self.root)
         self.link.paired = False
+        # An unpair is not a wedge: forget any latched unresponsive reason, or a
+        # deliberate revoke would keep reading as "attached but not answering".
+        self.link.clear_unproven_drop()
         websocket = self.link.websocket
         if websocket is not None:
             with suppress(Exception):
@@ -672,6 +859,14 @@ class BridgeService:
         self.link.websocket = websocket
         self.link.extension_id = extension_id
         self.link.browser = hello.browser
+        # A fresh authoritative socket supersedes any latched drop reason from
+        # the link it just replaced (including the "later connection wins"
+        # eviction above), so a reconnect cannot inherit a mute label.
+        self.link.clear_unproven_drop()
+        # The peer has just proven it is listening by sending `hello`; stamp it
+        # so `proven` is true from the first instant of the connection instead
+        # of waiting for the first pong.
+        self.link.last_frame_at = time.monotonic()
         self.link.paired = self._valid_saved_token(extension_id, hello.token)
         if not self.link.paired:
             self._ensure_pending(extension_id)
@@ -680,6 +875,11 @@ class BridgeService:
         try:
             while True:
                 frame = await websocket.receive_json()
+                # ANY frame, recorded BEFORE any dispatch on its type: this is
+                # the liveness signal `proven` reads, and taking it here (rather
+                # than inside each event branch) is what makes an older
+                # extension that only pongs count as alive.
+                self.link.last_frame_at = time.monotonic()
                 if frame.get("event") == "pair":
                     try:
                         pair = PairRequest.model_validate(frame)
@@ -758,6 +958,11 @@ class BridgeService:
             pass
         finally:
             if self.link.websocket is websocket:
+                # The peer ended this link itself (worker died, browser closed,
+                # tab torn down). That is NOT the unresponsive path — the daemon
+                # did not sever it — so drop any latched unresponsive reason and
+                # let the honest "not currently attached" state stand.
+                self.link.clear_unproven_drop()
                 self.link.disconnect()
                 self.publish_safely()
 
@@ -772,8 +977,40 @@ class BridgeService:
         if request.method == "ping":
             return JSONResponse({"id": request.id, "ok": True, "result": {"pong": True}})
         if self.link.websocket is None:
+            # A link THIS daemon severed for silence must not answer with
+            # EXTENSION_DISCONNECTED's "no browser is attached; ask the user to
+            # open their browser" for the LINK_DROP_TTL_S cooling-off window.
+            # The browser IS attached (and re-dialling); telling the operator to
+            # open it re-creates, one step later, exactly the misdirection this
+            # change exists to remove (design D1/D2). A peer that REALLY closed
+            # never latches the reason (`clear_unproven_drop` runs on every
+            # ordinary socket end), so it still gets the honest absent copy.
+            dropped_for = self.link.recent_drop_silence()
+            if self.link.dropped_unproven():
+                return self._error_response(
+                    request.id,
+                    ErrorCode.EXTENSION_UNRESPONSIVE,
+                    "the browser extension is attached but has not re-dialled since the "
+                    "bridge dropped its unresponsive link",
+                    {"phase": "dropped", "link_silent_s": dropped_for},
+                )
             return self._error_response(
                 request.id, ErrorCode.EXTENSION_DISCONNECTED, "extension not connected"
+            )
+        if not self.link.proven:
+            # A socket that is TCP-open but has said nothing for
+            # LINK_SILENCE_TIMEOUT_S. Refuse in milliseconds rather than let
+            # the command burn its whole budget on a peer nobody is home at,
+            # AND drop the link so the extension re-dials instead of staying
+            # wedged. This is the gate that turns "everything hangs" into
+            # "typed error immediately" even before a ping tick has noticed.
+            silent = self.link.silent_for()
+            await self._drop_unproven_link(f"command refused: link silent for {silent:.0f}s")
+            return self._error_response(
+                request.id,
+                ErrorCode.EXTENSION_UNRESPONSIVE,
+                "the browser extension stopped answering",
+                {"phase": "gate", "link_silent_s": silent},
             )
         # Re-validate against the on-disk record, not just the in-memory flag:
         # a separate-process ``pair --reset`` must fail in-flight and subsequent
@@ -859,12 +1096,71 @@ class BridgeService:
         future: asyncio.Future[Response] = asyncio.get_running_loop().create_future()
         self.link.pending[request.id] = future
         try:
-            await self.link.send(request.model_dump(mode="json"))
+            # Bounded INCLUDING the ``send_lock`` acquisition inside
+            # ``link.send``: a stuck lock holder used to hang the RPC past every
+            # deadline in COMMAND_TIMEOUTS while holding this tab's lock key,
+            # queueing every other command for the same key behind it.
+            await asyncio.wait_for(
+                self.link.send(request.model_dump(mode="json")), timeout=LINK_SEND_TIMEOUT_S
+            )
+        except asyncio.TimeoutError:
+            # Never left the daemon. Distinct from "delivered, no answer" and
+            # reported as such, so the diagnostic distinguishes "could not
+            # deliver" from "no reply".
+            #
+            # Drop OUR future before the teardown: the teardown fails every
+            # pending future with RuntimeError, and this one is never awaited
+            # (we return a typed error instead), so leaving it registered would
+            # produce an unretrieved-exception warning at collection time.
+            self.link.pending.pop(request.id, None)
+            silent = self.link.silent_for()
+            await self._drop_unproven_link(
+                f"send of {request.method} exceeded {LINK_SEND_TIMEOUT_S:.0f}s"
+            )
+            return self._error_response(
+                request.id,
+                ErrorCode.EXTENSION_UNRESPONSIVE,
+                f"{request.method} could not be delivered to the browser extension",
+                {"phase": "send", "link_silent_s": silent},
+            )
+        except Exception as exc:  # noqa: BLE001 - transport failure becomes typed wire error
+            self.link.pending.pop(request.id, None)
+            return self._error_response(request.id, ErrorCode.EXTENSION_DISCONNECTED, str(exc))
+        try:
             response = await self._await_response(
                 request.id, future, COMMAND_TIMEOUTS[request.method]
             )
             return JSONResponse(response.model_dump(mode="json", exclude_none=True))
         except asyncio.TimeoutError:
+            silent = self.link.silent_for()
+            # Promotion rule: a command that consumed its whole budget while the
+            # link was ALSO silent for 1.5 ping intervals is a dead peer, not a
+            # slow page. The slack is the record's own derivation for the
+            # sibling threshold — one tick can be dropped or delayed, tick
+            # spacing drifts with loop load, and `_supervise` inserts up to
+            # SUPERVISOR_BACKOFF_CAP_S of backoff after a failed tick, all of
+            # which make a HEALTHY peer's silence a sawtooth that can exceed a
+            # bare PING_INTERVAL_S (review R1-2 reproduced a healthy link torn
+            # down, close 4000, every session's pending futures failed). Zero
+            # slack here was strictly more aggressive than the 2.5× silence
+            # threshold it corroborates with, which is backwards.
+            #
+            # 1.5× covers a dropped tick plus the first backoff step (~21 s of
+            # spacing). Beyond that the DAEMON's own ping loop is the delayed
+            # party, and a genuine wedge has the rpc gate's 50 s detector and
+            # the full candidate length to trip on. A slow SITE still cannot
+            # trip this: the extension is ponging throughout, so silent_for()
+            # stays ~0.
+            if silent > PING_INTERVAL_S * 1.5:
+                await self._drop_unproven_link(
+                    f"{request.method} unanswered with the link silent for {silent:.0f}s"
+                )
+                return self._error_response(
+                    request.id,
+                    ErrorCode.EXTENSION_UNRESPONSIVE,
+                    f"{request.method} was delivered but the extension stopped answering",
+                    {"phase": "response", "link_silent_s": silent},
+                )
             code = (
                 ErrorCode.NAV_TIMEOUT if request.method in ("open", "goto") else ErrorCode.INTERNAL
             )
@@ -933,15 +1229,49 @@ class BridgeService:
         # current_url/pending_origin let the popup render the Connected site
         # (U3) and any in-flight approval (U2) without a separate RPC.
         pending = sorted(set(self.link.awaiting_origin.values()))
+        connected = self.link.proven
         return JSONResponse(
             {
                 "status": "ok",
                 "proto": PROTO_VERSION,
-                "extension_connected": self.link.websocket is not None,
+                # `proven`, never `websocket is not None` (see
+                # ExtensionLink.proven): a mute peer is NOT connected, and this
+                # one bit is what the popup, `lop browser status` and
+                # backend._health_ok all read.
+                "extension_connected": connected,
                 "paired": self.link.paired,
                 "browser": self.link.browser,
                 "current_url": self.link.current_url,
                 "current_title": self.link.current_title,
+                # Additive OPTIONAL fields (HTTP, not the WS protocol, so an old
+                # client that does not know them simply ignores them). They let
+                # the CLI AND the popup tell "no browser" from "browser present
+                # but mute" directly instead of inferring it from one boolean.
+                #
+                # `extension_unresponsive` covers BOTH halves of that state:
+                # a socket still attached and mute, and the LINK_DROP_TTL_S
+                # window after the daemon severed it for silence. Without the
+                # second half the honest line survives only until the teardown
+                # that ANSWERS with it, i.e. exactly one command — and the user
+                # who runs `lop browser status` afterwards, as the guide tells
+                # them to, reads "browser not currently attached" about a browser
+                # that is open (design D2/R1-5, QA Q1).
+                "extension_unresponsive": (self.link.websocket is not None and not connected)
+                or self.link.dropped_unproven(),
+                # Whether a link is attached RIGHT NOW, which is not the same as
+                # healthy (`extension_connected` owns that). It exists so the
+                # status line can word the same observation truthfully in both
+                # halves: the bridge WILL drop a mute-but-attached link, and HAS
+                # dropped one that is only latched (design D3).
+                "link_attached": self.link.websocket is not None,
+                # Live silence while a socket is up; otherwise the silence
+                # measured at the drop that latched the state, so the number
+                # does not collapse to 0 the instant the daemon acts on it.
+                "link_silent_s": (
+                    self.link.silent_for()
+                    if self.link.websocket is not None
+                    else self.link.recent_drop_silence()
+                ),
                 # How many tabs are driven, and their URLs. `current_url` alone
                 # framed a multi-tab world as one binding, so a stale value
                 # read as a system-wide lock; the count lets `status` say "no
@@ -973,7 +1303,7 @@ class BridgeService:
         """
         cleaned: list[str] = []
         before = dict(self.link.driven)
-        if self.link.websocket is not None and before:
+        if self.link.proven and before:
             # The extension's own live-surface listing is the ground truth;
             # anything we advertise that it does not list is a ghost. `tabs`
             # prunes dead surfaces extension-side as it lists, so this also
@@ -1009,8 +1339,11 @@ class BridgeService:
             except Exception:  # noqa: BLE001 - repair must never fail loudly
                 logger.warning("browser bridge repair could not list tabs", exc_info=True)
         elif before:
-            # No browser attached: nothing can be driven, so every record is a
-            # ghost by definition.
+            # No browser attached, OR one attached that has stopped answering:
+            # nothing can be driven either way, so every record is a ghost by
+            # definition. Reading `proven` here (not the bare socket) is what
+            # keeps repair's answer truthful about a mute peer instead of
+            # dispatching a `tabs` RPC that now fails fast and clearing nothing.
             cleaned = [tab.url for tab in before.values() if tab.url]
             self.link.driven.clear()
         republished = self.publish_safely()
@@ -1020,7 +1353,7 @@ class BridgeService:
                 "cleared_tabs": cleaned,
                 "driven_tabs": len(self.link.driven),
                 "heartbeat_republished": republished,
-                "extension_connected": self.link.websocket is not None,
+                "extension_connected": self.link.proven,
             }
         )
 

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -546,6 +546,12 @@ class BridgeService:
         # the daemon serializes them behind a per-tab lock so each command runs
         # to completion before the next starts. Concurrent sessions therefore
         # SHARE the tab safely rather than clobbering each other's navigation.
+        # In-flight callers per admission-only lock key (a per-OWNER key or
+        # `__global__`), so an eviction can distinguish "nobody holds it" from
+        # "nobody holds it yet, a queued caller is about to" — `asyncio.Lock`
+        # reports the former during the hand-off window that IS the latter. See
+        # `_release_key` (audit A4).
+        self._key_callers: dict[str, int] = {}
         self._tab_locks: dict[str, asyncio.Lock] = {}
 
     def publish(self) -> None:
@@ -558,6 +564,14 @@ class BridgeService:
         self.state.paired = self.link.paired
         self.state.extension_id = self.link.extension_id
         self.state.browser_name = self.link.browser
+        # The latched "attached but stopped answering" verdict, so the discovery
+        # file can tell a reader what /health would say. It matters because the
+        # demotion guard in `tools/builtin.py` decides from the FILE (a probe on
+        # the ABSENT side is forbidden by `bridge_browser_reachable`'s contract)
+        # and a drop writes `extension_connected=false` — without this the file
+        # is indistinguishable from a host with no bridge, which is how a paired
+        # running bridge got told to run `lop browser install` (design D3-2).
+        self.state.extension_unresponsive = self.link.dropped_unproven()
         state_store.publish(self.state, self.root)
 
     def publish_safely(self) -> bool:
@@ -727,6 +741,49 @@ class BridgeService:
             return False
         return True
 
+    def _wire_loss(self, expected: tuple[WebSocket | None, int]) -> str:
+        """Classify why the wire a command captured is no longer the live one.
+
+        Three answers, because the three need different remedies and the fence's
+        single refusal used to collapse them into one (review R3-4):
+
+        - ``"replaced"``: a handshake installed a NEW socket, which advances the
+          generation. The command died with its own connection, the replacement
+          is answering, so retrying is the whole remedy.
+        - ``"severed"``: THIS daemon severed the link for silence — the latch
+          `_drop_unproven_link` sets is live — and nothing has replaced it. The
+          browser is OPEN and the worker is mute, which is the wedge this PR
+          exists for, and "no browser is attached, ask the user to open it" is
+          then exactly the misdirection design D1 removed. The common
+          multi-session case (two commands timing out on ONE frozen worker)
+          lands here.
+        - ``"gone"``: the socket ended for any other reason — the peer closed it
+          or the pairing was revoked, both of which clear the latch. "No browser
+          is attached" is the honest answer there.
+
+        Compared on (socket, generation) together, the pair the fence itself
+        uses: only a replacement advances the generation, and only a replacement
+        puts a different live socket in place.
+        """
+        if self.link.generation != expected[1] or (
+            self.link.websocket is not None and self.link.websocket is not expected[0]
+        ):
+            return "replaced"
+        if self.link.websocket is None and self.link.dropped_unproven():
+            return "severed"
+        return "gone"
+
+    def _drop_silence(self, measured: float) -> float:
+        """The silence to report for a link this daemon severed.
+
+        The caller measured it on the live link moments earlier; a sibling's
+        drop also LATCHES the figure taken at its own drop, and that one is the
+        truth about why the link went away, so prefer it while the latch is
+        live (review R3-4's sibling case).
+        """
+        latched = self.link.recent_drop_silence()
+        return latched if self.link.dropped_unproven() and latched > 0.0 else measured
+
     async def _drop_unproven_link(
         self,
         reason: str,
@@ -832,11 +889,29 @@ class BridgeService:
         # deliberate revoke would keep reading as "attached but not answering".
         self.link.clear_unproven_drop()
         websocket = self.link.websocket
+        # The socket AND its generation, captured together before the close
+        # below yields: the guard after it asks whether this revoke is still
+        # looking at the live link, not merely whether some socket exists
+        # (audit A1, the revoke/replacement crossing).
+        generation = self.link.generation
         if websocket is not None:
             with suppress(Exception):
                 # 4003 = unpaired, the same code the handshake uses so the
                 # popup renders \"waiting to pair\" rather than a mystery drop.
                 await asyncio.wait_for(websocket.close(code=4003), timeout=LINK_CLOSE_TIMEOUT_S)
+            if not self.link.is_authoritative(websocket, generation):
+                # A handshake installed itself while that close was in flight.
+                # The revoke must NOT clear the link it did not close: doing so
+                # tore down the socket that replaced the revoked one and forgot
+                # its state, so the replacement's own re-dial was reported as
+                # gone.
+                #
+                # Preserving that connection is not the same as authorizing it.
+                # The new handshake computed its own `paired` from the pairing
+                # file `reset_pairing` had already removed, so it answers
+                # through the same `not_paired` gate as every other unpaired
+                # peer — nothing here revives a revoked token.
+                return
         self.link.disconnect()
         self.publish_safely()
 
@@ -1000,6 +1075,14 @@ class BridgeService:
         return PairResult(ok=True, token=token)
 
     async def extension(self, websocket: WebSocket) -> None:
+        # The four rejections below (and the ORIGIN one above) close WITHOUT a
+        # deadline, and that is correct rather than an oversight: every one of
+        # them returns BEFORE `attach()`, so no link state exists yet and no
+        # recovery is in flight — there is nothing for a stalled close to park.
+        # Every close AFTER the install IS bounded (`LINK_CLOSE_TIMEOUT_S`),
+        # because there the peer may be mid-teardown for a live link. That is the
+        # whole of the A2 rule; a close site added below this comment must
+        # re-check which side of `attach()` it sits on.
         extension_id = self._origin_extension_id(websocket)
         if not extension_id:
             await websocket.close(code=4004)
@@ -1038,9 +1121,17 @@ class BridgeService:
             # here would wipe the replacement this same block installs.
             self.link.forget_link_state()
         generation = self.link.attach(websocket)
-        if previous is not None:
-            with suppress(Exception):
-                await asyncio.wait_for(previous.close(code=4000), timeout=LINK_CLOSE_TIMEOUT_S)
+        # ── THE AUTHORITATIVE INSTALL IS ONE UNINTERRUPTED BLOCK ────────────
+        # Nothing between `attach` above and `publish_safely` below may await,
+        # and every write below is a SHARED-state write (identity, pairing,
+        # liveness, latch). The install used to sit after the superseded
+        # socket's bounded close, and `close` is an await: a third handshake
+        # could install itself in that window, after which the suspended one
+        # stamped THIS handshake's verdict — pairing included — onto the newer
+        # link. An unauthenticated peer whose token the daemon had just
+        # rejected was thereby authorized and drove RPCs (audit A1). Ordering
+        # is the whole guard here: a handshake that no longer owns the link has
+        # nothing left to write, because all of its writes already happened.
         self.link.extension_id = extension_id
         self.link.browser = hello.browser
         # A fresh authoritative socket supersedes any latched drop reason from
@@ -1055,6 +1146,22 @@ class BridgeService:
         if not self.link.paired:
             self._ensure_pending(extension_id)
         self.publish_safely()
+        # Only now, with this handshake fully installed, is the socket it
+        # replaced closed: a bounded courtesy to a peer that is already
+        # non-authoritative, whose outcome this handshake's authority must not
+        # depend on (audit A2).
+        if previous is not None:
+            with suppress(Exception):
+                await asyncio.wait_for(previous.close(code=4000), timeout=LINK_CLOSE_TIMEOUT_S)
+        if not self.link.is_authoritative(websocket, generation):
+            # A newer handshake installed itself while the superseded socket was
+            # being closed, so this one is now the superseded side. It must not
+            # speak: an ack on a wire that is no longer current tells a peer it
+            # is paired with a daemon that has already moved on — the ack half
+            # of the same window as the metadata install above (audit A1).
+            with suppress(Exception):
+                await asyncio.wait_for(websocket.close(code=4000), timeout=LINK_CLOSE_TIMEOUT_S)
+            return
         try:
             # Bounded and wire-scoped like every other send on this socket: the
             # handshake answer is the first thing a superseded write would
@@ -1373,23 +1480,28 @@ class BridgeService:
         # `request.id` — so holding the lock across the answer bought nothing and
         # cost every other owner its budget.
         future = self._register_pending(request)
-        wire = self._wire()
-        async with lock:
-            refused = await self._admit(request, future, wire)
-        # Evict a key that is neither shared nor currently held. Without this the
-        # map grows for the daemon's lifetime: a per-OWNER key is minted per
-        # session-resource, which is the same unbounded-growth defect round-3 M1
-        # fixed for the `__await__` keys. Known residual, benign and deliberate:
-        # a waiter that has not woken yet still holds the popped Lock object while
-        # a later request mints a fresh one, so two commands of ONE owner can be
-        # admitted concurrently — admission is a frame write, and the extension's
-        # per-proof lane re-serializes on arrival, so the worst case is "two
-        # frames admitted in an unspecified order".
-        if tab_key != "__global__" and not lock.locked():
-            self._tab_locks.pop(tab_key, None)
-        if refused is not None:
-            return refused
-        return await self._complete(request, future, wire)
+        # Counted BEFORE the lock so `_release_key` can tell "nobody holds it"
+        # from "nobody holds it yet, someone is queued" (see its docstring).
+        self._key_callers[tab_key] = self._key_callers.get(tab_key, 0) + 1
+        try:
+            wire = self._wire()
+            async with lock:
+                refused = await self._admit(request, future, wire)
+            if refused is not None:
+                return refused
+            return await self._complete(request, future, wire)
+        finally:
+            # CANCELLATION-SAFE CLEANUP for the registration → lock → send →
+            # response lifetime (audit A4). Registering the future BEFORE the
+            # lock is what this key shape needs — the answer may arrive while
+            # the caller is still queued — but it also means a caller cancelled
+            # while QUEUED (the ordinary client-disconnect case) never reaches
+            # `_complete`'s finally. Pre-fix it left a future in `link.pending`
+            # for a frame that was never sent and no response can ever answer,
+            # holding its request id until link teardown. The `finally` covers
+            # every exit: admitted, refused, timed out, cancelled.
+            self._forget_pending(request.id, future)
+            self._release_key(tab_key, lock)
 
     async def _dispatch_locked(self, request: Request) -> JSONResponse:
         """Dispatch one command with the caller's key held for its WHOLE life.
@@ -1407,10 +1519,17 @@ class BridgeService:
         # suspended across a reconnect can never sever (or answer on behalf of)
         # the healthy replacement that arrived in the meantime (audit A1).
         wire = self._wire()
-        refused = await self._admit(request, future, wire)
-        if refused is not None:
-            return refused
-        return await self._complete(request, future, wire)
+        try:
+            refused = await self._admit(request, future, wire)
+            if refused is not None:
+                return refused
+            return await self._complete(request, future, wire)
+        finally:
+            # The same cancellation-safe exit as the admission-only path: a
+            # caller that goes away while its frame is being written (or while
+            # the answer is awaited) must not leave its future registered for a
+            # response nobody is left to receive (audit A4).
+            self._forget_pending(request.id, future)
 
     def _wire(self) -> tuple[WebSocket | None, int]:
         """The current link as a fenceable pair (socket identity + generation)."""
@@ -1449,33 +1568,57 @@ class BridgeService:
             # Drop OUR future before the teardown: the teardown fails every
             # pending future with RuntimeError, and this one is never awaited
             # (we return a typed error instead), so leaving it registered would
-            # produce an unretrieved-exception warning at collection time.
-            self.link.pending.pop(request.id, None)
+            # produce an unretrieved-exception warning at collection time. By
+            # identity, not by id — `pending` is id-keyed and a teardown clears
+            # it, so an id-only pop can take a LATER request's future (audit A4).
+            self._forget_pending(request.id, future)
             silent = self.link.silent_for()
             dropped = await self._drop_unproven_link(
                 f"send of {request.method} exceeded {LINK_SEND_TIMEOUT_S:.0f}s",
                 expected=wire,
             )
-            if not dropped:
+            if not dropped and self._wire_loss(wire) == "replaced":
                 # The wire this command was being written to was superseded while
                 # the write was suspended, so the command was never delivered and
                 # there is no unresponsive peer to report — the replacement is
                 # answering. Say what actually happened (audit A1): the session's
                 # connection went away mid-send.
+                #
+                # `phase` is what makes that sayable to a reader: the client's
+                # table lookup returns one copy per CODE, and
+                # `extension_disconnected`'s copy is "no browser is attached, ask
+                # the user to open it" — false here, where the browser is open and
+                # the worker has just re-dialled. The two phase-carrying siblings
+                # below already route this way (design D3-3).
                 return self._error_response(
                     request.id,
                     ErrorCode.EXTENSION_DISCONNECTED,
                     f"{request.method} was not delivered: the extension replaced its "
                     "connection while the command was being written",
+                    {"phase": "replaced"},
                 )
+            # Either this caller severed the link, or a sibling already had: both
+            # mean the same wedged peer, so this is the unresponsive answer, not
+            # the replaced one (review R3-4).
             return self._error_response(
                 request.id,
                 ErrorCode.EXTENSION_UNRESPONSIVE,
                 f"{request.method} could not be delivered to the browser extension",
-                {"phase": "send", "link_silent_s": silent},
+                {"phase": "send", "link_silent_s": self._drop_silence(silent)},
             )
         except Exception as exc:  # noqa: BLE001 - transport failure becomes typed wire error
-            self.link.pending.pop(request.id, None)
+            # A future failed by a SIBLING's severance lands here — that
+            # teardown fails every pending future — and `extension_disconnected`
+            # renders "no browser is attached" for an open, wedged browser: the
+            # same misdirection the fence arm above answers, on the other path
+            # into it (review R3-4).
+            if self._wire_loss(wire) == "severed":
+                return self._error_response(
+                    request.id,
+                    ErrorCode.EXTENSION_UNRESPONSIVE,
+                    f"{request.method} could not be delivered to the browser extension",
+                    {"phase": "send", "link_silent_s": self._drop_silence(0.0)},
+                )
             return self._error_response(request.id, ErrorCode.EXTENSION_DISCONNECTED, str(exc))
         return None
 
@@ -1535,21 +1678,26 @@ class BridgeService:
                     f"{request.method} unanswered with the link silent for {silent:.0f}s",
                     expected=wire,
                 )
-                if not dropped:
+                if not dropped and self._wire_loss(wire) == "replaced":
                     # Same fence as the send deadline: nothing of ours is left to
                     # sever, so the honest answer is the one the failed future
-                    # already carries.
+                    # already carries. `phase` for the same reason as its sibling
+                    # in `_admit`: the code alone would render "no browser is
+                    # attached" (design D3-3).
                     return self._error_response(
                         request.id,
                         ErrorCode.EXTENSION_DISCONNECTED,
                         f"{request.method} was delivered on a connection the extension "
                         "has since replaced",
+                        {"phase": "replaced"},
                     )
+                # This caller severed the link, or a sibling already had — the
+                # same wedged peer either way (review R3-4).
                 return self._error_response(
                     request.id,
                     ErrorCode.EXTENSION_UNRESPONSIVE,
                     f"{request.method} was delivered but the extension stopped answering",
-                    {"phase": "response", "link_silent_s": silent},
+                    {"phase": "response", "link_silent_s": self._drop_silence(silent)},
                 )
             code = (
                 ErrorCode.NAV_TIMEOUT if request.method in ("open", "goto") else ErrorCode.INTERNAL
@@ -1561,10 +1709,74 @@ class BridgeService:
                 {"timeout_s": COMMAND_TIMEOUTS[request.method]},
             )
         except Exception as exc:  # noqa: BLE001 - transport failure becomes typed wire error
+            # Same sibling case as the send arm: a severed link makes this a
+            # wedged browser, not an absent one (review R3-4).
+            if self._wire_loss(wire) == "severed":
+                return self._error_response(
+                    request.id,
+                    ErrorCode.EXTENSION_UNRESPONSIVE,
+                    f"{request.method} was delivered but the extension stopped answering",
+                    {"phase": "response", "link_silent_s": self._drop_silence(0.0)},
+                )
             return self._error_response(request.id, ErrorCode.EXTENSION_DISCONNECTED, str(exc))
         finally:
-            self.link.pending.pop(request.id, None)
-            self.link.awaiting_origin.pop(request.id, None)
+            self._forget_pending(request.id, future)
+
+    def _forget_pending(self, request_id: str, future: asyncio.Future[Response]) -> None:
+        """Drop THIS request's pending record — by identity, never by id alone.
+
+        `link.pending` is keyed by request id, and a teardown (`forget_link_state`)
+        clears it, so a LATER request may re-use an id an earlier one had. A
+        cleanup that popped the id unconditionally would then strand that
+        unrelated caller's future: its answer would find no waiter and hang
+        until its own timeout (audit A4's identity requirement). The
+        awaiting-origin record goes with it, because both describe one
+        request's lifetime.
+        """
+        if self.link.pending.get(request_id) is future:
+            del self.link.pending[request_id]
+        self.link.awaiting_origin.pop(request_id, None)
+
+    def _release_key(self, tab_key: str, lock: asyncio.Lock) -> None:
+        """Drop one admission-only caller's hold on a key, evicting it if idle.
+
+        A per-OWNER key is minted per session-resource, so without eviction
+        `_tab_locks` grows for the daemon's lifetime — the same unbounded-growth
+        defect round-3 M1 fixed for the `__await__` keys, which is why the
+        eviction exists at all even though the lock held no navigation.
+
+        Eviction is safe only when ALL THREE hold: no caller is queued on the
+        key, nobody holds it, and the map still holds THIS Lock object (an
+        earlier caller may already have evicted it while a later request minted
+        a replacement).
+
+        Why the queued half needs its own counter: `asyncio.Lock.locked()` goes
+        False the instant `release()` hands the lock to the first waiter, so a
+        caller checking only `locked()` evicted a lock another request was
+        ALREADY waiting on. That waiter then ran under a Lock object the map no
+        longer contained, while the next request for the key minted a second
+        one and interleaved with it — mutual exclusion lost for one owner's
+        commands (audit A4). `_key_callers` counts every caller from the moment
+        it captures the key to the moment it releases, so "idle" here really
+        means idle.
+
+        Residual, benign and deliberate (unchanged from the scoping change): two
+        commands of ONE owner can still be admitted concurrently in the window
+        where the key was evicted between them — admission is a frame write, and
+        the extension's per-proof lane re-serializes on arrival, so the worst
+        case stays "two frames admitted in an unspecified order".
+        """
+        remaining = self._key_callers.get(tab_key, 0) - 1
+        if remaining > 0:
+            self._key_callers[tab_key] = remaining
+        else:
+            self._key_callers.pop(tab_key, None)
+        if (
+            not self._key_callers.get(tab_key)
+            and self._tab_locks.get(tab_key) is lock
+            and not lock.locked()
+        ):
+            self._tab_locks.pop(tab_key, None)
 
     async def _await_response(
         self, request_id: str, future: asyncio.Future[Response], base_timeout: float

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -95,6 +95,29 @@ LINK_DROP_TTL_S = 60.0
 #: Note `wait_for` cancels the waiter, not the holder — the teardown that
 #: follows is what deals with the holder.
 LINK_SEND_TIMEOUT_S = 5.0
+#: Ceiling on one `websocket.close()` during a TEARDOWN. A close is a send, so
+#: it carries the send's hazard: a peer that has stopped draining can leave it
+#: pending forever, and every teardown path here runs INSIDE the recovery the
+#: teardown exists to perform. Bounded with the send's own reasoning — a
+#: loopback close frame is sub-millisecond and seconds mean a dead peer — and
+#: kept separate from `LINK_SEND_TIMEOUT_S` only so the two call sites can be
+#: shortened independently in tests.
+LINK_CLOSE_TIMEOUT_S = LINK_SEND_TIMEOUT_S
+#: How long a direct liveness PROBE waits for the peer to say anything back.
+#:
+#: The promotion rule used to infer liveness from elapsed silence alone, which
+#: is why it needed a slack above one ping interval — the daemon is the only
+#: party that solicits speech, so daemon-side tick delay is indistinguishable
+#: from peer death (review R1-2). That slack (1.5 x 20 s = 30 s) then exceeded
+#: the 20 s budget of `read`/`snapshot`/`screenshot`, making the rule inert for
+#: exactly the methods the record added it for (review R2-3 / QA Q2-4). A probe
+#: asks the peer directly instead of inferring: a healthy worker answers a ping
+#: within one event-loop turn whatever it is doing (§2.2), and the daemon is
+#: demonstrably live at the moment it probes — it is running the timeout path.
+#: So a silence is no longer ambiguous by construction, and the window only has
+#: to cover a pathologically slow loop turn, which is the same generosity
+#: argument `LINK_SEND_TIMEOUT_S` already makes.
+PING_PROBE_TIMEOUT_S = 5.0
 #: How often the daemon re-reads the pairing file to notice an out-of-process
 #: revoke. Short enough that "Unpair" feels immediate, cheap enough to poll.
 REVOKE_WATCH_S = 3.0
@@ -223,6 +246,21 @@ class ExtensionLink:
 
     def __init__(self) -> None:
         self.websocket: WebSocket | None = None
+        # Monotonic id of the authoritative socket, bumped by every accept.
+        #
+        # Socket IDENTITY alone cannot fence a decision that spans an await: a
+        # caller captures `self.websocket`, awaits, and a replacement connection
+        # can arrive inside that window — at which point the captured socket is
+        # a closed object and the CURRENT one is a fresh healthy peer. Pairing
+        # the id with the object lets every check say "the link I decided about
+        # is still the link" in one expression, and keeps saying it when the
+        # socket has since been nulled (which identity-with-None cannot: a
+        # never-connected daemon and a dropped link would look alike).
+        self.generation = 0
+        # Set by the receive loop on EVERY frame, so an await can wait for the
+        # peer to speak instead of polling `last_frame_at`. Used only by the
+        # liveness probe (`_peer_answers_a_solicited_ping`).
+        self.frame_event = asyncio.Event()
         self.extension_id = ""
         self.browser = ""
         self.paired = False
@@ -426,8 +464,32 @@ class ExtensionLink:
         else:
             self.driven.clear()
 
-    async def send(self, payload: dict[str, Any]) -> None:
-        websocket = self.websocket
+    def attach(self, websocket: WebSocket) -> int:
+        """Make ``websocket`` the authoritative link and return its generation."""
+        self.generation += 1
+        self.websocket = websocket
+        return self.generation
+
+    def is_authoritative(self, websocket: WebSocket | None, generation: int) -> bool:
+        """Whether ``(websocket, generation)`` is still the live link.
+
+        The one predicate every deferred decision and every teardown re-checks
+        across its awaits (audit A1). Deliberately an identity check on the
+        socket OBJECT rather than a comparison of close codes or states: a
+        later connection replaces the object, so identity is the only thing
+        that cannot be spoofed by a peer that reconnects quickly.
+        """
+        return self.websocket is websocket and self.generation == generation
+
+    async def send(self, payload: dict[str, Any], *, wire: WebSocket | None = None) -> None:
+        """Write one frame to ``wire``, defaulting to the current link.
+
+        A caller that captured its socket before an await must PASS it here.
+        Defaulting to ``self.websocket`` at call time is how a command from a
+        superseded connection was delivered to its replacement — a request the
+        new peer never received, for a tab it does not own (audit A1).
+        """
+        websocket = wire if wire is not None else self.websocket
         if websocket is None:
             raise RuntimeError("extension disconnected")
         async with self.send_lock:
@@ -435,6 +497,17 @@ class ExtensionLink:
 
     def disconnect(self) -> None:
         self.websocket = None
+        self.forget_link_state()
+
+    def forget_link_state(self) -> None:
+        """Drop everything scoped to the CURRENT link, keeping the socket field.
+
+        A replacement connection needs exactly this and not `disconnect()`: the
+        superseded link's pending futures can never be answered by its
+        replacement, so they must fail NOW rather than at their own deadlines —
+        but nulling `websocket` here would then wipe the socket that is about to
+        be installed (audit A1).
+        """
         self.paired = False
         self.last_frame_at = 0.0
         for future in self.pending.values():
@@ -585,6 +658,12 @@ class BridgeService:
         await asyncio.sleep(PING_INTERVAL_S)
         if self.link.websocket is None:
             return
+        # Capture the wire this tick is ABOUT before its first await. The ping
+        # below can be suspended across a reconnect, and the teardown it then
+        # triggers must sever the socket it was pinging — never the healthy
+        # replacement that arrived in the meantime, which would fail every new
+        # session's futures for a socket that is answering perfectly (audit A1).
+        wire = (self.link.websocket, self.link.generation)
         if not self.link.proven:
             # Total silence for two ping intervals: not a slow peer, a dead
             # one. The check lives HERE because this loop already ticks every
@@ -592,20 +671,75 @@ class BridgeService:
             # bridge still notices instead of waiting for the next command.
             await self._drop_unproven_link(
                 f"no frame for {self.link.silent_for():.0f}s "
-                f"(deadline {LINK_SILENCE_TIMEOUT_S:.0f}s)"
+                f"(deadline {LINK_SILENCE_TIMEOUT_S:.0f}s)",
+                expected=wire,
             )
             return
         try:
             # Bounded for the same reason as every other send: a ping that
             # parks silently disarms the very detector this design rests on.
-            await asyncio.wait_for(self.link.send({"event": "ping"}), timeout=LINK_SEND_TIMEOUT_S)
+            await asyncio.wait_for(
+                self.link.send({"event": "ping"}, wire=wire[0]), timeout=LINK_SEND_TIMEOUT_S
+            )
         except asyncio.TimeoutError:
-            await self._drop_unproven_link("ping send exceeded its deadline")
+            await self._drop_unproven_link("ping send exceeded its deadline", expected=wire)
         except Exception:  # noqa: BLE001 - receive loop owns teardown
             logger.debug("browser extension ping failed", exc_info=True)
 
-    async def _drop_unproven_link(self, reason: str) -> None:
+    async def _peer_answers_a_solicited_ping(self) -> bool:
+        """Ask the peer directly whether it is still listening.
+
+        The promotion rule used to decide this from ELAPSED SILENCE alone, which
+        forced a threshold above the healthy sawtooth (1.5 x PING_INTERVAL_S) —
+        and that exceeded the 20 s budget of `read`/`snapshot`/`screenshot`, so
+        the rule could not fire for precisely the methods the record added it
+        for (review R2-3 / QA Q2-4). Lowering the number instead would re-open
+        review R1-2 (a delayed ping tick torn down as a dead peer), because the
+        DAEMON is the only party that solicits speech.
+
+        A probe removes the ambiguity rather than re-tuning it: the daemon is
+        demonstrably alive at the moment it asks (it is running the timeout
+        path), and a healthy worker answers a ping within one event-loop turn
+        no matter what a command is doing (record §2.2). An unanswered
+        solicitation is therefore direct evidence rather than an inference, and
+        ANY frame counts as the answer — the same "any frame" rule the silence
+        detector uses. It also fits inside every method's budget by
+        construction: it is bounded by PING_PROBE_TIMEOUT_S, not by a multiple
+        of PING_INTERVAL_S.
+
+        Deliberately bounded TWICE: the solicitation itself can hang, and the
+        answer can fail to come. Returns False when either does, which the
+        caller treats exactly as it treats the elapsed-silence corroboration.
+        """
+        websocket = self.link.websocket
+        if websocket is None:
+            return False
+        self.link.frame_event.clear()
+        try:
+            await asyncio.wait_for(
+                self.link.send({"event": "ping"}, wire=websocket), timeout=LINK_SEND_TIMEOUT_S
+            )
+        except Exception:  # noqa: BLE001 - an undeliverable solicitation is not an answer
+            return False
+        try:
+            await asyncio.wait_for(self.link.frame_event.wait(), PING_PROBE_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            return False
+        return True
+
+    async def _drop_unproven_link(
+        self,
+        reason: str,
+        *,
+        expected: tuple[WebSocket | None, int] | None = None,
+    ) -> bool:
         """Sever a link the daemon no longer trusts, and say why ONCE.
+
+        Returns whether the teardown was performed: False means the fence refused
+        it because the wire this decision was about is no longer authoritative.
+        Callers that answer the session must distinguish the two — "the extension
+        stopped answering" and "the connection this command was on was replaced"
+        are different facts, and the fence is exactly what tells them apart.
 
         Deliberately the SAME teardown the ordinary disconnect path uses
         (``link.disconnect()``), with a new trigger rather than a new mechanism:
@@ -620,8 +754,24 @@ class BridgeService:
         close as a lost pairing. A code the old worker does not understand
         would be treated as an ordinary close (which is why 4000, already
         meaningful to every released build, is the right one).
+
+        ``expected`` is the wire the CALLER decided about, captured before the
+        caller's own await. Teardown is fenced to it (audit A1): a decision that
+        spans an await can otherwise land after a replacement connection is
+        installed, at which point ``self.link.websocket`` is a fresh healthy peer
+        and this method would close it with 4000 and fail every new session's
+        futures. The close below also goes to the CAPTURED object, never to
+        whatever is current, so even a replacement arriving during the close
+        cannot be touched.
         """
-        websocket = self.link.websocket
+        current = (self.link.websocket, self.link.generation)
+        if expected is not None and current != expected:
+            # Nothing of OURS is left to sever: the socket this decision was
+            # about has been superseded (or already torn down). The latch is
+            # left alone, because the live replacement owns the link's state.
+            logger.debug("browser bridge skipped a stale teardown: %s", reason)
+            return False
+        websocket = current[0]
         logger.warning("browser bridge dropped an unresponsive extension: %s", reason)
         # Latch WHY, and how long the peer had been quiet, BEFORE the teardown
         # nulls the socket: this is the answer `_drop_unproven_link` is about to
@@ -639,8 +789,16 @@ class BridgeService:
         self.link.disconnect()
         self.publish_safely()
         if websocket is not None:
+            # BOUNDED, and scoped to the captured socket (audit A2). The caller
+            # is the RPC gate, the command-timeout path or the ping supervisor,
+            # so an unbounded close here parks the recovery that this teardown
+            # IS — a send-stalled peer would hang the initiating RPC and stall
+            # the liveness loop inside its own recovery. The state above is
+            # already cleared and every sibling future already failed, so the
+            # only thing this deadline bounds is the courtesy frame.
             with suppress(Exception):
-                await websocket.close(code=4000)
+                await asyncio.wait_for(websocket.close(code=4000), timeout=LINK_CLOSE_TIMEOUT_S)
+        return True
 
     async def _heartbeat(self) -> None:
         await self._supervise("heartbeat", self._heartbeat_tick)
@@ -678,17 +836,28 @@ class BridgeService:
             with suppress(Exception):
                 # 4003 = unpaired, the same code the handshake uses so the
                 # popup renders \"waiting to pair\" rather than a mystery drop.
-                await websocket.close(code=4003)
+                await asyncio.wait_for(websocket.close(code=4003), timeout=LINK_CLOSE_TIMEOUT_S)
         self.link.disconnect()
         self.publish_safely()
 
     async def _revocation_tick(self) -> None:
         await asyncio.sleep(REVOKE_WATCH_S)
-        if (
-            self.link.websocket is not None
-            and self.link.paired
-            and not self._live_pairing_matches()
-        ):
+        if not self.link.extension_id or self._live_pairing_matches():
+            return
+        # The pairing is gone ON DISK. Clear the latched drop reason HERE, before
+        # any socket test, because `revoke()` is unreachable once a drop has
+        # happened: `disconnect()` nulls the socket AND `paired`, so the guard
+        # below is false forever exactly while the latch is live (review R2-1,
+        # confirming QA Q2-1). Clearing it only in `revoke()` therefore left a
+        # deliberately unpaired bridge answering "attached and paired … pairing
+        # is preserved" for the rest of LINK_DROP_TTL_S — a claim about a pairing
+        # that no longer exists.
+        #
+        # The bound is one watch period: a revoke is reflected within
+        # REVOKE_WATCH_S of the file changing, the same order as the `/health`
+        # and RPC answers that read it.
+        self.link.clear_unproven_drop()
+        if self.link.websocket is not None and self.link.paired:
             logger.info("pairing revoked on disk; closing the live extension socket")
             await self.revoke()
 
@@ -852,11 +1021,26 @@ class BridgeService:
 
         # A later extension wins. This prevents two browser profiles from both
         # receiving commands while preserving reconnect after worker death.
-        if self.link.websocket is not None:
+        #
+        # The replacement is INSTALLED before the old socket is closed, so the
+        # supersession is atomic: from here every frame the old socket is still
+        # draining is ignored (the receive-loop fence below), and the close is a
+        # bounded courtesy to a peer that is no longer authoritative. Doing it
+        # the other way round left the old socket authoritative across the close
+        # await — precisely the window in which a superseded frame could stamp
+        # liveness or publish into the new connection's driven record (audit A1).
+        previous = self.link.websocket
+        if previous is not None:
+            # The superseded link's work is abandoned NOW: its futures can never
+            # be answered by the connection replacing it, so the waiters get the
+            # typed disconnect instead of burning their budgets. Its OWN socket
+            # is left in place for the bounded close below — clearing the field
+            # here would wipe the replacement this same block installs.
+            self.link.forget_link_state()
+        generation = self.link.attach(websocket)
+        if previous is not None:
             with suppress(Exception):
-                await self.link.websocket.close(code=4000)
-            self.link.disconnect()
-        self.link.websocket = websocket
+                await asyncio.wait_for(previous.close(code=4000), timeout=LINK_CLOSE_TIMEOUT_S)
         self.link.extension_id = extension_id
         self.link.browser = hello.browser
         # A fresh authoritative socket supersedes any latched drop reason from
@@ -871,22 +1055,55 @@ class BridgeService:
         if not self.link.paired:
             self._ensure_pending(extension_id)
         self.publish_safely()
-        await self.link.send(HelloAck(paired=self.link.paired).model_dump(mode="json"))
+        try:
+            # Bounded and wire-scoped like every other send on this socket: the
+            # handshake answer is the first thing a superseded write would
+            # misdeliver, and a peer that stopped draining must not park the
+            # accept path (audit A1/A2).
+            await asyncio.wait_for(
+                self.link.send(
+                    HelloAck(paired=self.link.paired).model_dump(mode="json"), wire=websocket
+                ),
+                timeout=LINK_SEND_TIMEOUT_S,
+            )
+        except Exception:  # noqa: BLE001 - an undeliverable handshake is a dead dial
+            with suppress(Exception):
+                await asyncio.wait_for(websocket.close(code=4000), timeout=LINK_CLOSE_TIMEOUT_S)
+            if self.link.websocket is websocket:
+                self.link.disconnect()
+                self.publish_safely()
+            return
         try:
             while True:
                 frame = await websocket.receive_json()
+                if not self.link.is_authoritative(websocket, generation):
+                    # A replacement connection is authoritative now and this
+                    # socket is a superseded one still draining buffered frames.
+                    # Its events must not stamp liveness, publish into the driven
+                    # record, drop an approval, or resolve a future — every one of
+                    # which is the LIVE link's state (audit A1, receive-side half).
+                    logger.debug("browser bridge stopped reading a superseded socket")
+                    break
                 # ANY frame, recorded BEFORE any dispatch on its type: this is
                 # the liveness signal `proven` reads, and taking it here (rather
                 # than inside each event branch) is what makes an older
-                # extension that only pongs count as alive.
+                # extension that only pongs count as alive. The probe waits on
+                # this event, so it is set on the same line as the stamp: a
+                # frame that counts as liveness but not as an answer would leave
+                # the probe blind to a peer that is plainly talking.
                 self.link.last_frame_at = time.monotonic()
+                self.link.frame_event.set()
                 if frame.get("event") == "pair":
                     try:
                         pair = PairRequest.model_validate(frame)
                     except ValidationError:
                         continue
                     result = await self._try_pair(pair)
-                    await self.link.send(result.model_dump(mode="json"))
+                    with suppress(Exception):
+                        await asyncio.wait_for(
+                            self.link.send(result.model_dump(mode="json"), wire=websocket),
+                            timeout=LINK_SEND_TIMEOUT_S,
+                        )
                     continue
                 if frame.get("event") == "awaiting_origin":
                     # The extension paused this request on a human origin
@@ -985,8 +1202,12 @@ class BridgeService:
             # change exists to remove (design D1/D2). A peer that REALLY closed
             # never latches the reason (`clear_unproven_drop` runs on every
             # ordinary socket end), so it still gets the honest absent copy.
-            dropped_for = self.link.recent_drop_silence()
+            # Read the latched silence only AFTER the guard that decides whether
+            # it means anything: the value is 0.0 both for "never dropped" and
+            # for "dropped at time zero", so trusting it before the check invites
+            # reading an ambiguous number as a fact (review R2-6).
             if self.link.dropped_unproven():
+                dropped_for = self.link.recent_drop_silence()
                 return self._error_response(
                     request.id,
                     ErrorCode.EXTENSION_UNRESPONSIVE,
@@ -1005,7 +1226,10 @@ class BridgeService:
             # wedged. This is the gate that turns "everything hangs" into
             # "typed error immediately" even before a ping tick has noticed.
             silent = self.link.silent_for()
-            await self._drop_unproven_link(f"command refused: link silent for {silent:.0f}s")
+            await self._drop_unproven_link(
+                f"command refused: link silent for {silent:.0f}s",
+                expected=(self.link.websocket, self.link.generation),
+            )
             return self._error_response(
                 request.id,
                 ErrorCode.EXTENSION_UNRESPONSIVE,
@@ -1056,12 +1280,61 @@ class BridgeService:
     @staticmethod
     def lock_key_for(request: Request) -> str:
         """The serialization key one RPC dispatches under (see the comment
-        above; a separate method so the lock topology is directly testable)."""
+        above; a separate method so the lock topology is directly testable).
+
+        Three shapes, and the difference between them is WHOSE budget a stuck
+        command may spend (audit A4, scoping answer D2):
+
+        - a per-REQUEST key for `await_access` (a human wait must queue behind
+          nothing);
+        - the short `__access__` key for `request_access`;
+        - a per-TAB key whenever the request names a tab — and here the lock
+          spans the WHOLE command on purpose, because that span is what stops
+          two commands interleaving into one tab's CDP session;
+        - otherwise a per-OWNER key (`__owner__:<proof>`) when the request
+          carries one, and `__global__` only for the proof-less remainder
+          (`tabs`, a handle-less `status`, legacy capability clients).
+
+        Why the owner key replaced `__global__` for owned no-tab commands: they
+        carry no `tab` (`resources.py` builds owner params without one), so one
+        owner's `open`/`owner_recover`/`owner_finish` used to serialize with
+        EVERY other owner's — across a full navigation (30 s) or an approval
+        wait (+65 s). A parked `open` therefore blocked a different owner's
+        `open`, and the `owner_recover` that exists to recover from exactly that
+        (audit A4). The cap race `__global__` was a PROXY guard for is not the
+        daemon's to enforce any more: `MAX_SURFACES` is a property of the
+        extension's surfaces map, and every mutation of it is a read-modify-write
+        inside that worker's `storeQueue`. The extension owns it; the extension
+        now guards it (`withAdmission`, `state.ts`). See the addendum's D2/D3.
+        """
         if request.method == "await_access":
             return f"__await__:{request.id}"
         if request.method == "request_access":
             return "__access__"
-        return str(request.params.get("tab") or "__global__")
+        tab = request.params.get("tab")
+        if tab:
+            return str(tab)
+        proof = request.params.get("owner_proof")
+        if isinstance(proof, str) and proof:
+            return f"__owner__:{proof}"
+        return "__global__"
+
+    @staticmethod
+    def _admission_only(tab_key: str) -> bool:
+        """Whether this key's lock may be released before the response.
+
+        True for exactly the two keys the scoping change is about — a per-OWNER
+        key and the proof-less `__global__` one — which exist to order the frame
+        onto the wire, not to hold a navigation or a human wait.
+
+        Everything else keeps the whole-command span: a per-TAB key IS the
+        CDP-interleave guard (and starves nobody, being per tab), `await_access`
+        has its own per-request key so its span cannot queue behind anything, and
+        `__access__` is the short shared key `request_access` has always used.
+        Derived from the KEY rather than re-reading the request, so the decision
+        cannot drift from `lock_key_for`.
+        """
+        return tab_key == "__global__" or tab_key.startswith("__owner__:")
 
     async def _dispatch_serialized(self, request: Request) -> JSONResponse:
         tab_key = self.lock_key_for(request)
@@ -1081,27 +1354,92 @@ class BridgeService:
                     return await self._dispatch_locked(request)
             finally:
                 self._tab_locks.pop(tab_key, None)
+        if not self._admission_only(tab_key):
+            async with lock:
+                response = await self._dispatch_locked(request)
+            # Per-tab keys used to be near-singleton; with every opened tab minting
+            # a token the map would now grow for the daemon's lifetime. Evict the
+            # key once its tab is closed and nothing is waiting on the lock —
+            # unlocked-and-unwaited means a later command for the same (now dead)
+            # handle can safely mint a fresh Lock.
+            if request.method == "close" and not lock.locked():
+                self._tab_locks.pop(tab_key, None)
+            return response
+        # ADMISSION ONLY (`_admission_only`'s docstring): register the pending
+        # future and get the frame onto the wire under the key, then release it
+        # BEFORE waiting for the answer. Nothing in the response phase reads
+        # shared daemon state under a key — `_await_response` resolves one future
+        # from `link.pending` and the timeout/teardown paths key off
+        # `request.id` — so holding the lock across the answer bought nothing and
+        # cost every other owner its budget.
+        future = self._register_pending(request)
+        wire = self._wire()
         async with lock:
-            response = await self._dispatch_locked(request)
-        # Per-tab keys used to be near-singleton; with every opened tab minting
-        # a token the map would now grow for the daemon's lifetime. Evict the
-        # key once its tab is closed and nothing is waiting on the lock —
-        # unlocked-and-unwaited means a later command for the same (now dead)
-        # handle can safely mint a fresh Lock.
-        if request.method == "close" and tab_key != "__global__" and not lock.locked():
+            refused = await self._admit(request, future, wire)
+        # Evict a key that is neither shared nor currently held. Without this the
+        # map grows for the daemon's lifetime: a per-OWNER key is minted per
+        # session-resource, which is the same unbounded-growth defect round-3 M1
+        # fixed for the `__await__` keys. Known residual, benign and deliberate:
+        # a waiter that has not woken yet still holds the popped Lock object while
+        # a later request mints a fresh one, so two commands of ONE owner can be
+        # admitted concurrently — admission is a frame write, and the extension's
+        # per-proof lane re-serializes on arrival, so the worst case is "two
+        # frames admitted in an unspecified order".
+        if tab_key != "__global__" and not lock.locked():
             self._tab_locks.pop(tab_key, None)
-        return response
+        if refused is not None:
+            return refused
+        return await self._complete(request, future, wire)
 
     async def _dispatch_locked(self, request: Request) -> JSONResponse:
+        """Dispatch one command with the caller's key held for its WHOLE life.
+
+        The per-TAB path: for those keys the lock span IS the guard that stops two
+        commands interleaving into one tab's CDP session, and it starves nobody
+        because it is per tab. Keys that may be released after admission go
+        through `_admit`/`_complete` directly from `_dispatch_serialized` — see
+        `_admission_only`.
+        """
+        future = self._register_pending(request)
+        # The wire THIS command is being sent on, captured before the first await
+        # on it. Every later decision about the link — the send deadline's
+        # teardown, the promotion rule — is fenced to it, so a command that was
+        # suspended across a reconnect can never sever (or answer on behalf of)
+        # the healthy replacement that arrived in the meantime (audit A1).
+        wire = self._wire()
+        refused = await self._admit(request, future, wire)
+        if refused is not None:
+            return refused
+        return await self._complete(request, future, wire)
+
+    def _wire(self) -> tuple[WebSocket | None, int]:
+        """The current link as a fenceable pair (socket identity + generation)."""
+        return (self.link.websocket, self.link.generation)
+
+    def _register_pending(self, request: Request) -> asyncio.Future[Response]:
+        """Register this command's future BEFORE its frame can be answered."""
         future: asyncio.Future[Response] = asyncio.get_running_loop().create_future()
         self.link.pending[request.id] = future
+        return future
+
+    async def _admit(
+        self, request: Request, future: asyncio.Future[Response], wire: tuple[WebSocket | None, int]
+    ) -> JSONResponse | None:
+        """Get one command onto the wire. None means it was delivered.
+
+        The ADMISSION phase, split out of `_dispatch_locked` so a caller can hold
+        its lock for exactly this much and release it before the answer (see
+        `_admission_only`). Nothing here waits on the peer — a bounded write and
+        nothing else — so every result it can return is final.
+        """
         try:
             # Bounded INCLUDING the ``send_lock`` acquisition inside
             # ``link.send``: a stuck lock holder used to hang the RPC past every
             # deadline in COMMAND_TIMEOUTS while holding this tab's lock key,
             # queueing every other command for the same key behind it.
             await asyncio.wait_for(
-                self.link.send(request.model_dump(mode="json")), timeout=LINK_SEND_TIMEOUT_S
+                self.link.send(request.model_dump(mode="json"), wire=wire[0]),
+                timeout=LINK_SEND_TIMEOUT_S,
             )
         except asyncio.TimeoutError:
             # Never left the daemon. Distinct from "delivered, no answer" and
@@ -1114,9 +1452,22 @@ class BridgeService:
             # produce an unretrieved-exception warning at collection time.
             self.link.pending.pop(request.id, None)
             silent = self.link.silent_for()
-            await self._drop_unproven_link(
-                f"send of {request.method} exceeded {LINK_SEND_TIMEOUT_S:.0f}s"
+            dropped = await self._drop_unproven_link(
+                f"send of {request.method} exceeded {LINK_SEND_TIMEOUT_S:.0f}s",
+                expected=wire,
             )
+            if not dropped:
+                # The wire this command was being written to was superseded while
+                # the write was suspended, so the command was never delivered and
+                # there is no unresponsive peer to report — the replacement is
+                # answering. Say what actually happened (audit A1): the session's
+                # connection went away mid-send.
+                return self._error_response(
+                    request.id,
+                    ErrorCode.EXTENSION_DISCONNECTED,
+                    f"{request.method} was not delivered: the extension replaced its "
+                    "connection while the command was being written",
+                )
             return self._error_response(
                 request.id,
                 ErrorCode.EXTENSION_UNRESPONSIVE,
@@ -1126,6 +1477,20 @@ class BridgeService:
         except Exception as exc:  # noqa: BLE001 - transport failure becomes typed wire error
             self.link.pending.pop(request.id, None)
             return self._error_response(request.id, ErrorCode.EXTENSION_DISCONNECTED, str(exc))
+        return None
+
+    async def _complete(
+        self, request: Request, future: asyncio.Future[Response], wire: tuple[WebSocket | None, int]
+    ) -> JSONResponse:
+        """Wait for one admitted command's answer and render it.
+
+        The RESPONSE phase, and deliberately key-independent: it resolves one
+        future out of ``link.pending`` and keys every teardown off ``request.id``
+        (plus A1's wire fence), so no caller needs to hold a lock across it. An
+        abandoned command — the daemon gave up, the extension answers later — is
+        covered by the ``pending`` eviction below (the id is gone, so a late frame
+        finds no future) together with that fence.
+        """
         try:
             response = await self._await_response(
                 request.id, future, COMMAND_TIMEOUTS[request.method]
@@ -1151,10 +1516,35 @@ class BridgeService:
             # the full candidate length to trip on. A slow SITE still cannot
             # trip this: the extension is ponging throughout, so silent_for()
             # stays ~0.
-            if silent > PING_INTERVAL_S * 1.5:
-                await self._drop_unproven_link(
-                    f"{request.method} unanswered with the link silent for {silent:.0f}s"
+            #
+            # …but elapsed silence ALONE cannot reach 30 s inside a 20 s budget,
+            # so on its own that rule was inert for exactly the methods the
+            # record added it for — `read`/`snapshot`/`screenshot` all time out
+            # at 20 s (review R2-3 / QA Q2-4 measured the change: the frozen
+            # worker returned `internal {timeout_s: 20.0}` where round 1 returned
+            # `extension_unresponsive`). The OR below is the fix for that, and it
+            # is deliberately NOT a lower threshold: a threshold below the
+            # healthy sawtooth is what review R1-2 reproduced, because the daemon
+            # is the only party that solicits speech. Asking the peer directly
+            # instead of inferring from a clock gives a definitive answer inside
+            # whatever budget the method has, so the rule fires for the tight
+            # methods without re-opening the false positive. The already-answered
+            # case short-circuits on the OR before probing.
+            if silent > PING_INTERVAL_S * 1.5 or not await self._peer_answers_a_solicited_ping():
+                dropped = await self._drop_unproven_link(
+                    f"{request.method} unanswered with the link silent for {silent:.0f}s",
+                    expected=wire,
                 )
+                if not dropped:
+                    # Same fence as the send deadline: nothing of ours is left to
+                    # sever, so the honest answer is the one the failed future
+                    # already carries.
+                    return self._error_response(
+                        request.id,
+                        ErrorCode.EXTENSION_DISCONNECTED,
+                        f"{request.method} was delivered on a connection the extension "
+                        "has since replaced",
+                    )
                 return self._error_response(
                     request.id,
                     ErrorCode.EXTENSION_UNRESPONSIVE,

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -1462,15 +1462,39 @@ class BridgeService:
             finally:
                 self._tab_locks.pop(tab_key, None)
         if not self._admission_only(tab_key):
-            async with lock:
-                response = await self._dispatch_locked(request)
-            # Per-tab keys used to be near-singleton; with every opened tab minting
-            # a token the map would now grow for the daemon's lifetime. Evict the
-            # key once its tab is closed and nothing is waiting on the lock —
-            # unlocked-and-unwaited means a later command for the same (now dead)
-            # handle can safely mint a fresh Lock.
-            if request.method == "close" and not lock.locked():
-                self._tab_locks.pop(tab_key, None)
+            # The per-TAB (and `__access__`) arm, counted the SAME way as the
+            # admission-only arm below: the count spans key-capture → release, so
+            # `_release_key` can tell "nobody holds it" from "nobody holds it
+            # yet, someone is queued".
+            #
+            # Why the count is required HERE and not merely tidy: per-tab keys
+            # used to be near-singleton, but with every opened tab minting a
+            # token the map would grow for the daemon's lifetime, so a `close`
+            # evicts the key once its tab is gone. The eviction used to test
+            # `lock.locked()` alone, which is False the instant `release()` hands
+            # the lock to its FIRST WAITER — so a `close` answering while another
+            # command was already queued on that tab dropped the key out from
+            # under the waiter. The waiter then ran under a Lock object the map no
+            # longer contained while the next request for the same tab minted a
+            # SECOND one and interleaved with it, losing the per-tab mutual
+            # exclusion that IS the reason this key shape holds its lock for the
+            # whole command (review R4-1, the same defect round 3 fixed for the
+            # admission-only arm and left behind here).
+            #
+            # The `finally` is what keeps a CANCELLED `close` from leaking its
+            # count: a leaked count pins the key forever, which is the unbounded
+            # growth the eviction exists to prevent. Only `close` releases the
+            # key; every other method returns the count to zero without evicting,
+            # because a per-tab key is deliberately retained between commands.
+            self._key_callers[tab_key] = self._key_callers.get(tab_key, 0) + 1
+            try:
+                async with lock:
+                    response = await self._dispatch_locked(request)
+            finally:
+                if request.method == "close":
+                    self._release_key(tab_key, lock)
+                else:
+                    self._uncount_key(tab_key)
             return response
         # ADMISSION ONLY (`_admission_only`'s docstring): register the pending
         # future and get the frame onto the wire under the key, then release it
@@ -1612,7 +1636,24 @@ class BridgeService:
             # renders "no browser is attached" for an open, wedged browser: the
             # same misdirection the fence arm above answers, on the other path
             # into it (review R3-4).
-            if self._wire_loss(wire) == "severed":
+            loss = self._wire_loss(wire)
+            if loss == "replaced":
+                # The same sibling case one step further out (review R4-3): a
+                # REPLACEMENT handshake fails every pending future too
+                # (`forget_link_state`), and it does so IMMEDIATELY rather than at
+                # a deadline — so on the path a worker re-dial actually takes,
+                # this arm, not the send-timeout fence above, is the one that
+                # answers. Without the test the code alone rendered "no browser is
+                # attached… ask the user to open their browser" for a browser that
+                # is open and already reconnected; `phase` is what routes it to the
+                # honest copy (design D3-3).
+                return self._error_response(
+                    request.id,
+                    ErrorCode.EXTENSION_DISCONNECTED,
+                    f"{request.method} was not delivered: the extension replaced its connection",
+                    {"phase": "replaced"},
+                )
+            if loss == "severed":
                 return self._error_response(
                     request.id,
                     ErrorCode.EXTENSION_UNRESPONSIVE,
@@ -1710,8 +1751,22 @@ class BridgeService:
             )
         except Exception as exc:  # noqa: BLE001 - transport failure becomes typed wire error
             # Same sibling case as the send arm: a severed link makes this a
-            # wedged browser, not an absent one (review R3-4).
-            if self._wire_loss(wire) == "severed":
+            # wedged browser, not an absent one (review R3-4) — and a REPLACED
+            # one makes it an open browser that needs no user action at all
+            # (review R4-3). The replacement arrives as a failed future, so this
+            # arm is the one a real re-dial reaches; the two timeout fences above
+            # cover only the narrower case where the replacement lands inside a
+            # timeout window.
+            loss = self._wire_loss(wire)
+            if loss == "replaced":
+                return self._error_response(
+                    request.id,
+                    ErrorCode.EXTENSION_DISCONNECTED,
+                    f"{request.method} was delivered on a connection the extension "
+                    "has since replaced",
+                    {"phase": "replaced"},
+                )
+            if loss == "severed":
                 return self._error_response(
                     request.id,
                     ErrorCode.EXTENSION_UNRESPONSIVE,
@@ -1729,21 +1784,57 @@ class BridgeService:
         clears it, so a LATER request may re-use an id an earlier one had. A
         cleanup that popped the id unconditionally would then strand that
         unrelated caller's future: its answer would find no waiter and hang
-        until its own timeout (audit A4's identity requirement). The
-        awaiting-origin record goes with it, because both describe one
-        request's lifetime.
+        until its own timeout (audit A4's identity requirement).
+
+        The awaiting-origin record is dropped only under the SAME identity proof,
+        because the two halves are removed for one reason and by one owner, and
+        the identity of the future is what proves the ownership. Popping the
+        marker by id alone re-opened the very window the future's guard exists
+        to close (review R4-2): `_drop_unproven_link` clears BOTH maps and then
+        parks up to `LINK_CLOSE_TIMEOUT_S` in its bounded `websocket.close()` on
+        a wedged peer, so a worker can genuinely re-dial, re-pair and file a NEW
+        request — passing the busy guard, because that guard reads the map the
+        teardown just emptied — while this older task is still unwinding. The
+        extension then announces a real human approval for that new request, and
+        an unguarded pop here deleted its marker, so the request lost its
+        deadline extension and failed at its BASE timeout while the user was
+        still looking at the prompt. Guarding only the future left exactly that
+        loss, with `NEW_FUTURE_PRESERVED: true, NEW_APPROVAL_MARKER_PRESERVED:
+        false` as the signature.
+
+        Correct on every path, because the only caller that may legitimately
+        clear another request's marker is the teardown itself, and it clears the
+        whole map. A request whose own future the teardown removed therefore
+        finds no identity match and touches nothing — which is what it must do,
+        since by then the marker belongs to whoever holds that id now.
         """
         if self.link.pending.get(request_id) is future:
             del self.link.pending[request_id]
-        self.link.awaiting_origin.pop(request_id, None)
+            self.link.awaiting_origin.pop(request_id, None)
+
+    def _uncount_key(self, tab_key: str) -> None:
+        """Return one caller's registration on a key, WITHOUT deciding eviction.
+
+        The counting half of `_release_key`, split out for the callers that must
+        bring the count back to zero but must NOT evict: a per-TAB key is
+        deliberately retained between commands (evicting it between them is what
+        let two sessions interleave into one tab's CDP session), so only a
+        `close` ever reaches the eviction decision below.
+        """
+        remaining = self._key_callers.get(tab_key, 0) - 1
+        if remaining > 0:
+            self._key_callers[tab_key] = remaining
+        else:
+            self._key_callers.pop(tab_key, None)
 
     def _release_key(self, tab_key: str, lock: asyncio.Lock) -> None:
-        """Drop one admission-only caller's hold on a key, evicting it if idle.
+        """Drop one caller's hold on a key, evicting it if the key is idle.
 
         A per-OWNER key is minted per session-resource, so without eviction
         `_tab_locks` grows for the daemon's lifetime — the same unbounded-growth
         defect round-3 M1 fixed for the `__await__` keys, which is why the
-        eviction exists at all even though the lock held no navigation.
+        eviction exists at all even though the lock held no navigation. The
+        per-TAB arm reaches here from `close` for the same reason.
 
         Eviction is safe only when ALL THREE hold: no caller is queued on the
         key, nobody holds it, and the map still holds THIS Lock object (an
@@ -1756,9 +1847,10 @@ class BridgeService:
         ALREADY waiting on. That waiter then ran under a Lock object the map no
         longer contained, while the next request for the key minted a second
         one and interleaved with it — mutual exclusion lost for one owner's
-        commands (audit A4). `_key_callers` counts every caller from the moment
-        it captures the key to the moment it releases, so "idle" here really
-        means idle.
+        commands (audit A4), and for one TAB's CDP session on the per-tab arm
+        (review R4-1). `_key_callers` counts every caller from the moment it
+        captures the key to the moment it releases, so "idle" here really means
+        idle.
 
         Residual, benign and deliberate (unchanged from the scoping change): two
         commands of ONE owner can still be admitted concurrently in the window
@@ -1766,11 +1858,7 @@ class BridgeService:
         the extension's per-proof lane re-serializes on arrival, so the worst
         case stays "two frames admitted in an unspecified order".
         """
-        remaining = self._key_callers.get(tab_key, 0) - 1
-        if remaining > 0:
-            self._key_callers[tab_key] = remaining
-        else:
-            self._key_callers.pop(tab_key, None)
+        self._uncount_key(tab_key)
         if (
             not self._key_callers.get(tab_key)
             and self._tab_locks.get(tab_key) is lock

--- a/local_operator/browser_bridge/protocol.py
+++ b/local_operator/browser_bridge/protocol.py
@@ -178,6 +178,21 @@ class ErrorCode(StrEnum):
     # extension predates ownership" — an already-released extension's wording
     # cannot be retrofitted, so the NEW side is what has to be unambiguous.
     OWNER_REFUSED = "owner_refused"
+    # The extension socket is TCP-open and paired but has stopped answering:
+    # either no frame of ANY kind for LINK_SILENCE_TIMEOUT_S, or a command that
+    # consumed its whole budget while the link was already silent. A code of its
+    # own rather than a reuse of EXTENSION_DISCONNECTED, whose client copy tells
+    # the user to open a browser that is in fact already open — reusing it would
+    # re-create, in a new place, exactly the misdiagnosis that made the reported
+    # incident expensive. Not BUSY either: BUSY means "retry this action once",
+    # and an immediate retry lands on the same poisoned chain.
+    #
+    # Daemon-to-session only: the extension leg never parses ErrorCode (it only
+    # emits one), and an old daemon simply never produces this value, so it
+    # needs no PROTO_VERSION bump. Adding a code the EXTENSION could emit would:
+    # an old daemon validates `ErrorDetail.code` against this enum, so a value
+    # it does not know fails Response.model_validate and the frame is dropped.
+    EXTENSION_UNRESPONSIVE = "extension_unresponsive"
     INTERNAL = "internal"
 
 

--- a/local_operator/browser_bridge/resources.py
+++ b/local_operator/browser_bridge/resources.py
@@ -241,10 +241,21 @@ class BrowserResource:
             #     a perfectly current extension from inside the incident.
             #
             # Only a genuinely old extension returns `internal` with NEITHER
-            # key (its HANDLERS fallthrough), so only that gets the message the
-            # reasoning above was written for. Keying on the absence of both
-            # discriminators is what keeps a future third producer from
-            # silently re-creating the misdiagnosis; a new `data` key belongs
+            # key — and even that is a guess rather than proof, which is why this
+            # branch is worth reading carefully before adding to it. `worker.ts`'s
+            # catch-all emits `internal` with an EMPTY `data` for any non-
+            # BridgeCommandError thrown inside a handler, and `deadline()`
+            # rethrows the underlying rejection verbatim, so a current extension
+            # can produce this exact shape too (review R2-4 reproduced one: a
+            # genuine `chrome.storage` rejection with the message "Access to
+            # storage is not allowed from this context."). The two are
+            # indistinguishable on the wire, so this branch is a best-effort
+            # mapping of the LEGACY case and the message it renders is the least
+            # wrong answer available, not a diagnosis.
+            #
+            # Keying on the absence of both discriminators is still right: it is
+            # what keeps a future third producer of `data`-carrying INTERNAL from
+            # silently re-creating the misdiagnosis, and a new `data` key belongs
             # in this predicate.
             if exc.code is ErrorCode.PROTO_MISMATCH or (
                 exc.code is ErrorCode.INTERNAL

--- a/local_operator/browser_bridge/resources.py
+++ b/local_operator/browser_bridge/resources.py
@@ -225,7 +225,32 @@ class BrowserResource:
             # not implement ownership at all. Keying on the typed code rather
             # than on the old side's wording is what stops a reworded message
             # from silently degrading this into a raw internal error.
-            if exc.code in (ErrorCode.INTERNAL, ErrorCode.PROTO_MISMATCH):
+            #
+            # The narrowing matters as much as the mapping: TWO kinds of
+            # data-carrying INTERNAL now reach this branch and NEITHER may be
+            # reported as a version mismatch, because both mean "the extension
+            # is wedged" — the one thing the old message told the operator not
+            # to look for.
+            #
+            #   * a DAEMON-side timeout, which carries `timeout_s`; and
+            #   * an EXTENSION-side per-call deadline, which carries `stalled`
+            #     (settle.ts's `deadline()`), i.e. exactly the wedged worker
+            #     this PR exists for — `owner_recover` reaches it through
+            #     `withOwnership` → `withSessionMutation` → `scopes()`, so the
+            #     recovery command would otherwise tell the operator to update
+            #     a perfectly current extension from inside the incident.
+            #
+            # Only a genuinely old extension returns `internal` with NEITHER
+            # key (its HANDLERS fallthrough), so only that gets the message the
+            # reasoning above was written for. Keying on the absence of both
+            # discriminators is what keeps a future third producer from
+            # silently re-creating the misdiagnosis; a new `data` key belongs
+            # in this predicate.
+            if exc.code is ErrorCode.PROTO_MISMATCH or (
+                exc.code is ErrorCode.INTERNAL
+                and "timeout_s" not in exc.data
+                and not exc.data.get("stalled")
+            ):
                 raise BrowserOwnershipError(
                     "Browser ownership recovery requires an updated Local Operator extension. "
                     "Update the extension, reconnect it, then retry; no new tab was allocated."

--- a/local_operator/browser_bridge/state.py
+++ b/local_operator/browser_bridge/state.py
@@ -36,6 +36,19 @@ class BridgeState(BaseModel):
     paired: bool = False
     extension_id: str = ""
     browser_name: str = ""
+    #: Whether the daemon has latched "the attached extension stopped answering"
+    #: and dropped its link for it (the same fact `/health` reports as
+    #: `extension_unresponsive`). Published because the reader that needs it most
+    #: cannot ask: `_execute_browser`'s demotion guard runs on the ABSENT side of
+    #: `liveness`, where the contract forbids a socket probe, and since a drop
+    #: writes `extension_connected=false` the file alone would otherwise look
+    #: exactly like a host with no bridge at all — which is how a paired, running
+    #: bridge got told to run `lop browser install` (design D3-2).
+    #:
+    #: Defaults false, so a file written by an older daemon (and every fixture)
+    #: reads as "no latch" — the conservative answer, since a false positive here
+    #: would claim a wedge the daemon never reported.
+    extension_unresponsive: bool = False
     heartbeat_at: float = Field(default_factory=time.time)
     started_at: float = Field(default_factory=time.time)
 

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1839,14 +1839,50 @@ def browser_command(args: argparse.Namespace) -> int:
         print(f"installed:           {'yes' if result['installed'] else 'no'}")
         print(f"daemon healthy:      {'yes' if result['healthy'] else 'no'}")
         connected = bool(health.get("extension_connected"))
+        unresponsive = bool(health.get("extension_unresponsive"))
         print(f"extension connected: {'yes' if connected else 'no'}")
         print(f"paired:              {'yes' if result['paired'] else 'no'}")
         # A paired-but-not-connected browser is the normal closed/backgrounded
         # state, not a fault; say so rather than leaving a user to guess (N2).
+        # `extension_unresponsive` is the OTHER way to be paired-but-not-
+        # connected — the browser is open and the extension socket is up, but
+        # the worker stopped answering — and telling that user "browser not
+        # currently attached, it reconnects when opened" is precisely the
+        # misdiagnosis that made the wedge expensive. The two lines are
+        # mutually exclusive on purpose: `extension_connected` is false in both
+        # cases, so only the discriminator separates them.
+        #
+        # The unresponsive branch has TWO truthful spellings, chosen by
+        # `link_attached`, because the daemon both observes the state and then
+        # acts on it: while a mute socket is still attached the drop is still
+        # ahead ("will drop and re-dial"); once it has been dropped, the link is
+        # gone and re-dialling is in progress. Printing the future tense after
+        # the drop would assert a severing that already happened, which is the
+        # false trail D3 caught, and printing the past tense before it asserts a
+        # drop nothing has performed yet. Both say the same thing the user needs:
+        # this is not "open your browser".
         if result["paired"] and not connected:
-            print(
-                "                     (browser not currently attached; it reconnects when opened)"
-            )
+            if unresponsive:
+                # Payloads WITHOUT `link_attached` are a daemon from an earlier
+                # head of this very change (the field is additive). There the
+                # tense is unknowable, so say only what is certainly true and
+                # assert no mechanism rather than guess one.
+                attached_now = health.get("link_attached")
+                if attached_now is True:
+                    note = (
+                        "browser attached but not answering; the bridge will drop and re-dial "
+                        "the link — retry once in a few seconds"
+                    )
+                elif attached_now is False:
+                    note = (
+                        "browser attached but not answering; the bridge dropped the link and "
+                        "is re-dialling it — retry once in a few seconds"
+                    )
+                else:
+                    note = "browser attached but not answering; retry once in a few seconds"
+            else:
+                note = "browser not currently attached; it reconnects when opened"
+            print(f"                     ({note})")
         # Driven tabs, PLURAL and counted. `driving: <url>` implied a single
         # system-wide binding; with one tab per session that framing turned a
         # stale URL into "something is holding the bridge". Say how many tabs

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -506,8 +506,11 @@ Every failure is one actionable string; act on it rather than retrying blindly:
   "(browser attached but not answering; the bridge dropped the link and is
   re-dialling it — retry once in a few seconds)" after the drop. A browser that
   is genuinely closed prints "(browser not currently attached; it reconnects
-  when opened)" instead — if THAT is what you see, the toggle step below is not
-  your remedy.
+  when opened)" instead — if THAT is what you see *inside the 60 s window the
+  latch covers*, the toggle step below is not your remedy. Past the window the
+  daemon genuinely cannot tell a closed browser from a wedged one — memory is
+  the only alternative to honesty, and `LINK_DROP_TTL_S` records the trade — so
+  read the 60 s window as the span that distinction is promised for.
 
   If it repeats, the worker is WEDGED rather than merely restarting, and the
   recovery is a reload — but use the one that works:

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -466,7 +466,10 @@ Every failure is one actionable string; act on it rather than retrying blindly:
      page in that browser:
      `open -g -a "Google Chrome" "https://example.com"` — or ask the user to
      click the extension's toolbar icon (opening the popup wakes the worker
-     instantly). Reconnection then happens within seconds.
+     instantly). Reconnection then happens within seconds. Note the limit of
+     that trick: it wakes a SUSPENDED worker, and does **not** unwedge a
+     WORKER THAT IS STILL RUNNING but no longer answering — for that case see
+     `extension_unresponsive` below, where the toolbar icon does nothing.
   3. **Still nothing?** The extension may be disabled or removed — ask the
      user to check `chrome://extensions`.
 - **"browser bridge not paired"** — run `lop browser pair` and have the user
@@ -485,6 +488,70 @@ Every failure is one actionable string; act on it rather than retrying blindly:
   — the daemon is fine; the command is likely stuck in the browser, e.g.
   waiting on a site-permission decision. Point the user at the extension
   popup rather than restarting anything (the error text says exactly this).
+- **"the browser extension is attached and paired but has stopped answering…"
+  (`extension_unresponsive`)** — the browser IS open and the extension's
+  socket IS up; the worker has simply stopped answering, so nothing can be
+  driven. The bridge drops the link (close code 4000) and the extension re-dials
+  on its own, usually in about a second (up to ~1 minute if the worker was
+  suspended), so **retry once after a few seconds** before doing anything else.
+  The daemon keeps answering `extension_unresponsive` — not
+  `extension_disconnected` — for 60 s after it drops the link
+  (`phase: "dropped"`), precisely so that retry cannot land on the "no browser
+  is attached" line, which would tell the user to open a browser that is open.
+
+  `lop browser status` tells the two states apart for that same 60 s window:
+  `extension connected: no` plus
+  "(browser attached but not answering; the bridge will drop and re-dial the
+  link — retry once in a few seconds)" while the socket is still attached, or
+  "(browser attached but not answering; the bridge dropped the link and is
+  re-dialling it — retry once in a few seconds)" after the drop. A browser that
+  is genuinely closed prints "(browser not currently attached; it reconnects
+  when opened)" instead — if THAT is what you see, the toggle step below is not
+  your remedy.
+
+  If it repeats, the worker is WEDGED rather than merely restarting, and the
+  recovery is a reload — but use the one that works:
+
+  1. **Ask the user to toggle the extension OFF then ON in
+     `chrome://extensions`.** This reloads the worker and
+     **preserves pairing** — verified on the operator's own machine against a
+     real wedge. Everything else the session owns is lost with the worker
+     (open tab handles, snapshot refs, pending site-permission decisions), so
+     re-`open` and re-`snapshot` afterwards. This is the same wording the error
+     text uses, and it is deliberate: Chrome shows Update and Remove next to it,
+     and neither of those is the measured cure.
+  2. **Clicking the extension's toolbar icon does NOT wake a wedged worker.**
+     No popup appears when the worker is unresponsive — the popup is served BY
+     that worker — so this is a dead end here even though it is the right first
+     move for an idle-suspended worker (see the "extension not connected"
+     checklist above). Measured on the operator's machine during the incident
+     that produced this section.
+  3. **Restarting the browser** also clears it (measured ~0.5 s to recover, and
+     pairing plus site grants survive), but it costs the user every tab.
+
+  A daemon restart does **not** help: the wedged state is in the extension
+  worker's own heap, not in the bridge.
+- **"the browser extension received `<method>` but did not answer within
+  `<N>`s"** (`internal`, `timeout_s`) — the DAEMON gave up on the extension
+  after the method's whole budget, which means the browser side never produced a
+  typed answer at all. The error text names the action, its budget and the same
+  toggle remedy: **retry once**, and if it repeats treat it as a wedged worker
+  and use the toggle step above. Do not restart the daemon — this is not a
+  bridge fault.
+- **"the browser extension stalled on `<call>` and gave up on this command"** —
+  one chrome/CDP call inside the extension exceeded its own deadline and was
+  abandoned, which is by design: it is what lets the NEXT command run instead
+  of queueing behind a stuck one. **Retry the command.** If it repeats on the
+  same call, the browser side is unhealthy rather than merely slow — ask the
+  user to toggle the extension OFF then ON in `chrome://extensions` (pairing is
+  preserved). The named call (`chrome.debugger.sendCommand(…)`,
+  `chrome.storage.local.get(…)`, `chrome.tabs.get(…)`) says which layer gave
+  up, which is the useful part when reporting it.
+- **"that tab cannot be driven: it is another extension's page"** —
+  Chrome refuses to attach the debugger to a page belonging to a DIFFERENT
+  extension, and that refusal is permanent for that tab. The bridge has already
+  dropped the handle; `open` the URL again to get a new tab. Do not retry
+  against the old handle.
 - **"tab is gone" / "tab crashed"** — the user closed or crashed it; `open` the
   URL again to get a fresh surface.
 - **"another debugger is attached"** — ask the user to close DevTools on that

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -8187,6 +8187,46 @@ def _bridge_liveness() -> tuple[Any, Any]:
         return None, None
 
 
+def _bridge_absent_result(tool_call_id: str, current: Any) -> ToolResult:
+    """The demotion diagnostic for a bridge that is UP with no browser attached.
+
+    Reached only when the discovery file shows a daemon whose pid is alive and
+    which remembers an extension from a real handshake (`extension_id`), i.e. the
+    bridge IS installed and was paired — the opposite of the state the generic
+    "set up the bridge" copy describes. Two shapes, because they need different
+    actions from the reader:
+
+    - the daemon has LATCHED a silent link (the incident's window). The worker is
+      mute and only a reload of the extension clears it, so this renders the same
+      copy `format_error` gives for the wire code, with the same typed
+      `error_code`, and the agent can branch on it.
+    - otherwise the browser is simply not attached right now (closed, or the
+      worker idle-suspended and is re-dialling). "install" and "open your
+      browser" are both wrong there; "check the state, then retry" is right, and
+      `lop browser status` is where the difference is visible.
+
+    A separate function rather than inline so both copies are reachable from a
+    unit test without standing up cmux, a daemon or a socket.
+    """
+    from local_operator.browser_bridge.backend import ERROR_MESSAGES
+    from local_operator.browser_bridge.protocol import ErrorCode
+
+    if bool(getattr(current, "extension_unresponsive", False)):
+        problem = _error(tool_call_id, "browser", ERROR_MESSAGES[ErrorCode.EXTENSION_UNRESPONSIVE])
+        problem.details = {"error_code": ErrorCode.EXTENSION_UNRESPONSIVE.value}
+        return problem
+    problem = _error(
+        tool_call_id,
+        "browser",
+        f"browser extension not attached: the bridge daemon (pid {current.pid}) is running and "
+        "remembers this browser, but nothing is connected to it right now. The extension "
+        "reconnects on its own when the browser is open — run 'lop browser status' to see the "
+        "current state, then retry this action.",
+    )
+    problem.details = {"error_code": ErrorCode.EXTENSION_DISCONNECTED.value}
+    return problem
+
+
 def _bridge_demotion_hint(classified: tuple[Any, Any] | None = None) -> str:
     """Why the extension is not being used, when it looked like it should be.
 
@@ -9379,6 +9419,19 @@ async def _execute_browser(
     # cmux. It costs a round-trip only in the stale-but-alive case.
     bridge_available = await bridge_browser_reachable(classified=bridge_liveness)
     if not cmux_available and not bridge_available:
+        # A bridge daemon that is UP but has no browser attached is not an
+        # unconfigured host: "run 'lop browser status' and 'lop browser install'
+        # to set up the bridge" sends a user with an installed, paired bridge to
+        # repair something that is not broken, which is what a session already
+        # recovered into the wedge window was told (design D3-2).
+        #
+        # The file separates the two without a socket: `liveness` answers ABSENT
+        # for both, but only the daemon case carries the extension id it
+        # remembers from a real handshake — and, while a drop for silence is
+        # still latched, the daemon publishes that latch too (see `state.py`).
+        current = bridge_liveness[1] if bridge_liveness is not None else None
+        if current is not None and current.extension_id:
+            return _bridge_absent_result(tool_call_id, current)
         return _error(
             tool_call_id,
             "browser",

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -8537,6 +8537,32 @@ def _browser_identity_params(context: ToolContext | None, tool_call_id: str) -> 
     return identity
 
 
+def _bridge_failure_result(tool_call_id: str, exc: BaseException, *, action: str) -> ToolResult:
+    """Render one bridge failure so every site answers with the same voice.
+
+    `str(exc)` on a `BridgeError` is the RAW daemon message. For a recovery
+    timeout that is literally `owner_recover timed out`: an internal verb, no
+    remedy, and no typed code for the agent to branch on — while the identical
+    wedge in a session that had already recovered got `format_error`'s full copy
+    ("…ask the user to toggle the Local Operator extension OFF then ON in
+    chrome://extensions (pairing is preserved)"). The recovery command is the
+    one that must never be the useless one (design D5/D2-1, review R2-2).
+
+    `BridgeUnreachable` and `BrowserOwnershipError` already carry complete
+    human sentences written for exactly this audience, so they keep `str(exc)`;
+    only the typed wire error is re-rendered.
+    """
+    from local_operator.browser_bridge.backend import BridgeError, format_error
+
+    if isinstance(exc, BridgeError):
+        problem = _error(tool_call_id, "browser", format_error(exc, action=action))
+        # The same typed code `_bridge_call` carries, so callers can branch on
+        # `extension_unresponsive` rather than substring-matching prose.
+        problem.details = {"error_code": exc.code.value}
+        return problem
+    return _error(tool_call_id, "browser", str(exc))
+
+
 async def _bridge_call(
     tool_call_id: str,
     action: str,
@@ -9217,7 +9243,14 @@ async def execute_browser(
                 await resource.recover()
                 state.surface_id = str(resource.record.get("surface_id", ""))
         except (BrowserOwnershipError, BridgeError, BridgeUnreachable) as exc:
-            return _error(tool_call_id, "browser", str(exc))
+            # A HUMAN phrase for the recovery, never the wire verb. `str(exc)`
+            # here used to render a recovery timeout as the bare daemon message
+            # `owner_recover timed out` — an internal verb name, no remedy, and
+            # no typed code — while the SAME wedge in an already-recovered
+            # session got `format_error`'s full, actionable copy. Two qualities
+            # of answer for one fault, on the command whose whole job is
+            # recovery (design D2-1, mechanism added by review R2-2).
+            return _bridge_failure_result(tool_call_id, exc, action="the browser tab recovery")
         action = str(args.get("action", "")).strip().lower()
         try:
             if action == "recover":
@@ -9267,7 +9300,16 @@ async def execute_browser(
             # Same containment the initialize/recover block above already has:
             # an expected ownership or bridge refusal is a sentence, never a
             # stack trace spent in the model's context.
-            return _error(tool_call_id, "browser", str(exc))
+            #
+            # `format_error` for the bridge errors, with the tool's own action
+            # name — except for `recover`, which is phrased the same way as the
+            # preamble above so the two render sites cannot drift into naming
+            # the wire verb (design D2-1).
+            return _bridge_failure_result(
+                tool_call_id,
+                exc,
+                action="the browser tab recovery" if action == "recover" else action,
+            )
         if resource.record.get("terminal"):
             return _error(tool_call_id, "browser", "Browser scope ended; resume before browsing.")
         if action == "open" and not state.surface_id:

--- a/tests/unit/browser_bridge/test_backend.py
+++ b/tests/unit/browser_bridge/test_backend.py
@@ -209,3 +209,36 @@ def test_origin_not_allowed_error_teaches_the_access_flow() -> None:
     # The agent is the PRIMARY notification channel: Chrome's banner is
     # best-effort on macOS, so the instruction to notify must be explicit.
     assert "NOTIFY THE USER" in text
+
+
+def test_a_replaced_wire_is_not_reported_as_an_absent_browser() -> None:
+    """Design D3-3: the CODE is ambiguous here, the daemon's `phase` is not.
+
+    Both A1 fence answers (send deadline, lost answer) report
+    `extension_disconnected`, whose copy tells the reader no browser is attached
+    and to ask the user to open one — false when the extension has just
+    re-dialled, and it resolves in about a second, so the copy names an action
+    that does not apply. The sibling answers carry `phase: send|response` and
+    render the honest unresponsive copy; these two must route by their own
+    phase, and the same code WITHOUT it keeps the absent-browser copy.
+    """
+    replaced = BridgeError(
+        ErrorCode.EXTENSION_DISCONNECTED,
+        "read was not delivered: the extension replaced its connection while the "
+        "command was being written",
+        {"phase": "replaced"},
+    )
+
+    text = format_error(replaced, action="read")
+
+    assert "replaced its connection" in text
+    assert "retry the action" in text
+    assert "no user action is needed" in text
+    assert "no browser is attached" not in text
+    assert "open their browser" not in text
+    assert "lop browser install" not in text
+
+    # The control: the same code and message without the phase is still the
+    # absent-browser answer, which is what a genuinely closed browser gets.
+    plain = BridgeError(ErrorCode.EXTENSION_DISCONNECTED, "extension not connected")
+    assert "no browser is attached" in format_error(plain)

--- a/tests/unit/browser_bridge/test_bridge_wedge.py
+++ b/tests/unit/browser_bridge/test_bridge_wedge.py
@@ -1,0 +1,848 @@
+"""Daemon-side guards for the browser-bridge wedge (design record §8.1).
+
+The incident these pin: an extension worker whose module-global serialized
+chains parked every later command forever, while `/health` and `lop browser
+status` kept answering "extension connected: yes" and `owner_recover` — the one
+command whose job is recovery — reported a version mismatch for a timeout.
+
+The tests are deliberately STRUCTURAL (a request that never reaches the wire, a
+future that is answered, a lock that is free, a close code that was sent) rather
+than timing assertions: see AGENTS.md, "Timing, flakes, and how to assert that
+something is fast". Where a row cannot fail on the pre-fix tree the docstring
+says so instead of implying a guard that does not exist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from starlette.testclient import TestClient
+
+from local_operator.browser_bridge import daemon as daemon_module
+from local_operator.browser_bridge import resources
+from local_operator.browser_bridge.backend import BridgeError, format_error
+from local_operator.browser_bridge.daemon import (
+    LINK_SILENCE_TIMEOUT_S,
+    BridgeService,
+    create_app,
+)
+from local_operator.browser_bridge.protocol import (
+    PROTO_VERSION,
+    ErrorCode,
+    ErrorDetail,
+    Request,
+    Response,
+)
+
+EXTENSION_ID = "a" * 32
+ORIGIN = f"chrome-extension://{EXTENSION_ID}"
+
+
+class _RecordingSocket:
+    """Stand-in for the extension leg's websocket: records close codes."""
+
+    def __init__(self) -> None:
+        self.closed: list[int | None] = []
+
+    async def close(self, code: int | None = None, reason: str | None = None) -> None:
+        self.closed.append(code)
+
+
+def _connected(service: BridgeService, *, silent_for: float = 0.0) -> _RecordingSocket:
+    """Give ``service`` an extension socket that spoke ``silent_for`` seconds ago."""
+    socket = _RecordingSocket()
+    service.link.websocket = socket  # type: ignore[assignment]
+    service.link.last_frame_at = time.monotonic() - silent_for
+    return socket
+
+
+def _health_payload(tmp_path: Path) -> dict[str, Any]:
+    app = create_app(root=tmp_path)
+    with TestClient(app) as client:
+        return client.get("/health").json()
+
+
+# --- D1 -------------------------------------------------------------------
+
+
+def test_mute_extension_is_not_advertised_as_connected(tmp_path: Path) -> None:
+    """A socket that has said nothing for LINK_SILENCE_TIMEOUT_S is not
+    "connected".
+
+    Pre-fix `/health` derived `extension_connected` from
+    `link.websocket is not None`, which is true whenever TCP is up and the peer
+    has not closed — measured on the real incident at 42/42 samples "connected,
+    paired" across an 84 s window in which every command hung.
+    """
+    app = create_app(root=tmp_path)
+    with TestClient(app) as client:
+        service = app.state.bridge
+        with client.websocket_connect("/extension", headers={"origin": ORIGIN}) as socket:
+            socket.send_json(
+                {
+                    "event": "hello",
+                    "proto": PROTO_VERSION,
+                    "token": "",
+                    "extension_version": "0.1.0",
+                    "browser": "Chrome/153",
+                }
+            )
+            socket.receive_json()
+            assert client.get("/health").json()["extension_connected"] is True
+            service.link.last_frame_at = time.monotonic() - (LINK_SILENCE_TIMEOUT_S + 1.0)
+            health = client.get("/health").json()
+            assert health["extension_connected"] is False
+            assert health["extension_unresponsive"] is True
+            assert health["link_silent_s"] > LINK_SILENCE_TIMEOUT_S
+
+
+# --- D2 -------------------------------------------------------------------
+
+
+def test_command_against_a_silent_link_fails_fast_with_a_typed_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A command against a known-mute link is refused BEFORE dispatch.
+
+    The structural half is `sent == []`: the request never reaches the
+    extension, so "it failed fast" is a fact about where the code returned
+    rather than a measurement of how long it took.
+    """
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "read", 0.05)
+    app = create_app(root=tmp_path)
+    with TestClient(app) as client:
+        service = app.state.bridge
+        with client.websocket_connect("/extension", headers={"origin": ORIGIN}) as socket:
+            socket.send_json(
+                {
+                    "event": "hello",
+                    "proto": PROTO_VERSION,
+                    "token": "",
+                    "extension_version": "0.1.0",
+                    "browser": "Chrome/153",
+                }
+            )
+            socket.receive_json()
+            sent: list[dict[str, Any]] = []
+
+            async def record(payload: dict[str, Any]) -> None:
+                sent.append(payload)
+
+            service.link.send = record  # type: ignore[method-assign]
+            service.link.last_frame_at = time.monotonic() - (LINK_SILENCE_TIMEOUT_S + 1.0)
+            response = client.post(
+                "/rpc",
+                headers={"X-Bridge-Key": app.state.bridge.state.session_key},
+                json={"id": "r-mute", "method": "read", "params": {"tab": "bridge:1:n"}},
+            )
+            body = response.json()
+            assert body["ok"] is False
+            assert body["error"]["code"] == ErrorCode.EXTENSION_UNRESPONSIVE.value
+            assert sent == [], "the request reached the extension"
+            assert "r-mute" not in service.link.pending
+
+
+# --- D3 -------------------------------------------------------------------
+
+
+def test_silence_detector_does_not_fire_on_a_pinging_idle_extension(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both directions in ONE test, so a detector that never fires cannot pass.
+
+    Negative half: a peer that keeps answering the daemon's pings is never torn
+    down, even though it sends nothing else. Positive half: stop answering and
+    the detector fires. `LINK_SILENCE_TIMEOUT_S` is shrunk so the positive half
+    does not cost a real 50 s.
+    """
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 0.05)
+    monkeypatch.setattr(daemon_module, "LINK_SILENCE_TIMEOUT_S", 0.25)
+    app = create_app(root=tmp_path)
+    with TestClient(app) as client:
+        service = app.state.bridge
+        with client.websocket_connect("/extension", headers={"origin": ORIGIN}) as socket:
+            socket.send_json(
+                {
+                    "event": "hello",
+                    "proto": PROTO_VERSION,
+                    "token": "",
+                    "extension_version": "0.1.0",
+                    "browser": "Chrome/153",
+                }
+            )
+            socket.receive_json()
+            first_socket = service.link.websocket
+            # Negative: pong for several silence-windows' worth of ping ticks.
+            for _ in range(4):
+                socket.send_json({"event": "pong"})
+                time.sleep(0.1)
+            assert service.link.proven is True
+            assert service.link.websocket is first_socket, "a pinging peer was torn down"
+
+            # Positive: go silent. The supervised ping loop tears the link down.
+            deadline = time.monotonic() + 5.0
+            while service.link.websocket is not None and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert service.link.websocket is None, "a silent peer was never dropped"
+
+
+# --- D4 -------------------------------------------------------------------
+
+
+def test_awaiting_origin_wait_is_not_torn_down_by_the_detector(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The false-positive guard the design's riskiest claim rests on.
+
+    A command blocked on a HUMAN for longer than the silence deadline must not
+    lose its link: the extension keeps ponging while the popup waits, so
+    `silent_for()` stays near zero. Rejected design alternative — tying the
+    threshold to COMMAND_TIMEOUTS — would have to be ~95 s here, which is why
+    the detector keys on frames rather than on command duration.
+
+    CHARACTERISATION, not a pre-fix guard: the pre-fix tree has no detector at
+    all, so this passes there. Its proof-of-failure is to disable the frame
+    timestamp (the `last_frame_at` write in the receive loop) on the FIXED tree
+    and watch it tear the link down mid-prompt.
+    """
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 0.05)
+    monkeypatch.setattr(daemon_module, "LINK_SILENCE_TIMEOUT_S", 0.2)
+    app = create_app(root=tmp_path)
+    with TestClient(app) as client:
+        service = app.state.bridge
+        with client.websocket_connect("/extension", headers={"origin": ORIGIN}) as socket:
+            socket.send_json(
+                {
+                    "event": "hello",
+                    "proto": PROTO_VERSION,
+                    "token": "",
+                    "extension_version": "0.1.0",
+                    "browser": "Chrome/153",
+                }
+            )
+            socket.receive_json()
+            socket.send_json(
+                {"event": "awaiting_origin", "id": "r-prompt", "origin": "https://slow.example"}
+            )
+            first_socket = service.link.websocket
+            # Keep ponging for several times the silence deadline: the command is
+            # "waiting on a human" for far longer than the detector's window. The
+            # cadence must be comfortably INSIDE the deadline (0.04 s against
+            # 0.2 s) or the test measures its own scheduling jitter rather than
+            # the detector — a pong that lands late tears the link down and the
+            # failure reads as a false positive in the code under test.
+            for _ in range(15):
+                socket.send_json({"event": "pong"})
+                time.sleep(0.04)
+            assert service.link.websocket is first_socket
+            assert service.link.awaiting_origin == {"r-prompt": "https://slow.example"}
+
+
+# --- D5 / D6 --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_command_timeout_against_a_silent_link_is_promoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Promotion rule: a dead command PLUS a silent link corroborates a dead
+    peer, and the session hears `extension_unresponsive` rather than a generic
+    `internal` it would read as a page-level problem.
+
+    Pre-fix the timeout branch always returned NAV_TIMEOUT/INTERNAL.
+    """
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "read", 0.05)
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 0.01)
+    service = BridgeService(root=tmp_path)
+    # Silent for 1 s: proven (well inside LINK_SILENCE_TIMEOUT_S, so the rpc gate
+    # lets the command through) but already past one ping interval.
+    _connected(service, silent_for=1.0)
+
+    async def silent(payload: dict[str, Any]) -> None:
+        # Delivered and accepted — the send RETURNS, it does not park — and then
+        # no response ever arrives. Parking here instead would exercise the send
+        # deadline (D7), not the promotion rule.
+        return None
+
+    service.link.send = silent  # type: ignore[method-assign]
+    response = await service._dispatch_serialized(
+        Request(id="r-dead", method="read", params={"tab": "bridge:1:n"})
+    )
+    body = bytes(response.body).decode()
+    assert ErrorCode.EXTENSION_UNRESPONSIVE.value in body
+    assert '"phase":"response"' in body.replace(" ", "")
+
+
+@pytest.mark.asyncio
+async def test_command_timeout_against_a_live_link_is_still_nav_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The "verify it still refuses where it should" half: proves D5 narrowed
+    the timeout branch rather than replacing it.
+
+    A slow page is slow INSIDE the extension, which is ponging normally, so the
+    promotion rule must not fire and `open` must still report nav_timeout with
+    the budget it exhausted. Fails if the promotion is unconditional.
+    """
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "open", 0.05)
+    service = BridgeService(root=tmp_path)
+    socket = _connected(service, silent_for=0.0)
+
+    async def ponging(payload: dict[str, Any]) -> None:
+        # The extension received the command and is working on it. Its pongs
+        # keep arriving for the whole budget — that is what a slow page looks
+        # like on the wire. The send RETURNS; only the answer is missing.
+        service.link.last_frame_at = time.monotonic()
+        return None
+
+    service.link.send = ponging  # type: ignore[method-assign]
+    response = await service._dispatch_serialized(
+        Request(id="r-slow", method="open", params={"url": "https://slow.example"})
+    )
+    body = bytes(response.body).decode().replace(" ", "")
+    assert ErrorCode.NAV_TIMEOUT.value in body
+    assert '"timeout_s":0.05' in body
+    assert ErrorCode.EXTENSION_UNRESPONSIVE.value not in body
+    assert service.link.websocket is socket, "a healthy-but-slow link was torn down"
+
+
+# --- D7 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blocked_send_does_not_outlive_its_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An un-writable socket must not hold the per-tab lock past its deadline.
+
+    Pre-fix `_dispatch_locked` awaited `link.send()` unbounded while holding the
+    lock key taken by `_dispatch_serialized`, so a stuck send (a peer that
+    stopped draining its TCP receive buffer, or a stuck `send_lock` holder)
+    queued every other command for that key behind it forever.
+
+    The record phrased the structural half as "`service._tab_locks` is empty
+    afterwards"; the per-TAB key is deliberately RETAINED until `close`
+    (evicting it between commands would let two sessions interleave on one tab),
+    so the invariant asserted here is the one that actually matters: the lock is
+    FREE and the NEXT command on that key answers.
+    """
+    monkeypatch.setattr(daemon_module, "LINK_SEND_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 0.01)
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "read", 0.05)
+    service = BridgeService(root=tmp_path)
+    _connected(service, silent_for=0.0)
+
+    async def blocked(payload: dict[str, Any]) -> None:
+        await asyncio.sleep(3600)
+
+    service.link.send = blocked  # type: ignore[method-assign]
+    request = Request(id="r-send", method="read", params={"tab": "bridge:7:abc"})
+    # BOUNDED, and that bound is part of the guard rather than test hygiene: the
+    # stub under test parks for an hour, so a regression that drops the send
+    # deadline presents as a HUNG test (RC=124 under `timeout`, and under
+    # `-n auto --dist worksteal` a killed worker carrying unrelated tests, the
+    # failure mode tests/e2e/watchdog.py exists to avoid) instead of a red one
+    # (review R1-6, reproduced). 2 s is well above LINK_SEND_TIMEOUT_S (0.05)
+    # and the command budget, so a correct implementation can never reach it,
+    # while a regression fails in seconds with the defect named.
+    try:
+        response = await asyncio.wait_for(service._dispatch_serialized(request), timeout=2.0)
+    except asyncio.TimeoutError:  # pragma: no cover - only on a regression
+        raise AssertionError(
+            "a blocked link.send() outlived its deadline: the per-tab lock is held forever"
+        ) from None
+    body = bytes(response.body).decode().replace(" ", "")
+    assert ErrorCode.EXTENSION_UNRESPONSIVE.value in body
+    assert '"phase":"send"' in body
+    assert not service._tab_locks["bridge:7:abc"].locked()
+    # Latched even though the peer's silence was ~0 when the send deadline
+    # fired: "we severed an attached link" is a fact of its own, not a
+    # function of how long the peer had been quiet.
+    assert service.link.dropped_unproven() is True
+
+    # The next command on the same key is served, not queued behind a corpse.
+    async def answer(payload: dict[str, Any]) -> None:
+        request_model = Request.model_validate(payload)
+        future = service.link.pending.get(request_model.id)
+        if future and not future.done():
+            future.set_result(Response(id=request_model.id, ok=True, result={"text": "ok"}))
+
+    _connected(service, silent_for=0.0)
+    service.link.send = answer  # type: ignore[method-assign]
+    try:
+        second = await asyncio.wait_for(
+            service._dispatch_serialized(
+                Request(id="r-next", method="read", params={"tab": "bridge:7:abc"})
+            ),
+            timeout=2.0,
+        )
+    except asyncio.TimeoutError:  # pragma: no cover - only on a regression
+        raise AssertionError("the lock outlived its holder: the next command never ran") from None
+    assert '"ok":true' in bytes(second.body).decode().replace(" ", "")
+
+
+# --- D8 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_closes_with_4000_and_clears_pending(
+    tmp_path: Path,
+) -> None:
+    """The teardown's whole wire-compatibility story is the close code.
+
+    `worker.ts` handles 4000 explicitly (suppress the connState write, reset
+    state, schedule the ~1 s fast-path reconnect), so an ALREADY-INSTALLED
+    extension recovers from a daemon-initiated drop without a protocol bump. A
+    code it did not know would be treated as an ordinary close; a code the peer
+    must INTERPRET (the rejected 4005 "recycle") is not a free change.
+    """
+    service = BridgeService(root=tmp_path)
+    socket = _connected(service, silent_for=LINK_SILENCE_TIMEOUT_S + 1.0)
+    loop = asyncio.get_running_loop()
+    pending: asyncio.Future[Response] = loop.create_future()
+    service.link.pending["r-pending"] = pending
+    service.link.awaiting_origin["r-pending"] = "https://x.example"
+    service.link.note_driven("bridge:1:n", "https://x.example", "X")
+
+    await service._drop_unproven_link("test")
+
+    assert socket.closed == [4000]
+    assert pending.done() and isinstance(pending.exception(), RuntimeError)
+    assert service.link.pending == {}
+    assert service.link.awaiting_origin == {}
+    assert service.link.driven == {}
+    assert service.link.websocket is None
+    assert service.link.proven is False
+
+
+# --- D9 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recover_timeout_is_not_reported_as_a_version_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """P3, in BOTH directions.
+
+    The daemon attaches `timeout_s` to its own timeout errors and to nothing
+    else, so that key is the discriminator between "the extension does not
+    implement ownership" (still true of a genuinely old build, whose HANDLERS
+    fallthrough returns `internal` with no data) and "the extension did not
+    answer in time" — the one that was true. Pre-fix `resources.py` mapped both
+    to "requires an updated Local Operator extension", which is a wrong
+    diagnosis that costs real time: the reporting session was told to replace a
+    current extension while a wedged worker went unmentioned.
+    """
+
+    class _FailingBridge:
+        def __init__(self, error: BridgeError) -> None:
+            self.error = error
+
+        async def call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            raise self.error
+
+    resource = resources.BrowserResource(tmp_path, tmp_path.name)
+    resource.initialize()
+
+    timeout_error = BridgeError(ErrorCode.INTERNAL, "owner_recover timed out", {"timeout_s": 20.0})
+    monkeypatch.setattr(resources, "BridgeClient", lambda: _FailingBridge(timeout_error))
+    with pytest.raises(BridgeError) as raised:
+        await resource.recover()
+    assert "updated Local Operator extension" not in str(raised.value)
+    assert raised.value.data["timeout_s"] == 20.0
+
+    legacy_error = BridgeError(ErrorCode.INTERNAL, "unknown method owner_recover")
+    monkeypatch.setattr(resources, "BridgeClient", lambda: _FailingBridge(legacy_error))
+    with pytest.raises(resources.BrowserOwnershipError) as legacy:
+        await resource.recover()
+    assert "requires an updated Local Operator extension" in str(legacy.value)
+
+
+# --- D10 ------------------------------------------------------------------
+
+
+def test_unresponsive_code_round_trips_and_has_client_copy() -> None:
+    """The new code must survive the wire model AND the generated TS.
+
+    `gen_ts --check` is the guard that stops Python-only protocol drift: the
+    checked-in `protocol.gen.ts` is what the extension compiles against.
+    """
+    from local_operator.browser_bridge import gen_ts
+
+    assert gen_ts.main(["--check"]) == 0, "protocol.gen.ts is stale"
+    frame = Response(
+        id="r-1",
+        ok=False,
+        error=ErrorDetail(code=ErrorCode.EXTENSION_UNRESPONSIVE, message="mute", data={}),
+    )
+    assert Response.model_validate_json(frame.model_dump_json()) == frame
+    # The client copy is the dedicated one, not the generic fallback: it names
+    # retry and the manual escape hatch. Reusing EXTENSION_DISCONNECTED's copy
+    # would tell the user to open a browser that is already open.
+    rendered = format_error(BridgeError(ErrorCode.EXTENSION_UNRESPONSIVE, "mute"), action="read")
+    assert "stopped answering" in rendered
+    assert "chrome://extensions" in rendered
+    assert "no browser is attached" not in rendered
+
+
+# --- D11 ------------------------------------------------------------------
+
+
+def test_status_output_distinguishes_absent_from_unresponsive(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`lop browser status` must not say "not currently attached" about a
+    browser that IS attached.
+
+    Both states share `extension_connected: false`, so only the new
+    `extension_unresponsive` discriminator separates them — and the two lines
+    are mutually exclusive, which is what makes a wrong branch visible instead
+    of merely incomplete.
+    """
+    from local_operator import cli
+    from local_operator.browser_bridge import install
+
+    def _run(health_extra: dict[str, Any]) -> str:
+        monkeypatch.setattr(
+            install,
+            "status",
+            lambda: {
+                "installed": True,
+                "healthy": True,
+                "paired": True,
+                "port": 4099,
+                "log": "/tmp/synthetic-bridge.log",
+                # Hermetic: `stale_heartbeat_age()` would read the discovery file
+                # at the DEFAULT root, i.e. the operator's real run dir.
+                "health": {
+                    "extension_connected": False,
+                    "driven_tabs": [],
+                    **health_extra,
+                },
+            },
+        )
+        monkeypatch.setattr(install, "stale_heartbeat_age", lambda: None)
+        assert cli.browser_command(_namespace("status")) == 0
+        return capsys.readouterr().out
+
+    unresponsive = _run(
+        {"extension_unresponsive": True, "link_attached": True, "link_silent_s": 51.0}
+    )
+    assert "attached but not answering" in unresponsive
+    assert "will drop and re-dial" in unresponsive, "still attached: the drop is ahead, not done"
+    assert "not currently attached" not in unresponsive
+
+    # The SAME state one teardown later. This is the case the guide sends the
+    # user to `status` for, and it used to print the absent line (design D2 /
+    # review R1-5 / QA Q1).
+    dropped = _run({"extension_unresponsive": True, "link_attached": False, "link_silent_s": 51.0})
+    assert "attached but not answering" in dropped
+    assert "dropped the link" in dropped
+    assert "will drop" not in dropped, "the past tense must not promise a severing that happened"
+    assert "not currently attached" not in dropped
+
+    # A daemon from an earlier head of this change reports the state but not the
+    # side of the drop (`link_attached` is additive). Then the tense is
+    # unknowable, so no mechanism may be asserted in either direction.
+    undecidable = _run({"extension_unresponsive": True, "link_silent_s": 51.0})
+    assert "attached but not answering" in undecidable
+    assert "will drop" not in undecidable and "dropped the link" not in undecidable
+    assert "not currently attached" not in undecidable
+    assert "retry once in a few seconds" in undecidable
+
+    absent = _run({})
+    assert "not currently attached" in absent
+    assert "attached but not answering" not in absent
+
+
+def _namespace(command: str) -> Any:
+    import argparse
+
+    return argparse.Namespace(browser_command=command, repair=False)
+
+
+# --- Round 1 remediation guards -------------------------------------------
+#
+# Every test below pins a defect that the round-1 review reproduced against the
+# previous head. They are structural (a discriminator that is present, a link
+# that is still the same object, a latch that survives a teardown) rather than
+# timing assertions, per AGENTS.md.
+
+
+class _HttpRequest:
+    """The minimum ``rpc()`` reads off a Starlette request: a key and a body.
+
+    Built by hand so a test can exercise the HTTP gate's own branches without a
+    live port; the headers dict and ``json()`` are exactly the two surfaces
+    ``rpc()`` touches before dispatch.
+    """
+
+    def __init__(self, service: BridgeService, payload: dict[str, Any]) -> None:
+        self.headers = {"x-bridge-key": service.state.session_key}
+        self._payload = payload
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+async def _rpc(service: BridgeService, payload: dict[str, Any]) -> Any:
+    """Call the HTTP gate with the two attributes it reads off a request.
+
+    The handler touches only ``headers["x-bridge-key"]`` and ``await json()``,
+    so a duck-typed double is the honest fixture; the cast is only for pyright,
+    which cannot know that a narrower object is sufficient here.
+    """
+    return await service.rpc(cast(Any, _HttpRequest(service, payload)))
+
+
+async def _health(service: BridgeService) -> dict[str, Any]:
+    """The daemon's own /health payload, without standing up a port."""
+    import json as _json
+
+    response = await service.health(None)  # type: ignore[arg-type]
+    return _json.loads(bytes(response.body).decode("utf-8"))
+
+
+# --- R1-1 ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stalled_owner_recover_is_not_reported_as_a_version_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stalled extension must never render as a version mismatch, either.
+
+    `settle.ts`'s `deadline()` is a SECOND producer of a data-bearing INTERNAL:
+    it rejects `internal` + `data.stalled` with NO `timeout_s`, and the worker
+    passes `error.data` through verbatim. `owner_recover` reaches it through
+    `withOwnership` → `withSessionMutation` → `scopes()`, so keying the
+    "update your extension" mapping on the ABSENCE of `timeout_s` alone sent the
+    recovery command back to the exact P3 misdiagnosis, from inside the incident
+    that command exists to survive (review R1-1, reproduced against the previous
+    head). The predicate must therefore key on both discriminators, and a new
+    `internal` discriminator belongs in it rather than beside it.
+    """
+
+    class _FailingBridge:
+        def __init__(self, error: BridgeError) -> None:
+            self.error = error
+
+        async def call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            raise self.error
+
+    resource = resources.BrowserResource(tmp_path, tmp_path.name)
+    resource.initialize()
+
+    stalled = BridgeError(
+        ErrorCode.INTERNAL,
+        "chrome.storage.session.set(ownerScopes) did not respond within 5000ms",
+        {"stalled": "chrome.storage.session.set(ownerScopes)"},
+    )
+    monkeypatch.setattr(resources, "BridgeClient", lambda: _FailingBridge(stalled))
+    with pytest.raises(BridgeError) as raised:
+        await resource.recover()
+    assert "updated Local Operator extension" not in str(raised.value)
+    assert raised.value.data["stalled"] == "chrome.storage.session.set(ownerScopes)"
+
+    # And the genuine legacy case is still mapped: no discriminator at all.
+    legacy = BridgeError(ErrorCode.INTERNAL, "unknown method owner_recover")
+    monkeypatch.setattr(resources, "BridgeClient", lambda: _FailingBridge(legacy))
+    with pytest.raises(resources.BrowserOwnershipError) as mapped:
+        await resource.recover()
+    assert "requires an updated Local Operator extension" in str(mapped.value)
+
+
+# --- R1-2 ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_drifted_ping_tick_does_not_promote_a_healthy_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The promotion rule must carry slack for a dropped or delayed tick.
+
+    A healthy peer speaks only when spoken to, so its silence sawtooths from 0
+    to one ping interval plus whatever drift the DAEMON's own loop adds: a tick
+    can be dropped, and `_supervise` inserts up to `SUPERVISOR_BACKOFF_CAP_S`
+    after a failed one. With zero slack (`silent_for() > PING_INTERVAL_S`) a
+    command timing out in that sliver tore down a healthy link — close 4000 and
+    every session's pending futures failed, which is the record's own hazard at
+    the sibling threshold (review R1-2, reproduced). This is the boundary BELOW
+    the slack: 1.2 intervals of silence must NOT corroborate a dead peer.
+    """
+
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "read", 0.05)
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 1.0)
+    service = BridgeService(root=tmp_path)
+    # 1.2 intervals: past a bare interval, inside the 1.5x slack. Proven (far
+    # inside LINK_SILENCE_TIMEOUT_S), so the rpc gate lets the command through.
+    socket = _connected(service, silent_for=1.2)
+
+    async def silent(payload: dict[str, Any]) -> None:
+        return None
+
+    service.link.send = silent  # type: ignore[method-assign]
+    response = await service._dispatch_serialized(
+        Request(id="r-drift", method="read", params={"tab": "bridge:9:n"})
+    )
+    body = bytes(response.body).decode().replace(" ", "")
+    assert ErrorCode.INTERNAL.value in body
+    assert '"timeout_s":0.05' in body
+    assert ErrorCode.EXTENSION_UNRESPONSIVE.value not in body
+    assert service.link.websocket is socket, "a healthy link with a drifted tick was torn down"
+
+
+@pytest.mark.asyncio
+async def test_a_corroborated_dead_peer_still_promotes_past_the_slack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The boundary ABOVE the slack: the rule must still fire.
+
+    Without this half, clamping the promotion rule to silence only would pass the
+    test above and lose the corroboration the record added it for.
+    """
+
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "read", 0.05)
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 1.0)
+    service = BridgeService(root=tmp_path)
+    # 2 intervals of silence: past the 1.5x slack, still proven.
+    socket = _connected(service, silent_for=2.0)
+
+    async def silent(payload: dict[str, Any]) -> None:
+        return None
+
+    service.link.send = silent  # type: ignore[method-assign]
+    response = await service._dispatch_serialized(
+        Request(id="r-dead", method="read", params={"tab": "bridge:9:n"})
+    )
+    body = bytes(response.body).decode().replace(" ", "")
+    assert ErrorCode.EXTENSION_UNRESPONSIVE.value in body
+    assert '"phase":"response"' in body
+    assert socket.closed == [4000], "a corroborated dead peer must be severed"
+
+
+# --- D2 / R1-5 / Q1 -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_severed_silent_link_stays_honest_until_the_browser_returns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The honest state must outlive the teardown that answers with it.
+
+    The single upstream defect here: the teardown nulls the socket as part of
+    ANSWERING, and `/health` derived the discriminator from the live socket, so
+    the "attached but not answering" line was observable for at most one command
+    and then fell back to "browser not currently attached; it reconnects when
+    opened" — advice to open a browser that is open, told to a user who had just
+    been sent to `lop browser status` by the error copy. Both the health payload
+    and the NEXT rpc must carry the reason (design D2 / review R1-5 / QA Q1).
+    """
+    service = BridgeService(root=tmp_path)
+    socket = _connected(service, silent_for=LINK_SILENCE_TIMEOUT_S + 3.0)
+
+    await service._drop_unproven_link("test guard")
+
+    assert socket.closed == [4000]
+    # The latch survives the teardown, with the silence measured AT the drop
+    # rather than collapsing to 0 with the socket.
+    assert service.link.recent_drop_silence() > LINK_SILENCE_TIMEOUT_S
+
+    health = await _health(service)
+    assert health["extension_connected"] is False
+    assert health["extension_unresponsive"] is True
+    assert health["link_attached"] is False, "the socket really is gone"
+    assert health["link_silent_s"] > LINK_SILENCE_TIMEOUT_S
+
+    # The retry the error copy advises must NOT land on "no browser is attached".
+    response = await _rpc(service, {"id": "r-retry", "method": "tabs", "params": {}})
+    body = bytes(response.body).decode().replace(" ", "")
+    assert ErrorCode.EXTENSION_UNRESPONSIVE.value in body
+    assert ErrorCode.EXTENSION_DISCONNECTED.value not in body
+    assert '"phase":"dropped"' in body
+
+    # And it expires: a browser that is genuinely gone must not read as
+    # "attached but mute" forever.
+    monkeypatch.setattr(daemon_module, "LINK_DROP_TTL_S", 0.01)
+    time.sleep(0.02)
+    assert service.link.recent_drop_silence() == 0.0
+    health = await _health(service)
+    assert health["extension_unresponsive"] is False
+    response = await _rpc(service, {"id": "r-later", "method": "tabs", "params": {}})
+    assert ErrorCode.EXTENSION_DISCONNECTED.value in bytes(response.body).decode()
+
+
+def test_a_peer_that_closes_its_own_socket_is_absent_not_unresponsive(tmp_path: Path) -> None:
+    """A link the daemon did NOT sever must never inherit the unresponsive label.
+
+    The latch is cleared on every ordinary socket end and by a new authoritative
+    socket, so a browser the user simply closed reads as absent — the honest
+    line for that state — rather than as a mute peer.
+    """
+    app = create_app(root=tmp_path)
+    with TestClient(app) as client:
+        service = app.state.bridge
+        with client.websocket_connect("/extension", headers={"origin": ORIGIN}) as socket:
+            socket.send_json(
+                {
+                    "event": "hello",
+                    "proto": PROTO_VERSION,
+                    "token": "",
+                    "extension_version": "0.1.0",
+                    "browser": "Chrome/153",
+                }
+            )
+            socket.receive_json()
+            # Pretend an earlier silence drop latched the honest state...
+            service.link.note_unproven_drop(LINK_SILENCE_TIMEOUT_S + 1.0)
+            assert client.get("/health").json()["extension_unresponsive"] is True
+        # ...and then the peer itself goes away.
+        health = client.get("/health").json()
+        assert health["extension_unresponsive"] is False
+        assert health["link_attached"] is False
+        assert service.link.dropped_unproven() is False
+
+
+# --- D5 / D6 --------------------------------------------------------------
+
+
+def test_a_daemon_side_timeout_names_a_remedy_not_a_raw_code() -> None:
+    """`internal` + `timeout_s` must render as an action, not as a bare code.
+
+    P3 correctly stopped a daemon-side timeout reading as a version mismatch,
+    but left it on the generic fallback: an obscure code, the daemon's internal
+    verb name, and no remedy at all — on `owner_recover`, whose entire job is
+    recovery (design D5). The budget stays in details for diagnostics.
+    """
+    rendered = format_error(
+        BridgeError(ErrorCode.INTERNAL, "owner_recover timed out", {"timeout_s": 20.0})
+    )
+    assert "did not answer within 20s" in rendered
+    assert "chrome://extensions" in rendered
+    assert "internal" not in rendered
+    assert "owner_recover" not in rendered, "the daemon's internal verb does not belong in prose"
+    assert "browser bridge error" not in rendered
+
+
+def test_the_undrivable_tab_copy_names_no_opaque_handle() -> None:
+    """No `(unknown)` and no `bridge:<tab>:<nonce>` capability in the sentence.
+
+    `format_error`'s only handle here is the session's own opaque capability
+    string, so the sentence used to read either `(unknown)` or a token in the
+    middle of prose — neither human-meaningful (design D6).
+    """
+    rendered = format_error(
+        BridgeError(
+            ErrorCode.INTERNAL, "Chrome refused to debug this tab", {"undrivable_tab": "x"}
+        ),
+        action="read",
+        surface="bridge:12:deadbeef",
+    )
+    assert "cannot be driven" in rendered
+    assert "(unknown)" not in rendered
+    assert "bridge:12:deadbeef" not in rendered
+    assert "'open' with a URL" in rendered

--- a/tests/unit/browser_bridge/test_bridge_wedge.py
+++ b/tests/unit/browser_bridge/test_bridge_wedge.py
@@ -1725,3 +1725,191 @@ async def test_a_sibling_teardown_is_not_reported_as_a_replacement(
         service.link.generation == generation
     ), "no replacement attached, which is the fact both answers had to respect"
     assert service.link.dropped_unproven(), "the latched reason is what the answer reports"
+
+
+class _WedgedPeer(_GatedClosePeer):
+    """A paired peer that accepts a command write and never finishes it.
+
+    R4-2's repro needs the peer wedged on BOTH legs at once, because the two are
+    what produce the window: the parked command write is what makes `_admit`'s
+    send deadline fire and call `_drop_unproven_link`, and the parked *close* is
+    what keeps that teardown suspended after it has already cleared both maps.
+    Distinct from `_GatedClosePeer`, which refuses nothing until the handshake
+    asks it to close.
+    """
+
+    def __init__(self, extension_id: str = EXTENSION_ID) -> None:
+        super().__init__(extension_id)
+        self.write_entered = asyncio.Event()
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+        if "method" in payload:
+            self.write_entered.set()
+            await asyncio.Future()  # a write that never completes
+
+
+@pytest.mark.asyncio
+async def test_a_reused_id_does_not_cost_the_new_request_its_approval_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """R4-2 (major): the marker's removal needs the SAME identity proof the future got.
+
+    `_forget_pending` deleted `link.pending` by identity — because a teardown
+    clears that map, so a later request may re-use an id — and then popped
+    `link.awaiting_origin` by id ALONE. Both describe one request's lifetime, but
+    only the identity can prove WHICH request, so the unguarded half deleted a
+    live request's marker. The window needs no hand-inserted state:
+
+    1. a paired peer wedges, an old command's send deadline fires inside `_admit`
+       (which forgets our future and then tears the link down), and the
+       teardown's bounded `websocket.close()` parks on the wedged peer AFTER
+       `forget_link_state()` has cleared both maps;
+    2. the worker genuinely re-dials inside that window and re-pairs through the
+       real `extension()`;
+    3. a NEW request re-using the old id passes the busy guard — the guard reads
+       the map the teardown emptied — reaches the wire, and the extension
+       announces a human approval for it through the real receive loop;
+    4. the old task's parked close finishes, and its `finally` unwinds through
+       `_forget_pending`.
+
+    Pre-fix that unwind took the new marker with it: `NEW_FUTURE_PRESERVED: true,
+    NEW_APPROVAL_MARKER_PRESERVED: false`, so the new request lost the deadline
+    extension `_await_response` exists to give it and failed at its BASE timeout
+    while the user was still looking at the prompt.
+
+    This row is also the only one that can see the FUTURE's identity guard
+    (review R4-4's missing coverage): reverting it to a bare `pop(id)` leaves
+    every other row green.
+    """
+
+    monkeypatch.setattr(daemon_module, "LINK_SEND_TIMEOUT_S", 0.05)
+    _saved_pairing(tmp_path, "good-token")
+    service = BridgeService(root=tmp_path)
+
+    wedged = _WedgedPeer()
+    wedged.push(_hello(token="good-token"))
+    wedged_task = asyncio.create_task(service.extension(wedged))  # type: ignore[arg-type]
+    assert await _settles(lambda: service.link.websocket is wedged and service.link.paired)
+
+    old_id = "r-abc123abcdef"
+    old_task = asyncio.create_task(
+        service._dispatch_serialized(
+            Request(id=old_id, method="read", params={"tab": "bridge:1:n"})
+        )
+    )
+    await asyncio.wait_for(wedged.write_entered.wait(), timeout=2.0)
+    # Step 1: the send deadline fired and the teardown is now parked in its
+    # bounded close, with both maps already cleared.
+    await asyncio.wait_for(wedged.close_entered.wait(), timeout=2.0)
+    assert service.link.pending == {}, "precondition: the teardown cleared `pending`"
+    assert service.link.awaiting_origin == {}, "precondition: the teardown cleared the markers"
+
+    # Step 2: the worker re-dials for real and re-pairs. A peer that records
+    # frames without answering them, so the new request's future stays registered.
+    reconnected = _FakePeer()
+    reconnected.push(_hello(token="good-token"))
+    reconnected_task = asyncio.create_task(service.extension(reconnected))  # type: ignore[arg-type]
+    assert await _settles(
+        lambda: service.link.websocket is reconnected and service.link.paired
+    ), "the re-dial did not re-pair"
+
+    # Step 3: a NEW request re-using the old id — a different tab, so it takes a
+    # different key and is not queued behind the old task's per-tab lock.
+    new_task = asyncio.create_task(
+        service._dispatch_serialized(
+            Request(id=old_id, method="read", params={"tab": "bridge:2:m"})
+        )
+    )
+    assert await _settles(
+        lambda: any(frame.get("id") == old_id for frame in reconnected.sent)
+    ), "the new request never reached the wire"
+    new_future = service.link.pending.get(old_id)
+    assert new_future is not None, "the new request registered no future to preserve"
+
+    # ...and the extension announces a genuine human approval for it.
+    reconnected.push({"event": "awaiting_origin", "id": old_id, "origin": "https://example.com"})
+    assert await _settles(lambda: old_id in service.link.awaiting_origin), "no marker was set"
+
+    # Step 4: the old task's parked close finishes and it unwinds.
+    wedged.release_close.set()
+    with suppress(Exception):
+        await asyncio.wait_for(old_task, timeout=2.0)
+
+    assert (
+        service.link.pending.get(old_id) is new_future
+    ), "the old unwind popped a LATER request's future, which its identity guard prevents"
+    assert (
+        old_id in service.link.awaiting_origin
+    ), "the old unwind popped the NEW request's approval marker, so it expires at the base deadline"
+
+    for task in (new_task, reconnected_task, wedged_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_a_real_replacement_handshake_names_the_replacement(tmp_path: Path) -> None:
+    """R4-3 (minor): `phase: replaced` must cover the arm a re-dial actually reaches.
+
+    The delta gave the phase to the two TIMEOUT fences, but a genuine replacement
+    handshake calls `forget_link_state()`, which fails every pending future with
+    `RuntimeError("extension disconnected")` immediately — so an in-flight command
+    does not reach a timeout at all. It lands in the generic `except Exception`
+    arm, and without a `replaced` test there it fell through to a bare
+    `extension_disconnected` whose rendered copy is "the bridge daemon is running
+    but no browser is attached. Ask the user to open their browser" — for a
+    browser that is demonstrably open, paired and reconnected. That is precisely
+    the misdirection class this PR exists to remove (design D3-3), on the path a
+    worker re-dial takes most often.
+
+    The assertion is on the RENDERED sentence, not the code, because the code is
+    shared and only `phase` selects the copy.
+    """
+
+    _saved_pairing(tmp_path, "good-token")
+    service = BridgeService(root=tmp_path)
+
+    first = _FakePeer()
+    first.push(_hello(token="good-token"))
+    first_task = asyncio.create_task(service.extension(first))  # type: ignore[arg-type]
+    assert await _settles(lambda: service.link.websocket is first and service.link.paired)
+
+    command_task = asyncio.create_task(
+        service._dispatch_serialized(
+            Request(id="r-inflight", method="read", params={"tab": "bridge:1:n"})
+        )
+    )
+    assert await _settles(
+        lambda: any(frame.get("id") == "r-inflight" for frame in first.sent)
+    ), "the command never reached the wire"
+
+    # A GENUINE replacement handshake, through the production accept path.
+    second = _FakePeer()
+    second.push(_hello(token="good-token"))
+    second_task = asyncio.create_task(service.extension(second))  # type: ignore[arg-type]
+    assert await _settles(
+        lambda: service.link.websocket is second and service.link.paired
+    ), "the replacement did not install"
+
+    response = await asyncio.wait_for(command_task, timeout=2.0)
+    error = json.loads(bytes(response.body).decode("utf-8"))["error"]
+
+    assert error["code"] == ErrorCode.EXTENSION_DISCONNECTED.value, error
+    assert error.get("data", {}).get("phase") == "replaced", (
+        "a replacement handshake answered without naming the replacement, so the "
+        "reader is told to open a browser that is already open: " + json.dumps(error)
+    )
+
+    rendered = format_error(
+        BridgeError(ErrorCode(error["code"]), error["message"], error.get("data"))
+    )
+    assert "no browser is attached" not in rendered, rendered
+    assert "open their browser" not in rendered, rendered
+    assert "retry the action" in rendered, rendered
+
+    for task in (first_task, second_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task

--- a/tests/unit/browser_bridge/test_bridge_wedge.py
+++ b/tests/unit/browser_bridge/test_bridge_wedge.py
@@ -15,6 +15,8 @@ says so instead of implying a guard that does not exist.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import time
 from contextlib import suppress
 from pathlib import Path
@@ -1128,6 +1130,11 @@ async def test_an_old_send_deadline_cannot_sever_its_replacement(
     assert ErrorCode.EXTENSION_DISCONNECTED.value in body
     assert ErrorCode.EXTENSION_UNRESPONSIVE.value not in body
     assert "notdelivered" in body.replace('"', ""), body
+    # ...and it carries `phase`, so the reader is not told to open a browser
+    # that is already open (design D3-3). Without the discriminator the client
+    # renders the code's own copy: "no browser is attached. Ask the user to
+    # open their browser".
+    assert '"phase":"replaced"' in body, body
 
 
 @pytest.mark.asyncio
@@ -1378,3 +1385,343 @@ async def test_a_superseded_socket_that_never_closes_does_not_park_the_accept(
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task
+
+
+# --- Audit round 2 re-audit: A1, the handshake's shared-state install -------
+#
+# The auditor drove three overlapping hellos at the real `extension()` and
+# showed that a superseded handshake could still WRITE. Their verdict was that
+# the replacement path retained the stale-handler defect with an authorization
+# consequence (`rpc not_paired -> ok`), and that a revoke could clear a
+# replacement that arrived while its close was in flight. Both rows below fail
+# on `bb039c18e`.
+
+
+class _GatedClosePeer(_FakePeer):
+    """A peer whose ``close()`` parks until the test releases it.
+
+    A1's repro needs the superseded socket's close held OPEN while a third
+    handshake arrives — that await is the window the daemon has to survive.
+    Distinct from ``_StallingClosePeer``, which models a close that never
+    finishes at all (A2's bound), rather than one that resumes into a race.
+    """
+
+    def __init__(self, extension_id: str = EXTENSION_ID) -> None:
+        super().__init__(extension_id)
+        self.close_entered = asyncio.Event()
+        self.release_close = asyncio.Event()
+
+    async def close(self, code: int | None = None, reason: str | None = None) -> None:
+        self.closed.append(code)
+        self.close_entered.set()
+        await self.release_close.wait()
+
+
+class _AnsweringPeer(_FakePeer):
+    """A scripted peer that ANSWERS every command frame it is sent.
+
+    The authorization half of the A1 row is that an invalid-token peer could be
+    DRIVEN, so the test has to show the drive either landing (pre-fix) or never
+    leaving the daemon (post-fix). A peer that stayed mute could not tell those
+    apart — it would look identical to a daemon that refused.
+    """
+
+    def __init__(self, extension_id: str = EXTENSION_ID) -> None:
+        super().__init__(extension_id)
+        self.commands: list[dict[str, Any]] = []
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        await super().send_json(payload)
+        if "method" in payload:
+            self.commands.append(payload)
+            self.push({"id": payload["id"], "ok": True, "result": {"driven": True}})
+
+
+def _saved_pairing(root: Path, token: str) -> None:
+    """Write the REAL pairing record the handshake validates against.
+
+    The auditor's script stubbed ``_read_json``; this writes the file the daemon
+    actually reads, through the same writer ``_try_pair`` uses, inside the
+    test's own root. Token validation, the origin check and ``reset_pairing``
+    therefore all run for real.
+    """
+    daemon_module._private_write(
+        daemon_module._pairing_path(root),
+        {
+            "extension_id": EXTENSION_ID,
+            "token_sha256": hashlib.sha256(token.encode()).hexdigest(),
+            "paired_at": time.time(),
+        },
+    )
+
+
+async def _reply(service: BridgeService, request_id: str) -> dict[str, Any]:
+    """The decoded body of one `tabs` RPC through the real HTTP gate."""
+    response = await _rpc(service, {"id": request_id, "method": "tabs", "params": {}})
+    return json.loads(bytes(response.body).decode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_a_superseded_handshake_cannot_authorize_its_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A1 (blocker): the install must not straddle an await, and the ack must be fenced.
+
+    The auditor's sequence against the pinned head, through the production
+    `extension()`, token check and `rpc()`: W1's close is held, W2 (valid token)
+    installs itself and parks on that close, W3 arrives with the permitted
+    extension id and an INVALID token, and when W1's close is released the
+    superseded W2 writes its own verdict — `paired: True` — onto W3's link. W3
+    then drives RPCs through the real pairing gate:
+
+        before: not_paired      after: ok -> {"accepted_by_unpaired_peer": true}
+
+    That is authorization of a rejected token, not a stale frame. The guard is
+    ordering: every shared-state write (identity, pairing, liveness, latch)
+    completes before the first yield after `attach`, so a handshake that no
+    longer owns the link has nothing left to write, and the ack it would have
+    sent is fenced by identity too.
+    """
+
+    monkeypatch.setattr(daemon_module, "LINK_CLOSE_TIMEOUT_S", 5.0)
+    _saved_pairing(tmp_path, "good-token")
+    service = BridgeService(root=tmp_path)
+
+    first = _GatedClosePeer()
+    first.push(_hello(token="good-token"))
+    first_task = asyncio.create_task(service.extension(first))  # type: ignore[arg-type]
+    assert await _settles(lambda: service.link.websocket is first)
+    assert service.link.paired, "precondition: the first peer holds the saved, valid token"
+
+    # W2: a VALID token. It becomes the link, then parks closing W1 — the
+    # window the auditor exploited. (`attach` precedes that close on every
+    # head, which is why only the INSTALL ORDER is the fix, not the arrival.)
+    second = _FakePeer()
+    second.push(_hello(token="good-token"))
+    second_task = asyncio.create_task(service.extension(second))  # type: ignore[arg-type]
+    await asyncio.wait_for(first.close_entered.wait(), timeout=2.0)
+    assert service.link.websocket is second, "W2 is the authoritative link"
+    assert second.sent == [], "precondition: W2 is still inside its handshake"
+
+    # W3: same permitted extension id, INVALID token. It supersedes W2 while W2
+    # is still parked, and gets its own honest `paired: false` ack.
+    third = _AnsweringPeer()
+    third.push(_hello(token="bad-token"))
+    third_task = asyncio.create_task(service.extension(third))  # type: ignore[arg-type]
+    assert await _settles(
+        lambda: any(frame.get("event") == "hello_ack" for frame in third.sent)
+    ), "the newest peer's handshake answer never went out"
+    assert service.link.websocket is third
+    assert service.link.paired is False, "the invalid token did not pair"
+
+    before = await _reply(service, "before")
+    assert before["error"]["code"] == ErrorCode.NOT_PAIRED.value, before
+
+    # Release W1's close: the superseded W2 resumes INSIDE its handshake. One
+    # buffered frame lets a superseded receive loop exit on either head, so the
+    # discriminator below is the pairing verdict rather than a parked task.
+    first.release_close.set()
+    second.push({"event": "pong"})
+    await asyncio.wait_for(second_task, timeout=2.0)
+
+    after = await _reply(service, "after")
+    assert (
+        after.get("error", {}).get("code") == ErrorCode.NOT_PAIRED.value
+    ), "a superseded handshake authorized the newest, invalid-token peer: " + json.dumps(after)
+    assert service.link.websocket is third
+    assert service.link.paired is False, "the stale handshake rewrote pairing"
+    assert second.sent == [], "a handshake that lost authority still spoke on its wire"
+    assert third.commands == [], "an unpaired peer was driven with a command"
+
+    for task in (third_task, first_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_a_revoke_does_not_clear_a_replacement_that_arrived_mid_close(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A1's revoke half: a scoped revoke must not tear down a later handshake.
+
+    `revoke()` captures the socket, awaits its bounded close, and then cleared
+    the link UNCONDITIONALLY. Installing a replacement during that await
+    therefore had its socket nulled and its state forgotten by a revoke that had
+    already closed the connection it was aimed at — the auditor's
+    `replacementStillAuthoritative: false`.
+
+    The control that makes this a fix and not a hole: preserving the connection
+    is NOT authorization. The replacement computed its own `paired` from the
+    pairing file `reset_pairing` had already removed, so it is refused by the
+    same `not_paired` gate as any other unpaired peer.
+    """
+
+    monkeypatch.setattr(daemon_module, "LINK_CLOSE_TIMEOUT_S", 5.0)
+    _saved_pairing(tmp_path, "good-token")
+    service = BridgeService(root=tmp_path)
+
+    revoked = _GatedClosePeer()
+    revoked.push(_hello(token="good-token"))
+    revoked_task = asyncio.create_task(service.extension(revoked))  # type: ignore[arg-type]
+    assert await _settles(lambda: service.link.paired)
+    generation = service.link.generation
+
+    revoke_task = asyncio.create_task(service.revoke())
+    await asyncio.wait_for(revoked.close_entered.wait(), timeout=2.0)
+
+    # The replacement dials while the revoked socket's close is still parked.
+    replacement = _AnsweringPeer()
+    replacement.push(_hello(token="good-token"))
+    replacement_task = asyncio.create_task(service.extension(replacement))  # type: ignore[arg-type]
+    assert await _settles(lambda: service.link.websocket is replacement)
+
+    revoked.release_close.set()
+    await asyncio.wait_for(revoke_task, timeout=2.0)
+
+    assert service.link.websocket is replacement, "the revoke cleared the link it did not close"
+    assert service.link.generation == generation + 1, "the replacement's link state was forgotten"
+    assert service.link.paired is False, "a revoked token paired the replacement"
+    assert 4003 in revoked.closed, "the revoked socket was not closed as unpaired"
+
+    after = await _reply(service, "after")
+    assert after["error"]["code"] == ErrorCode.NOT_PAIRED.value, after
+    assert replacement.commands == [], "a revoked pairing drove the replacement"
+
+    for task in (replacement_task, revoked_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_a_lost_answer_on_a_replaced_wire_names_the_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Design D3-3, the response half: "replaced" is not "no browser is attached".
+
+    The reachable interleaving is a command registered in the gap between
+    `forget_link_state()` and `attach()` during a handshake: the replacement
+    does not fail that future (it was not in the map when the superseded link's
+    state was dropped), so this command's answer never arrives on either wire.
+    By the time its budget expires the promotion rule finds, on a mute
+    replacement, nothing of ours left to sever — and the honest answer is that
+    the extension replaced its connection.
+
+    That answer carries `extension_disconnected`, whose copy tells the reader no
+    browser is attached and to ask the user to open one. `phase: replaced` is
+    what makes the client render the truthful copy instead (design D3-3), which
+    is why this row asserts BOTH the phase and that the absent-browser sentence
+    is not what the model would read.
+    """
+
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "read", 0.05)
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 1.0)
+    monkeypatch.setattr(daemon_module, "PING_PROBE_TIMEOUT_S", 0.05)
+    service = BridgeService(root=tmp_path)
+    old = _connected(service, silent_for=2.0)
+    service.link.paired = True
+    old_wire = (service.link.websocket, service.link.generation)
+
+    # The REAL `link.send`: the frame must genuinely land on the superseded wire
+    # (that is what makes this command "delivered, never answered"), and nothing
+    # ever pushes a response frame back — `_RecordingSocket` only records.
+    task = asyncio.get_running_loop().create_task(
+        service._dispatch_serialized(
+            Request(id="r-lost", method="read", params={"tab": "bridge:9:n"})
+        )
+    )
+    await asyncio.sleep(0)
+    for _ in range(100):
+        if old.sent:
+            break
+        await asyncio.sleep(0.002)
+    assert old.sent == [
+        {"id": "r-lost", "method": "read", "params": {"tab": "bridge:9:n"}}
+    ], "precondition: the command was delivered on the superseded wire"
+    assert service.link.pending.get("r-lost") is not None, "precondition: nothing failed its future"
+
+    # The replacement: attached WITHOUT the superseded link's state being
+    # dropped, which is what leaves this command's future pending across it.
+    replacement = _RecordingSocket()
+    service.link.attach(replacement)  # type: ignore[arg-type]
+    service.link.paired = True
+    service.link.last_frame_at = time.monotonic()
+
+    response = await asyncio.wait_for(task, timeout=5.0)
+    body = bytes(response.body).decode().replace(" ", "")
+
+    assert service.link.websocket is replacement, "the replacement was severed"
+    assert (service.link.websocket, service.link.generation) != old_wire
+    assert ErrorCode.EXTENSION_DISCONNECTED.value in body, body
+    assert '"phase":"replaced"' in body, body
+    assert "hassincereplaced" in body, body
+    # The rendered copy, not just the code: this is what the model reads.
+    from local_operator.browser_bridge.backend import BridgeError, format_error
+
+    rendered = format_error(
+        BridgeError(
+            ErrorCode.EXTENSION_DISCONNECTED,
+            "read was delivered on a connection the extension has since replaced",
+            {"phase": "replaced"},
+        ),
+        action="read",
+    )
+    assert "no browser is attached" not in rendered
+    assert "open their browser" not in rendered
+    assert "retry the action" in rendered
+
+
+@pytest.mark.asyncio
+async def test_a_sibling_teardown_is_not_reported_as_a_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """R3-4 (major): the fence refused for TWO reasons and only one was true.
+
+    Two sessions timing out on ONE frozen worker is the multi-session case this
+    PR exists for. The first timeout severs the link (`disconnect()` nulls the
+    socket and leaves the generation alone); the second then asks the fence about
+    the wire it captured, is refused, and used to take the "a replacement
+    answered" arm — telling the reader no browser is attached and to ask the user
+    to open one, for a browser that is open and wedged, with nothing having been
+    replaced. At `a733b08a4` both commands answered `extension_unresponsive`.
+
+    The assertion is deliberately race-tolerant about WHICH command severs the
+    link (the two probes overlap): what must hold is that NEITHER answer claims a
+    replacement, because no replacement happened on this wire.
+    """
+
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "read", 0.05)
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "snapshot", 0.05)
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 1.0)
+    # Long enough that both commands are inside the probe at the same time, which
+    # is the interleaving that puts one of them on the wrong arm.
+    monkeypatch.setattr(daemon_module, "PING_PROBE_TIMEOUT_S", 0.15)
+    service = BridgeService(root=tmp_path)
+    socket = _connected(service, silent_for=2.0)
+    service.link.paired = True
+    generation = service.link.generation
+
+    bodies = await asyncio.gather(
+        *(
+            service._dispatch_serialized(
+                Request(id=f"r-{index}", method=method, params={"tab": f"bridge:{index}:n"})
+            )
+            for index, method in ((1, "read"), (2, "snapshot"))
+        )
+    )
+    decoded = [bytes(body.body).decode().replace(" ", "") for body in bodies]
+
+    for body in decoded:
+        assert ErrorCode.EXTENSION_DISCONNECTED.value not in body, (
+            "a command on a torn-down wire was told the extension replaced its connection: " + body
+        )
+        assert ErrorCode.EXTENSION_UNRESPONSIVE.value in body, body
+        assert '"link_silent_s"' in body, body
+
+    assert socket.closed == [4000], "the wedge is severed exactly once"
+    assert service.link.websocket is None, "the link stays down until the peer re-dials"
+    assert (
+        service.link.generation == generation
+    ), "no replacement attached, which is the fact both answers had to respect"
+    assert service.link.dropped_unproven(), "the latched reason is what the answer reports"

--- a/tests/unit/browser_bridge/test_bridge_wedge.py
+++ b/tests/unit/browser_bridge/test_bridge_wedge.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import asyncio
 import time
+from contextlib import suppress
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import pytest
 from starlette.testclient import TestClient
@@ -43,13 +44,112 @@ ORIGIN = f"chrome-extension://{EXTENSION_ID}"
 
 
 class _RecordingSocket:
-    """Stand-in for the extension leg's websocket: records close codes."""
+    """Stand-in for the extension leg's websocket: records close codes and frames."""
 
     def __init__(self) -> None:
         self.closed: list[int | None] = []
+        self.sent: list[dict[str, Any]] = []
 
     async def close(self, code: int | None = None, reason: str | None = None) -> None:
         self.closed.append(code)
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+
+class _StallingSendSocket(_RecordingSocket):
+    """A socket that ACCEPTS the write and never finishes it.
+
+    The distinction matters: parking the coroutine before `send_json` is entered
+    would never set ``entered``, and the test could not tell a write that was
+    suspended from one that was never attempted.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entered = asyncio.Event()
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.entered.set()
+        await asyncio.Future()
+
+
+class _StallingCloseSocket(_RecordingSocket):
+    """A socket whose close() never resolves (audit A2's fake close)."""
+
+    async def close(self, code: int | None = None, reason: str | None = None) -> None:
+        self.closed.append(code)
+        await asyncio.Future()
+
+
+class _FakePeer:
+    """A scripted /extension connection: feeds frames, records what it is sent.
+
+    The receive path is a QUEUE rather than a list so a test can decide when a
+    frame becomes available — which is the whole point of the stale-frame row:
+    the frame must arrive strictly after the socket stops being authoritative.
+    """
+
+    def __init__(self, extension_id: str = EXTENSION_ID) -> None:
+        self.headers = {"origin": f"chrome-extension://{extension_id}"}
+        self.accepted = False
+        self.closed: list[int | None] = []
+        self.sent: list[dict[str, Any]] = []
+        self._frames: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive_json(self) -> dict[str, Any]:
+        return await self._frames.get()
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+    async def close(self, code: int | None = None, reason: str | None = None) -> None:
+        self.closed.append(code)
+
+    def push(self, frame: dict[str, Any]) -> None:
+        self._frames.put_nowait(frame)
+
+
+class _StallingClosePeer(_FakePeer):
+    """A superseded connection that is asked to close and never finishes it."""
+
+    def __init__(self, extension_id: str = EXTENSION_ID) -> None:
+        super().__init__(extension_id)
+        self.close_entered = asyncio.Event()
+
+    async def close(self, code: int | None = None, reason: str | None = None) -> None:
+        self.closed.append(code)
+        self.close_entered.set()
+        await asyncio.Future()
+
+
+def _hello(**overrides: Any) -> dict[str, Any]:
+    frame = {
+        "event": "hello",
+        "proto": PROTO_VERSION,
+        "token": "",
+        "extension_version": "0.1.10",
+        "browser": "Chrome/153",
+    }
+    frame.update(overrides)
+    return frame
+
+
+async def _settles(predicate: Callable[[], bool], seconds: float = 2.0) -> bool:
+    """Await ``predicate``, giving REAL timers room to fire.
+
+    A loop of ``await asyncio.sleep(0)`` advances no clock, so it can never let a
+    deadline expire — which is exactly the behaviour these callers assert on.
+    """
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.005)
+    return predicate()
 
 
 def _connected(service: BridgeService, *, silent_for: float = 0.0) -> _RecordingSocket:
@@ -58,6 +158,21 @@ def _connected(service: BridgeService, *, silent_for: float = 0.0) -> _Recording
     service.link.websocket = socket  # type: ignore[assignment]
     service.link.last_frame_at = time.monotonic() - silent_for
     return socket
+
+
+def _peer_spoke(service: BridgeService) -> None:
+    """Record that the extension just said something.
+
+    The receive loop does TWO things with an arriving frame — stamps liveness
+    and sets the probe's event — so a test stub that stands in for a live peer
+    must do both, or it models a peer that is talking while refusing to answer
+    (which is not a state the protocol can produce). The `wire` keyword on every
+    stub below is the other half of the same change: a send is scoped to the
+    socket the caller captured, so a stub that models the extension leg has to
+    accept it.
+    """
+    service.link.last_frame_at = time.monotonic()
+    service.link.frame_event.set()
 
 
 def _health_payload(tmp_path: Path) -> dict[str, Any]:
@@ -129,7 +244,7 @@ def test_command_against_a_silent_link_fails_fast_with_a_typed_code(
             socket.receive_json()
             sent: list[dict[str, Any]] = []
 
-            async def record(payload: dict[str, Any]) -> None:
+            async def record(payload: dict[str, Any], *, wire: Any = None) -> None:
                 sent.append(payload)
 
             service.link.send = record  # type: ignore[method-assign]
@@ -262,7 +377,7 @@ async def test_command_timeout_against_a_silent_link_is_promoted(
     # lets the command through) but already past one ping interval.
     _connected(service, silent_for=1.0)
 
-    async def silent(payload: dict[str, Any]) -> None:
+    async def silent(payload: dict[str, Any], *, wire: Any = None) -> None:
         # Delivered and accepted — the send RETURNS, it does not park — and then
         # no response ever arrives. Parking here instead would exercise the send
         # deadline (D7), not the promotion rule.
@@ -292,11 +407,11 @@ async def test_command_timeout_against_a_live_link_is_still_nav_timeout(
     service = BridgeService(root=tmp_path)
     socket = _connected(service, silent_for=0.0)
 
-    async def ponging(payload: dict[str, Any]) -> None:
+    async def ponging(payload: dict[str, Any], *, wire: Any = None) -> None:
         # The extension received the command and is working on it. Its pongs
         # keep arriving for the whole budget — that is what a slow page looks
         # like on the wire. The send RETURNS; only the answer is missing.
-        service.link.last_frame_at = time.monotonic()
+        _peer_spoke(service)
         return None
 
     service.link.send = ponging  # type: ignore[method-assign]
@@ -336,7 +451,7 @@ async def test_blocked_send_does_not_outlive_its_deadline(
     service = BridgeService(root=tmp_path)
     _connected(service, silent_for=0.0)
 
-    async def blocked(payload: dict[str, Any]) -> None:
+    async def blocked(payload: dict[str, Any], *, wire: Any = None) -> None:
         await asyncio.sleep(3600)
 
     service.link.send = blocked  # type: ignore[method-assign]
@@ -365,7 +480,7 @@ async def test_blocked_send_does_not_outlive_its_deadline(
     assert service.link.dropped_unproven() is True
 
     # The next command on the same key is served, not queued behind a corpse.
-    async def answer(payload: dict[str, Any]) -> None:
+    async def answer(payload: dict[str, Any], *, wire: Any = None) -> None:
         request_model = Request.model_validate(payload)
         future = service.link.pending.get(request_model.id)
         if future and not future.done():
@@ -682,10 +797,17 @@ async def test_a_drifted_ping_tick_does_not_promote_a_healthy_link(
     # inside LINK_SILENCE_TIMEOUT_S), so the rpc gate lets the command through.
     socket = _connected(service, silent_for=1.2)
 
-    async def silent(payload: dict[str, Any]) -> None:
+    async def answering(payload: dict[str, Any], *, wire: Any = None) -> None:
+        # A HEALTHY peer's job in this row is not to be asleep: it answers a
+        # solicited ping within an event-loop turn whatever else it is doing
+        # (record §2.2). The fixture therefore has to answer, because the rule
+        # under test now ASKS the peer instead of inferring from a clock — and a
+        # stub that stayed mute would be modelling the defect, not the healthy
+        # link this row exists to protect.
+        _peer_spoke(service)
         return None
 
-    service.link.send = silent  # type: ignore[method-assign]
+    service.link.send = answering  # type: ignore[method-assign]
     response = await service._dispatch_serialized(
         Request(id="r-drift", method="read", params={"tab": "bridge:9:n"})
     )
@@ -712,7 +834,7 @@ async def test_a_corroborated_dead_peer_still_promotes_past_the_slack(
     # 2 intervals of silence: past the 1.5x slack, still proven.
     socket = _connected(service, silent_for=2.0)
 
-    async def silent(payload: dict[str, Any]) -> None:
+    async def silent(payload: dict[str, Any], *, wire: Any = None) -> None:
         return None
 
     service.link.send = silent  # type: ignore[method-assign]
@@ -723,6 +845,53 @@ async def test_a_corroborated_dead_peer_still_promotes_past_the_slack(
     assert ErrorCode.EXTENSION_UNRESPONSIVE.value in body
     assert '"phase":"response"' in body
     assert socket.closed == [4000], "a corroborated dead peer must be severed"
+
+
+@pytest.mark.asyncio
+async def test_the_tight_budget_methods_can_still_corroborate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rule must fire for a 20 s method, not only past the 30 s slack.
+
+    Review R2-3 / QA Q2-4 measured the regression this pins: `PING_INTERVAL_S *
+    1.5` is 30 s, above the 20 s budget of `read`/`snapshot`/`screenshot`, so a
+    frozen worker was answered `internal {timeout_s: 20}` where round 1 answered
+    `extension_unresponsive` — the rule had gone inert for exactly the methods
+    the record introduced it for ("requiring 50 s would make a `read` unable to
+    ever corroborate, since its own timeout fires first", §2.4).
+
+    Silence here is 1.2 intervals — deliberately INSIDE the slack, below the
+    threshold that protects a healthy link — so this row can only pass because
+    the daemon ASKS the peer and gets nothing back. The companion row above
+    (1.2 intervals, peer answering) is what stops that from becoming a licence
+    to tear down healthy links: together they pin "the clock alone cannot
+    decide; the answer can".
+    """
+
+    monkeypatch.setitem(daemon_module.COMMAND_TIMEOUTS, "read", 0.05)
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 1.0)
+    # The probe window is shortened so the row is deterministic and fast; the
+    # REAL number is a magnitude below every method's budget, which is the whole
+    # property under test (see daemon.PING_PROBE_TIMEOUT_S).
+    monkeypatch.setattr(daemon_module, "PING_PROBE_TIMEOUT_S", 0.05)
+    service = BridgeService(root=tmp_path)
+    socket = _connected(service, silent_for=1.2)
+
+    async def mute(payload: dict[str, Any], *, wire: Any = None) -> None:
+        # Accepts the frame and answers NOTHING — not the command, and not the
+        # probe's ping. This is the wedged worker: its socket is open and it is
+        # still draining, so only a direct question distinguishes it from a slow
+        # page.
+        return None
+
+    service.link.send = mute  # type: ignore[method-assign]
+    response = await service._dispatch_serialized(
+        Request(id="r-frozen", method="read", params={"tab": "bridge:9:n"})
+    )
+    body = bytes(response.body).decode().replace(" ", "")
+    assert ErrorCode.EXTENSION_UNRESPONSIVE.value in body
+    assert '"phase":"response"' in body
+    assert socket.closed == [4000], "a mute peer inside the slack must be severed"
 
 
 # --- D2 / R1-5 / Q1 -------------------------------------------------------
@@ -810,22 +979,79 @@ def test_a_peer_that_closes_its_own_socket_is_absent_not_unresponsive(tmp_path: 
 # --- D5 / D6 --------------------------------------------------------------
 
 
-def test_a_daemon_side_timeout_names_a_remedy_not_a_raw_code() -> None:
-    """`internal` + `timeout_s` must render as an action, not as a bare code.
+class _RecoverFailure:
+    """A browser resource whose recovery preamble raises the given error.
+
+    Deliberately the REAL seams `execute_browser` drives (`lock`, `initialize`,
+    `recover`, `recovered`) rather than a stubbed render helper: the defect this
+    stands in for was a GREEN guard over a broken path, because the guard called
+    `format_error` directly with the default empty `action` while the tool passed
+    the daemon's verb name (design D2-1, review R2-2).
+    """
+
+    def __init__(self, exc: BaseException, *, recovered: bool) -> None:
+        self._exc = exc
+        self.generation = "g-test"
+        self.record: dict[str, Any] = {"surface_id": "bridge:9:nonce"}
+        self.recovered = recovered
+        self.lock = asyncio.Lock()
+
+    def initialize(self) -> None:
+        return None
+
+    async def recover(self) -> dict[str, Any]:
+        raise self._exc
+
+
+def _recover_context(exc: BaseException, *, recovered: bool) -> Any:
+    from local_operator.harness.types import BrowserSurface, ToolContext
+
+    surface = BrowserSurface()
+    surface.surface_id = "bridge:9:nonce"
+    surface.resource = _RecoverFailure(exc, recovered=recovered)  # type: ignore[assignment]
+    return ToolContext(browser=surface)
+
+
+@pytest.mark.asyncio
+async def test_a_daemon_side_timeout_names_a_remedy_not_a_raw_code() -> None:
+    """`internal` + `timeout_s` must render as an action, not as a bare code,
+    THROUGH THE TOOL — both of its render sites.
 
     P3 correctly stopped a daemon-side timeout reading as a version mismatch,
     but left it on the generic fallback: an obscure code, the daemon's internal
-    verb name, and no remedy at all — on `owner_recover`, whose entire job is
+    verb name, and no remedy at all — on the recovery path, whose entire job is
     recovery (design D5). The budget stays in details for diagnostics.
+
+    The two sites are the recovery preamble and an explicit `recover` action.
+    They used to disagree: the preamble rendered `format_error`, the action
+    returned `str(exc)` — the raw `owner_recover timed out`, with no remedy and
+    no typed code (design D2-1, review R2-2). The previous version of this test
+    called `format_error` directly and passed vacuously; it now drives the tool
+    with a resource whose `recover()` raises.
     """
-    rendered = format_error(
-        BridgeError(ErrorCode.INTERNAL, "owner_recover timed out", {"timeout_s": 20.0})
+    from local_operator.tools import builtin
+
+    error = BridgeError(ErrorCode.INTERNAL, "owner_recover timed out", {"timeout_s": 20.0})
+
+    # The preamble site: the session had not recovered yet, which is the flow the
+    # reported incident took.
+    preamble = await builtin.execute_browser(
+        "t", {"action": "read"}, None, None, _recover_context(error, recovered=False)
     )
-    assert "did not answer within 20s" in rendered
-    assert "chrome://extensions" in rendered
-    assert "internal" not in rendered
-    assert "owner_recover" not in rendered, "the daemon's internal verb does not belong in prose"
-    assert "browser bridge error" not in rendered
+    # The explicit-action site. `recovered=True` so the preamble passes and the
+    # action's own `recover()` call is what fails.
+    explicit = await builtin.execute_browser(
+        "t", {"action": "recover"}, None, None, _recover_context(error, recovered=True)
+    )
+
+    for result in (preamble, explicit):
+        assert "did not answer within 20s" in result.text
+        assert "chrome://extensions" in result.text, "the remedy must travel with the failure"
+        assert "internal" not in result.text
+        assert "owner_recover" not in result.text, "the internal verb does not belong in prose"
+        assert "browser bridge error" not in result.text
+        assert "the browser tab recovery" in result.text
+        assert (result.details or {}).get("error_code") == "internal"
 
 
 def test_the_undrivable_tab_copy_names_no_opaque_handle() -> None:
@@ -846,3 +1072,309 @@ def test_the_undrivable_tab_copy_names_no_opaque_handle() -> None:
     assert "(unknown)" not in rendered
     assert "bridge:12:deadbeef" not in rendered
     assert "'open' with a URL" in rendered
+
+
+# --- Audit round 1: A1 — the generation fence -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_old_send_deadline_cannot_sever_its_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A1, the daemon's command half. The most severe of the audit's findings.
+
+    An OLD `send_json` is suspended when the daemon's link is replaced by a
+    freshly healthy one. The old send's deadline then fires, and pre-fix
+    `_drop_unproven_link` captured `self.link.websocket` — the CURRENT socket —
+    closing the HEALTHY replacement with 4000 and failing every new session's
+    futures. Reproduced by the auditor against the pinned head:
+
+        {"new_closed":[4000],"new_still_attached":false,
+         "response":{"error":{"code":"extension_unresponsive",
+                              "data":{"phase":"send",...}}}}
+
+    The fence is what makes those two sockets distinguishable: the teardown is
+    scoped to the wire the caller decided about, and a caller whose wire is gone
+    is told so rather than being handed a lie about a peer that is answering.
+    """
+
+    monkeypatch.setattr(daemon_module, "LINK_SEND_TIMEOUT_S", 0.05)
+    service = BridgeService(root=tmp_path)
+    old = _StallingSendSocket()
+    service.link.attach(old)  # type: ignore[arg-type]
+    service.link.paired = True
+    service.link.last_frame_at = time.monotonic()
+
+    task = asyncio.create_task(
+        service._dispatch_serialized(
+            Request(id="r-old", method="read", params={"tab": "bridge:1:n"})
+        )
+    )
+    await asyncio.wait_for(old.entered.wait(), timeout=2.0)
+
+    # A later, healthy connection arrives while the old write is still in flight.
+    new = _RecordingSocket()
+    service.link.forget_link_state()
+    service.link.attach(new)  # type: ignore[arg-type]
+    service.link.paired = True
+    service.link.last_frame_at = time.monotonic()
+
+    response = await asyncio.wait_for(task, timeout=2.0)
+    body = bytes(response.body).decode().replace(" ", "")
+
+    assert new.closed == [], "the healthy replacement was severed by a stale decision"
+    assert service.link.websocket is new
+    assert service.link.dropped_unproven() is False, "nothing was severed, so nothing is latched"
+    assert ErrorCode.EXTENSION_DISCONNECTED.value in body
+    assert ErrorCode.EXTENSION_UNRESPONSIVE.value not in body
+    assert "notdelivered" in body.replace('"', ""), body
+
+
+@pytest.mark.asyncio
+async def test_an_old_ping_deadline_cannot_sever_its_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A1, the ping path — the same shape, and the audit names it explicitly.
+
+    `_ping_tick`'s bounded send is the other place a deadline can fire long
+    after the socket it was measuring stopped being the socket. A ping whose
+    send parks must not take the replacement down with it, or a single stalled
+    tick costs every session on a bridge that is now healthy.
+    """
+
+    monkeypatch.setattr(daemon_module, "LINK_SEND_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(daemon_module, "PING_INTERVAL_S", 0.01)
+    service = BridgeService(root=tmp_path)
+    old = _StallingSendSocket()
+    service.link.attach(old)  # type: ignore[arg-type]
+    service.link.paired = True
+    service.link.last_frame_at = time.monotonic()
+
+    tick = asyncio.create_task(service._ping_tick())
+    await asyncio.wait_for(old.entered.wait(), timeout=2.0)
+
+    new = _RecordingSocket()
+    service.link.forget_link_state()
+    service.link.attach(new)  # type: ignore[arg-type]
+    service.link.paired = True
+    service.link.last_frame_at = time.monotonic()
+
+    await asyncio.wait_for(tick, timeout=2.0)
+
+    assert new.closed == [], "a stale ping tick severed the live replacement"
+    assert service.link.websocket is new
+    assert service.link.dropped_unproven() is False
+
+
+@pytest.mark.asyncio
+async def test_a_superseded_frame_cannot_touch_the_live_link(tmp_path: Path) -> None:
+    """A1, the receive half: an abandoned connection keeps draining frames.
+
+    The audit inserted `bridge:1:old` into the NEW connection's driven records
+    through a frame that completed on the old socket
+    (`staleDrivenAccepted:true`). It is protocol fault injection rather than
+    proof that real Chrome delivers a post-close frame — but the receive loop
+    had no fence at all, so any buffered or delayed frame was processed as if it
+    belonged to the live link. This pins the fence on the LOOP BODY, not just on
+    the `finally` that already checked identity.
+    """
+
+    service = BridgeService(root=tmp_path)
+    stale = _FakePeer()
+    stale.push(_hello())
+    stale_task = asyncio.create_task(service.extension(stale))  # type: ignore[arg-type]
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if stale.sent:
+            break
+    assert stale.sent, "the handshake answer never went out"
+    first_generation = service.link.generation
+
+    live = _FakePeer()
+    live.push(_hello())
+    live_task = asyncio.create_task(service.extension(live))  # type: ignore[arg-type]
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if live.sent:
+            break
+    assert service.link.generation == first_generation + 1
+    assert service.link.websocket is live
+    assert stale.closed == [4000], "the superseded socket was closed"
+
+    # Freeze the live link's observable liveness, then let the stale socket
+    # deliver the frame it was sitting on.
+    service.link.last_frame_at = 1234.5
+    stale.push(
+        {"event": "tab_update", "tab": "bridge:1:old", "url": "https://old.test", "title": "OLD"}
+    )
+    await asyncio.sleep(0.05)
+
+    assert service.link.driven == {}, "a superseded frame published into the live link"
+    assert service.link.last_frame_at == 1234.5, "a superseded frame stamped liveness"
+    assert service.link.websocket is live
+
+    for task in (stale_task, live_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+# --- Audit round 1: A2 — the teardown close is bounded ----------------------
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_teardown_close_is_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A2: a close that never resolves must not park the recovery it IS.
+
+    `_drop_unproven_link` clears the link and then awaits `websocket.close()`;
+    pre-fix that await had no deadline, so a send-stalled peer left the
+    initiating RPC — or the ping supervisor — pending forever with the link
+    already cleared. The auditor's probe against the pinned head:
+
+        {"case":"drop with blocked close","link_cleared":true,"drop_completed":false}
+
+    Bounded here, and asserted through an outer `wait_for` so a regression fails
+    as a red assertion in ~0.05 s rather than as a hung test (RC=124 under
+    `-n auto --dist worksteal` is a killed worker carrying unrelated tests).
+    """
+
+    monkeypatch.setattr(daemon_module, "LINK_CLOSE_TIMEOUT_S", 0.05)
+    service = BridgeService(root=tmp_path)
+    socket = _StallingCloseSocket()
+    service.link.attach(socket)  # type: ignore[arg-type]
+    service.link.last_frame_at = time.monotonic()
+    service.link.paired = True
+
+    dropped = await asyncio.wait_for(
+        service._drop_unproven_link("audit stalled close"), timeout=2.0
+    )
+
+    assert dropped is True
+    assert socket.closed == [4000], "the close was never attempted"
+    assert service.link.websocket is None
+    assert service.link.dropped_unproven() is True
+
+
+# --- QA Q2-1 / review R2-1: a revoke clears the latch -----------------------
+
+
+@pytest.mark.asyncio
+async def test_a_revoke_clears_a_latched_unproven_drop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The latch must not outlive the pairing it describes.
+
+    `lop browser pair --reset` runs in ANOTHER process, so the only thing the
+    daemon can notice is the pairing file changing. Pre-fix the clear lived in
+    `revoke()`, whose every path requires a live socket (`_revocation_tick`
+    guarded on `websocket is not None and paired`) — and the latch exists only
+    AFTER `disconnect()` has nulled both. So for the rest of `LINK_DROP_TTL_S`
+    the daemon told every caller "attached and paired … pairing is preserved"
+    about a bridge the user had deliberately unpaired (QA Q2-1, mechanism added
+    by review R2-1).
+
+    The fix moves the clear to where the revocation is OBSERVED. No socket here
+    on purpose: that is the state a drop leaves behind, and the state the old
+    guard could not act in.
+    """
+
+    service = BridgeService(root=tmp_path)
+    service.link.extension_id = EXTENSION_ID
+    daemon_module._private_write(
+        daemon_module._pairing_path(tmp_path), {"extension_id": EXTENSION_ID, "token_hash": "x"}
+    )
+    service.link.note_unproven_drop(52.0)
+    assert service.link.dropped_unproven() is True
+    assert service.link.websocket is None
+
+    daemon_module.reset_pairing(tmp_path)
+    monkeypatch.setattr(daemon_module, "REVOKE_WATCH_S", 0.0)
+    await service._revocation_tick()
+
+    assert service.link.dropped_unproven() is False, "an unpaired bridge still reads as wedged"
+
+
+@pytest.mark.asyncio
+async def test_a_revocation_tick_leaves_a_live_pairing_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The inverse guard: a tick that finds the pairing intact changes nothing.
+
+    Without this half, clearing the latch unconditionally on every tick would
+    pass the row above and quietly disable the honest "attached but not
+    answering" answer for a bridge that is merely mute.
+    """
+
+    service = BridgeService(root=tmp_path)
+    service.link.extension_id = EXTENSION_ID
+    daemon_module._private_write(
+        daemon_module._pairing_path(tmp_path), {"extension_id": EXTENSION_ID, "token_hash": "x"}
+    )
+    service.link.note_unproven_drop(52.0)
+
+    monkeypatch.setattr(daemon_module, "REVOKE_WATCH_S", 0.0)
+    await service._revocation_tick()
+
+    assert service.link.dropped_unproven() is True
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_revoke_close_is_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A2's sibling: `revoke()` closes with 4003 and must not park either.
+
+    The same hole one function over, and this one is reached from the RPC gate
+    and from the revocation watcher — so an unresponsive peer could park the
+    revocation itself (audit A2 asks for the sibling closes explicitly, so that
+    the fix is not merely relocated).
+    """
+
+    monkeypatch.setattr(daemon_module, "LINK_CLOSE_TIMEOUT_S", 0.05)
+    service = BridgeService(root=tmp_path)
+    socket = _StallingCloseSocket()
+    service.link.attach(socket)  # type: ignore[arg-type]
+    service.link.paired = True
+
+    await asyncio.wait_for(service.revoke(), timeout=2.0)
+
+    assert socket.closed == [4003], "the 4003 revoke close was never attempted"
+    assert service.link.websocket is None
+
+
+@pytest.mark.asyncio
+async def test_a_superseded_socket_that_never_closes_does_not_park_the_accept(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A2's other sibling: the later-connection-wins eviction close.
+
+    A second browser profile arriving while the first is mid-close used to make
+    the ACCEPT path await that close, so the healthy new connection could not
+    finish its handshake behind a peer that never answers a close frame.
+    """
+
+    monkeypatch.setattr(daemon_module, "LINK_CLOSE_TIMEOUT_S", 0.05)
+    service = BridgeService(root=tmp_path)
+    first = _StallingClosePeer()
+    first.push(_hello())
+    first_task = asyncio.create_task(service.extension(first))  # type: ignore[arg-type]
+    assert await _settles(lambda: bool(first.sent)), "precondition: the first connection handshook"
+
+    second = _FakePeer()
+    second.push(_hello())
+    second_task = asyncio.create_task(service.extension(second))  # type: ignore[arg-type]
+    assert await _settles(
+        lambda: bool(second.sent)
+    ), "the replacement's handshake completed behind a stalled close"
+
+    assert first.close_entered.is_set(), "the superseded socket was asked to close"
+    assert second.sent, "the replacement's handshake completed behind a stalled close"
+    assert service.link.generation == 2
+    assert service.link.websocket is second
+
+    for task in (first_task, second_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task

--- a/tests/unit/browser_bridge/test_daemon.py
+++ b/tests/unit/browser_bridge/test_daemon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from contextlib import suppress
 from pathlib import Path
@@ -635,3 +636,198 @@ async def test_owner_keys_are_evicted_so_the_lock_map_cannot_grow(tmp_path: Path
             )
         )
     assert service._tab_locks == {}, f"proof keys retained: {sorted(service._tab_locks)}"
+
+
+# --- Audit round-2 re-audit: A4, the admission/response lifetime ------------
+#
+# The auditor's round-2 re-audit kept A4 at MAJOR: registering the pending
+# future BEFORE the admission lock (which the extension's early answer requires)
+# meant a caller cancelled while QUEUED never reached the only cleanup there
+# was. Their controlled run on the pinned head:
+#
+#     {"case": "cancel admission-only waiter before send",
+#      "pendingLeaked": ["cancelled-queued"], "framesSent": 0}
+#
+# Both rows below fail on `bb039c18e`.
+
+
+class _FakeWire:
+    """A scripted socket leg: records writes, and can park one mid-send.
+
+    ``release`` set means a write does not complete until the test says so,
+    which parks a caller INSIDE admission — holding or queued on its key —
+    without a wall-clock sleep. Every wait in these rows is on a frame count or
+    an event, per AGENTS.md, "Wait on the event, never on the clock".
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self.entered = asyncio.Event()
+        self.release: asyncio.Event | None = None
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+        self.entered.set()
+        if self.release is not None:
+            await self.release.wait()
+
+    async def close(self, code: int | None = None) -> None:
+        return None
+
+
+def _owner_request(request_id: str, proof: str) -> Any:
+    """An owner-scoped, no-tab command: the admission-only key shape."""
+    from local_operator.browser_bridge.protocol import Request
+
+    return Request(
+        id=request_id,
+        method="owner_recover",
+        params={"owner_proof": proof, "requester": "session:s1", "owner_generation": "g1"},
+    )
+
+
+async def _write_frames(wire: _FakeWire, count: int) -> None:
+    """Return once ``wire`` has recorded ``count`` writes (event, not a clock)."""
+    for _ in range(200):
+        if len(wire.sent) >= count:
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"only {len(wire.sent)} of {count} writes were attempted")
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_queued_admission_leaves_no_pending_future(tmp_path: Path) -> None:
+    """A4 (major): the cleanup must span registration → lock → send → response.
+
+    The auditor cancelled a waiter queued behind an admission-only lock, after
+    that waiter had already registered its future, and found the future still
+    registered with no frame sent and no answer possible. The leak is not merely
+    untidy: the request id stays occupied until link teardown, so repeated
+    client disconnects grow retained state on a long-lived healthy link.
+
+    The positive controls this row also pins: a cancelled queued caller sends NO
+    late frame, and the key it was queued on survives for the caller that still
+    holds it — eviction is the holder's exit, not the cancelled caller's.
+    """
+    from local_operator.browser_bridge.daemon import BridgeService
+
+    service = BridgeService(root=tmp_path)
+    wire = _FakeWire()
+    service.link.websocket = wire  # type: ignore[assignment]
+    service.link.last_frame_at = time.monotonic()
+
+    holder = _owner_request("r-holder", "h" * 32)
+    key = service.lock_key_for(holder)
+    wire.release = asyncio.Event()  # the holder parks inside admission
+    holder_task = asyncio.get_running_loop().create_task(service._dispatch_serialized(holder))
+    await _write_frames(wire, 1)
+
+    queued = _owner_request("cancelled-queued", "h" * 32)
+    queued_task = asyncio.get_running_loop().create_task(service._dispatch_serialized(queued))
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if queued.id in service.link.pending:
+            break
+    assert (
+        queued.id in service.link.pending
+    ), "precondition: the future is registered before the lock is granted"
+    assert len(wire.sent) == 1, "precondition: the queued caller has written nothing"
+
+    queued_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await queued_task
+
+    assert (
+        queued.id not in service.link.pending
+    ), "cancelling a queued request left a future registered for a frame that was never sent"
+    assert len(wire.sent) == 1, "a cancelled queued request sent a late frame"
+    assert service._key_callers.get(key) == 1, "the cancelled caller's hold on the key leaked"
+    assert key in service._tab_locks, "the key was evicted while its holder was still using it"
+
+    # The holder leaves cancelled too: THAT exit is what evicts the key.
+    holder_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await holder_task
+    assert service._key_callers == {}, "the caller counter leaked"
+    assert key not in service._tab_locks, "the key outlived every caller"
+
+
+@pytest.mark.asyncio
+async def test_a_key_another_caller_is_queued_on_is_not_evicted(tmp_path: Path) -> None:
+    """A4: eviction must not drop a lock a queued caller is about to take.
+
+    `asyncio.Lock.locked()` goes False the instant `release()` hands the lock to
+    the first waiter, so an eviction decided on `locked()` alone removed a lock
+    another request was already waiting on. That waiter then ran under a Lock
+    object the map no longer held, while the next request for the key minted a
+    SECOND one and interleaved with it — mutual exclusion lost for one owner's
+    commands. The structural assertion is that the map still holds the lock
+    object the queued caller is admitted under.
+    """
+    from local_operator.browser_bridge.daemon import BridgeService
+
+    service = BridgeService(root=tmp_path)
+    wire = _FakeWire()
+    service.link.websocket = wire  # type: ignore[assignment]
+    service.link.last_frame_at = time.monotonic()
+
+    holder = _owner_request("r-holder", "k" * 32)
+    key = service.lock_key_for(holder)
+    held_lock = service._tab_locks.setdefault(key, asyncio.Lock())
+    wire.release = asyncio.Event()
+    holder_task = asyncio.get_running_loop().create_task(service._dispatch_serialized(holder))
+    await _write_frames(wire, 1)
+
+    queued = _owner_request("r-queued", "k" * 32)
+    queued_task = asyncio.get_running_loop().create_task(service._dispatch_serialized(queued))
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if queued.id in service.link.pending:
+            break
+    assert queued.id in service.link.pending, "precondition: the queued caller registered"
+
+    # Let the holder's write complete. It then releases the lock, the queued
+    # caller takes it and writes its own frame — which is what proves the
+    # hand-off ran before the assertion below.
+    wire.release.set()
+    await _write_frames(wire, 2)
+
+    assert (
+        service._tab_locks.get(key) is held_lock
+    ), "eviction dropped the lock a queued caller was admitted under"
+
+    for task in (holder_task, queued_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_tab_command_leaves_no_pending_future(tmp_path: Path) -> None:
+    """A4, the sibling arm: the same leak existed on the lock-held path.
+
+    `_dispatch_locked` registers its future before `_admit` and relied on
+    `_complete`'s `finally` alone, so a caller cancelled mid-send left an
+    unanswerable future behind exactly as the admission-only arm did. Same
+    defect class, same guard — this row keeps the two arms from drifting apart.
+    """
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import Request
+
+    service = BridgeService(root=tmp_path)
+    wire = _FakeWire()
+    wire.release = asyncio.Event()
+    service.link.websocket = wire  # type: ignore[assignment]
+
+    request = Request(id="r-tab-cancel", method="read", params={"tab": "bridge:1:n"})
+    task = asyncio.get_running_loop().create_task(service._dispatch_serialized(request))
+    await _write_frames(wire, 1)
+    assert request.id in service.link.pending
+
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+    assert (
+        request.id not in service.link.pending
+    ), "a cancelled tab command left its future registered"

--- a/tests/unit/browser_bridge/test_daemon.py
+++ b/tests/unit/browser_bridge/test_daemon.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from contextlib import suppress
 from pathlib import Path
+from typing import Any
 
 import pytest
 from starlette.testclient import TestClient
@@ -172,7 +173,7 @@ async def test_await_access_does_not_block_request_access(tmp_path: Path) -> Non
 
     service = BridgeService(root=tmp_path)
 
-    async def serve(payload: dict[str, object]) -> None:
+    async def serve(payload: dict[str, object], *, wire: Any = None) -> None:
         request = Request.model_validate(payload)
 
         async def respond() -> None:
@@ -218,7 +219,7 @@ async def test_cancelled_await_evicts_its_lock_key(tmp_path: Path) -> None:
 
     service = BridgeService(root=tmp_path)
 
-    async def park_forever(payload: dict[str, object]) -> None:
+    async def park_forever(payload: dict[str, object], *, wire: Any = None) -> None:
         await asyncio.sleep(3600)
 
     service.link.send = park_forever  # type: ignore[method-assign]
@@ -252,7 +253,7 @@ async def test_await_lock_key_evicted_on_normal_and_error_exits(
     service = BridgeService(root=tmp_path)
 
     # Normal exit: the fake extension answers immediately.
-    async def answer(payload: dict[str, object]) -> None:
+    async def answer(payload: dict[str, object], *, wire: Any = None) -> None:
         request = Request.model_validate(payload)
         future = service.link.pending.get(request.id)
         if future and not future.done():
@@ -268,7 +269,7 @@ async def test_await_lock_key_evicted_on_normal_and_error_exits(
 
     # Error exit (timeout): the extension never answers; the daemon's command
     # timeout fires inside _dispatch_locked.
-    async def silent(payload: dict[str, object]) -> None:
+    async def silent(payload: dict[str, object], *, wire: Any = None) -> None:
         await asyncio.sleep(daemon_mod.COMMAND_TIMEOUTS["await_access"] + 0.5)
 
     service.link.send = silent  # type: ignore[method-assign]
@@ -463,3 +464,174 @@ def test_tab_closed_event_clears_driven_state_over_the_socket(tmp_path: Path) ->
             cleared = client.get("/health").json()
             assert cleared["current_url"] == ""
             assert cleared["driven_tabs"] == []
+
+
+# --- Audit A4 / scoping D2: the daemon's lock topology ----------------------
+
+
+def test_no_tab_commands_key_on_their_owner_not_the_daemon() -> None:
+    """A4: one owner's no-tab command must not spend another owner's budget.
+
+    `open`, `owner_recover`, `owner_finish`, `owner_retain` and `owner_release`
+    all carry no `tab`, so under the old rule every one of them keyed
+    `__global__` — and the lock was held for the WHOLE command, across a 30 s
+    navigation or a +65 s origin-approval wait. A parked `open` therefore blocked
+    a different owner's `open`, and the `owner_recover` whose entire job is
+    recovering from exactly that. The key is now the owner.
+    """
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import Request
+
+    key_of = BridgeService.lock_key_for
+    proof_a = "a" * 40
+    proof_b = "b" * 40
+
+    assert (
+        key_of(Request(id="r-1", method="open", params={"owner_proof": proof_a}))
+        == f"__owner__:{proof_a}"
+    )
+    assert (
+        key_of(Request(id="r-2", method="owner_recover", params={"owner_proof": proof_a}))
+        == f"__owner__:{proof_a}"
+    )
+    # Same owner, same key: its own ordering guarantee is what recovery needs.
+    assert key_of(Request(id="r-1", method="open", params={"owner_proof": proof_a})) == key_of(
+        Request(id="r-3", method="owner_finish", params={"owner_proof": proof_a})
+    )
+    # Different owners, different keys: independent progress.
+    assert key_of(Request(id="r-4", method="open", params={"owner_proof": proof_b})) != key_of(
+        Request(id="r-5", method="open", params={"owner_proof": proof_a})
+    )
+    # Proof-less commands keep the shared key (they read global state).
+    assert key_of(Request(id="r-6", method="tabs", params={})) == "__global__"
+    assert key_of(Request(id="r-7", method="status", params={})) == "__global__"
+    # A per-tab command is still per tab, and an empty/absent proof is not a key.
+    assert key_of(Request(id="r-8", method="goto", params={"tab": "bridge:1:n"})) == "bridge:1:n"
+    assert key_of(Request(id="r-9", method="open", params={"owner_proof": ""})) == "__global__"
+
+
+def test_only_the_owner_and_global_keys_release_after_admission() -> None:
+    """The duration half of D2, pinned structurally.
+
+    Per-tab keys MUST keep the whole-command span (that span is the CDP
+    interleave guard), and `await_access`/`__access__` keep their own spans.
+    Only the two keys the scoping change is about may be released at admission.
+    """
+    from local_operator.browser_bridge.daemon import BridgeService
+
+    admission_only = BridgeService._admission_only
+    assert admission_only("__global__") is True
+    assert admission_only("__owner__:" + "a" * 40) is True
+    assert admission_only("bridge:1:n") is False
+    assert admission_only("__access__") is False
+    assert admission_only("__await__:r-1") is False
+
+
+@pytest.mark.asyncio
+async def test_a_parked_open_does_not_block_another_owners_open(tmp_path: Path) -> None:
+    """The audit's repro inverted into a regression test.
+
+    Owner A's `open` is parked (standing in for a slow navigation or an approval
+    wait the extension is blocked on); owner B's `open` must be ADMITTED and
+    answered without waiting for it. Under the old `__global__` key B queued
+    behind A's whole command, so this test fails pre-fix.
+    """
+    import asyncio
+
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import Request, Response
+
+    service = BridgeService(root=tmp_path)
+
+    class _Socket:
+        def __init__(self) -> None:
+            self.closed: list[int | None] = []
+
+        async def send_json(self, payload: object) -> None:
+            return None
+
+        async def close(self, code: int | None = None) -> None:
+            self.closed.append(code)
+
+    service.link.websocket = _Socket()  # type: ignore[assignment]
+    service.link.last_frame_at = time.monotonic()
+    proof_a, proof_b = "a" * 40, "b" * 40
+    parked = asyncio.Event()
+
+    async def serve(payload: dict[str, Any], *, wire: Any = None) -> None:
+        request = Request.model_validate(payload)
+        if request.params.get("owner_proof") == proof_a:
+            parked.set()
+            return  # never answers, and never will
+        future = service.link.pending.get(request.id)
+        if future and not future.done():
+            future.set_result(Response(id=request.id, ok=True, result={"tab": "bridge:2:b"}))
+
+    service.link.send = serve  # type: ignore[method-assign]
+
+    def _params(proof: str) -> dict[str, Any]:
+        return {
+            "url": "https://slow.example",
+            "owner_proof": proof,
+            "requester": "session:s1",
+            "owner_generation": "g1",
+            "allocation_id": "a1",
+        }
+
+    first = asyncio.create_task(
+        service._dispatch_serialized(Request(id="r-a", method="open", params=_params(proof_a)))
+    )
+    await asyncio.wait_for(parked.wait(), timeout=2.0)
+    try:
+        second = await asyncio.wait_for(
+            service._dispatch_serialized(Request(id="r-b", method="open", params=_params(proof_b))),
+            timeout=2.0,
+        )
+        assert '"ok":true' in bytes(second.body).decode().replace(" ", "")
+    finally:
+        first.cancel()
+        with suppress(asyncio.CancelledError):
+            await first
+
+
+@pytest.mark.asyncio
+async def test_owner_keys_are_evicted_so_the_lock_map_cannot_grow(tmp_path: Path) -> None:
+    """Round-3 M1's defect class, reopened by the per-owner key.
+
+    A per-owner key is minted per session-resource, so without eviction
+    `_tab_locks` grows for the daemon's lifetime exactly as the `__await__` keys
+    did. N distinct owners must leave NO proof keys behind.
+    """
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import Request, Response
+
+    service = BridgeService(root=tmp_path)
+
+    class _Socket:
+        async def send_json(self, payload: object) -> None:
+            return None
+
+        async def close(self, code: int | None = None) -> None:
+            return None
+
+    service.link.websocket = _Socket()  # type: ignore[assignment]
+    service.link.last_frame_at = time.monotonic()
+
+    async def serve(payload: dict[str, Any], *, wire: Any = None) -> None:
+        request = Request.model_validate(payload)
+        future = service.link.pending.get(request.id)
+        if future and not future.done():
+            future.set_result(Response(id=request.id, ok=True, result={"state": "allocated"}))
+
+    service.link.send = serve  # type: ignore[method-assign]
+
+    for index in range(5):
+        proof = f"{index:040d}"
+        await service._dispatch_serialized(
+            Request(
+                id=f"r-{index}",
+                method="owner_recover",
+                params={"owner_proof": proof, "requester": "session:s1", "owner_generation": "g1"},
+            )
+        )
+    assert service._tab_locks == {}, f"proof keys retained: {sorted(service._tab_locks)}"

--- a/tests/unit/browser_bridge/test_daemon.py
+++ b/tests/unit/browser_bridge/test_daemon.py
@@ -11,7 +11,7 @@ from starlette.testclient import TestClient
 
 from local_operator.browser_bridge import state as state_store
 from local_operator.browser_bridge.daemon import create_app, pairing_status
-from local_operator.browser_bridge.protocol import PROTO_VERSION
+from local_operator.browser_bridge.protocol import PROTO_VERSION, Response
 
 EXTENSION_ID = "a" * 32
 ORIGIN = f"chrome-extension://{EXTENSION_ID}"
@@ -831,3 +831,112 @@ async def test_a_cancelled_tab_command_leaves_no_pending_future(tmp_path: Path) 
     assert (
         request.id not in service.link.pending
     ), "a cancelled tab command left its future registered"
+
+
+@pytest.mark.asyncio
+async def test_a_tab_close_does_not_evict_a_key_a_command_is_queued_on(tmp_path: Path) -> None:
+    """R4-1 (major): the per-tab `close` eviction had the defect R3-3 fixed elsewhere.
+
+    The admission-only arm was moved onto the per-key caller count, and the
+    sibling `close` arm was left testing `lock.locked()` alone — which is False
+    the instant `release()` hands the per-tab lock to its FIRST WAITER. A `close`
+    answering while another command for that same tab was already queued
+    therefore evicted the key under the waiter, the waiter ran under a Lock
+    object the map no longer held, and the next request for that tab minted a
+    SECOND one and interleaved with it:
+
+        {"key_evicted_while_B_was_queued": true, "B_still_in_flight": true,
+         "C_admitted_concurrently": true, "C_lock_is_a_SECOND_object": true,
+         "MUTUAL_EXCLUSION_LOST_FOR_TAB": true, "wire_order": ["A", "B", "C"]}
+
+    Two commands interleaving into one tab's CDP session is the reason the
+    per-tab key holds its lock for the whole command rather than releasing it
+    after admission, so losing it here costs more than it did on the
+    admission-only arm (where the extension's per-proof lane re-serializes on
+    arrival). Reachable whenever a session closes a tab another session is still
+    reading.
+
+    `Lock._waiters` is how this row observes that C is queued rather than merely
+    unscheduled — the state that makes the eviction unsafe.
+    """
+
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import Request
+
+    service = BridgeService(root=tmp_path)
+    wire = _FakeWire()
+    service.link.websocket = wire  # type: ignore[assignment]
+    service.link.paired = True
+    service.link.last_frame_at = time.monotonic()
+
+    closing = Request(id="r-close", method="close", params={"tab": "bridge:s-1"})
+    key = service.lock_key_for(closing)
+    held_lock = service._tab_locks.setdefault(key, asyncio.Lock())
+    wire.release = asyncio.Event()
+
+    close_task = asyncio.get_running_loop().create_task(service._dispatch_serialized(closing))
+    await _write_frames(wire, 1)
+
+    queued = Request(id="r-queued-read", method="read", params={"tab": "bridge:s-1"})
+    queued_task = asyncio.get_running_loop().create_task(service._dispatch_serialized(queued))
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if getattr(held_lock, "_waiters", None):
+            break
+    assert getattr(held_lock, "_waiters", None), "precondition: the queued caller is on the lock"
+
+    # Let the `close`'s write land and answer it, so it leaves the `async with` —
+    # which is where the eviction used to run, with the waiter woken by
+    # `release()` but not yet holding.
+    wire.release.set()
+    service.link.pending[closing.id].set_result(Response(id=closing.id, ok=True, result={}))
+    with suppress(Exception):
+        await asyncio.wait_for(close_task, timeout=2.0)
+
+    assert (
+        service._tab_locks.get(key) is held_lock
+    ), "a `close` evicted the key a command was already queued on"
+
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if queued.id in service.link.pending:
+            break
+    assert queued.id in service.link.pending, "the queued command never took the key"
+
+    # ...and the next request for that tab is queued behind it, not interleaved
+    # with it under a freshly minted Lock.
+    later = Request(id="r-later-read", method="read", params={"tab": "bridge:s-1"})
+    later_task = asyncio.get_running_loop().create_task(service._dispatch_serialized(later))
+    for _ in range(50):
+        await asyncio.sleep(0)
+    assert later.id not in service.link.pending, "a second command interleaved into one tab"
+    assert len(wire.sent) == 2, f"only two frames should have reached the wire: {wire.sent}"
+
+    for task in (queued_task, later_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    # The positive control the row would otherwise lose: an UNDISPUTED `close`
+    # still evicts the key. Without it, deleting the eviction outright would leave
+    # this row green while the unbounded map growth the eviction exists to stop
+    # came back.
+    fresh = BridgeService(root=tmp_path)
+
+    class _Answering:
+        async def send_json(self, payload: Any, *, wire: Any = None) -> None:
+            request = Request.model_validate(payload)
+            future = fresh.link.pending.get(request.id)
+            if future and not future.done():
+                future.set_result(Response(id=request.id, ok=True, result={}))
+
+        async def close(self, code: int | None = None) -> None:
+            return None
+
+    fresh.link.websocket = _Answering()  # type: ignore[assignment]
+    fresh.link.paired = True
+    fresh.link.last_frame_at = time.monotonic()
+    undisputed = Request(id="r-undisputed-close", method="close", params={"tab": "bridge:z:1"})
+    await fresh._dispatch_serialized(undisputed)
+    assert fresh._tab_locks == {}, "an undisputed `close` left its key behind"
+    assert fresh._key_callers == {}, "the caller counter leaked"

--- a/tests/unit/browser_bridge/test_daemon.py
+++ b/tests/unit/browser_bridge/test_daemon.py
@@ -295,6 +295,11 @@ async def test_heartbeat_loop_survives_publish_failure(tmp_path: Path, monkeypat
     monkeypatch.setattr(state_store, "HEARTBEAT_INTERVAL_S", 0.01)
     service = daemon_module.BridgeService(root=tmp_path)
     service.link.websocket = object()  # type: ignore[assignment]
+    # `publish` now derives extension_connected from `link.proven`, not from the
+    # bare socket object, so a fixture standing in for a CONNECTED extension has
+    # to carry a fresh liveness stamp — otherwise this test would fail on the
+    # connection bit rather than on the publish-failure recovery it is about.
+    service.link.last_frame_at = time.monotonic()
 
     calls = {"n": 0}
     real_publish = state_store.publish

--- a/tests/unit/tools/test_browser_tool.py
+++ b/tests/unit/tools/test_browser_tool.py
@@ -966,6 +966,12 @@ def test_every_action_degrades_without_cmux(monkeypatch) -> None:
     """Absence is not an error state: the tool is not advertised at all, and a
     host that forces it on gets one clear message per action, never a raise."""
     monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    # Hermetic: the demotion guard classifies the bridge from the DISCOVERY FILE,
+    # so without this the developer's own daemon decides which copy this test
+    # sees — and whether it sees the guard at all (a fresh bridge would hand the
+    # tool a real backend and there would be no "not available" text at all).
+    # Pin "no daemon" explicitly.
+    monkeypatch.setattr(builtin, "_bridge_liveness", lambda: (None, None))
     assert builtin.build_browser_tool(_ctx()) is None
     forced = builtin.AgentTool(
         name="browser",
@@ -1356,3 +1362,65 @@ def test_run_cmux_kills_the_child_when_the_turn_is_cancelled(monkeypatch) -> Non
     asyncio.run(scenario())
     assert proc.killed, "the cmux child was left running"
     assert proc.waited, "an unreaped child is a zombie until the operator exits"
+
+
+def test_a_running_bridge_with_no_browser_is_not_reported_as_unconfigured(monkeypatch) -> None:
+    """Design D3-2: a drop is not an unconfigured host.
+
+    After the daemon severs a silent link, `extension_connected` is false, so
+    `state_store.liveness()` answers ABSENT and the demotion guard fires — and it
+    used to tell the reader to run `lop browser install` to "set up the bridge",
+    on a machine where the bridge is installed, paired and running. The same
+    session's later `recover` got the good copy, so the incident's own window was
+    the one place the answer was wrong (design D1/D2-1's class, on a third site).
+
+    Two shapes, both keyed on facts the file already carries: the daemon
+    latched a silent link (the wedge), or the browser simply is not attached
+    right now. Neither names an install, and both carry a typed `error_code` so
+    the agent can branch to the remedy instead of substring-matching prose.
+    """
+    from local_operator.browser_bridge import state as state_store
+
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+
+    def classify(*, extension_unresponsive: bool):
+        # `pid` is THIS process, so the classification is about a live daemon;
+        # the guard reads the state object directly, so no socket is opened.
+        current = state_store.BridgeState(
+            pid=os.getpid(),
+            port=4099,
+            session_key="s" * 32,
+            proto=1,
+            extension_connected=False,
+            paired=False,
+            extension_id="a" * 32,
+            browser_name="Chrome/153",
+            extension_unresponsive=extension_unresponsive,
+        )
+        return lambda: (state_store.Liveness.ABSENT, current)
+
+    forced = builtin.AgentTool(
+        name="browser",
+        label="Browser",
+        description="d",
+        parameters={},
+        approval_tier="write",
+        concurrency="shared",
+        execute=builtin.execute_browser,
+    )
+
+    # 1. The wedge: the daemon dropped a link for silence and says so.
+    monkeypatch.setattr(builtin, "_bridge_liveness", classify(extension_unresponsive=True))
+    wedged = _run(forced, "t1", {"action": "tabs"}, _ctx())
+    assert wedged.is_error
+    assert "lop browser install" not in wedged.text
+    assert "stopped answering" in wedged.text, wedged.text
+    assert (wedged.details or {}).get("error_code") == "extension_unresponsive"
+
+    # 2. No browser attached, no latch: still not an unconfigured host.
+    monkeypatch.setattr(builtin, "_bridge_liveness", classify(extension_unresponsive=False))
+    idle = _run(forced, "t2", {"action": "tabs"}, _ctx())
+    assert idle.is_error
+    assert "lop browser install" not in idle.text
+    assert "remembers this browser" in idle.text, idle.text
+    assert (idle.details or {}).get("error_code") == "extension_disconnected"


### PR DESCRIPTION
Release: patch — an unresponsive browser extension no longer wedges every session: the daemon detects a mute peer, stops advertising it as connected, fails commands fast with an actionable message, and the extension's shared command chains self-drain so one stuck Chrome call can no longer park every later command.

## Why

Three sessions went dead at the same instant, `lop browser status` reported
`extension connected: yes` throughout, and `owner_recover` — the command whose
entire job is recovery — answered "requires an updated Local Operator
extension". Two independent defects composed:

1. **A hang is not an error.** Every module-level serialized chain in the
   extension is built as `queue.catch(() => {}).then(op)` so "each link swallows
   its predecessor's failure so the chain cannot poison later calls". That is true
   for a **rejection** and false for a **hang** — `.catch()` never runs on a
   promise that never settles. One stuck chrome/CDP call parked every later
   command, for every session, because the chains (`groupQueue`, `storeQueue`,
   `axQueue`, the per-`owner_proof` ownership lane) are module-global.
2. **The daemon had no liveness bound.** `publish()` and `/health` derived
   `extension_connected` from `link.websocket is not None`, which is true whenever
   TCP is up and the peer has not closed — so a mute peer was advertised as
   healthy, `state.liveness()` acquitted it, and the popup and CLI repeated it.

**Reproduced on the real path** (Chrome 153.0.8010.37, a driven tab whose
renderer stopped answering while the worker stayed healthy):

| probe | result |
|---|---|
| `read` (owner 1, stuck tab) | 20.040 s → `internal` / `read timed out` `{timeout_s: 20.0}` |
| `tabs` (owner 1) | 20.014 s → `tabs timed out` → the poison is the **per-owner lane** |
| `tabs` / `open` (owner 2, own proof) | 2.915 s ok / 0.712 s ok → **per-owner**, not global |
| `read` repeated after the daemon dropped the link | 20.030 s → timed out again → the daemon's deadline does not heal the worker |
| `owner_recover` (owner 1) | 20.020 s → rendered as "requires an updated Local Operator extension" |
| `/health` | **42/42 samples** over the 84 s window: `extension_connected: true, paired: true` |

A second real flavour: socket open, nothing serviced (worker stopped) — `read`
20.006 s, `open` 30.017 s, 32/32 health samples "connected"; worker *death* by
contrast gives typed `extension_disconnected` in 0.046 s. Measured recovery:
browser restart 0.5 s, daemon restart 1.52 s, popup wake 2.26–5.13 s, reconnect
alarm floor 58.21 s.

## What changed

**P1 — bound the awaits inside the ops (the cure).** One helper, `settle.ts`'s
`deadline()`, now wraps every chrome API await inside the extension's serialized
chains, with the per-call-class ceilings collected in one table (CDP command 15 s;
attach/detach 5 s; `chrome.tabs`/`tabGroups`/`storage` — session **and** `local`,
every grant write in `access-grants.ts` included — /`alarms` 5 s; `executeScript`
15 s). The two page-work ceilings were **raised from 10 s in round 1** on QA's own
measurements (7.49 s `read`, 10.91 s `screenshot`, against the 20 s `read` budget);
see the round-1 section below for the derivation and the load A/B. It rejects `internal` + `data.stalled`, which is this
protocol's existing pattern — a **new wire code would be silently dropped** by an
already-released daemon, because `ErrorDetail.code` is typed to the enum and a
`Response.model_validate` failure is a silent `continue`. The deadline makes the
op **settle**, which is what lets the chain drain; bounding the *chain* instead is
the documented double-spend and is explicitly not done.

**P2 — the daemon stops lying and self-heals.** `ExtensionLink.last_frame_at` +
`proven` (any frame within `LINK_SILENCE_TIMEOUT_S = 50 s`), `publish()` /
`/health` / `repair()` keyed on it, teardown (close **4000**) from the ping tick /
`rpc()` gate / command-timeout promotion rule, three
additive `/health` fields (`extension_unresponsive`, `link_attached`,
`link_silent_s`), a new client-facing `ErrorCode.EXTENSION_UNRESPONSIVE` with its own
copy, and a `lop browser status` line that distinguishes "attached but not
answering" from "not currently attached" — in BOTH the still-attached and the
just-severed window, because the reason for the drop is **latched**
(`LINK_DROP_TTL_S = 60 s`) rather than derived from a socket the teardown itself
nulls. For that window `rpc()` answers `extension_unresponsive`
(`phase: "dropped"`) rather than `extension_disconnected`, so the retry the error
copy advises cannot land on "no browser is attached".

**P2's promotion rule, as it actually ships (round 2 changed its shape).** Round 1
raised its silence threshold to `PING_INTERVAL_S * 1.5` (30 s) after reproducing it
tearing down a HEALTHY peer at zero slack — but 30 s exceeds the 20 s budget of
`read`/`snapshot`/`screenshot`, so the rule went **inert for exactly the methods the
record introduced it for**, and lowering the number is not available (any threshold
at or below one ping interval re-opens the healthy-link teardown, because the daemon
cannot tell a delayed tick from a dead peer by looking at a clock). It now ASKS the
peer instead of inferring: a bounded solicited ping (`PING_PROBE_TIMEOUT_S = 5 s`)
whose non-answer is the corroboration, with the elapsed-silence test kept as a
short-circuit fast path. A healthy worker answers within one event-loop turn
whatever a command is doing, so the probe cannot false-positive; 5 s is a magnitude
below every method's budget, so it fires for the 20 s methods too.

**P3 — `recover()` stops misdiagnosing.** A daemon-side timeout is now
discriminated by `data.timeout_s` (which only the daemon's timeout branch sets),
so a timeout no longer reports "update your extension" while a genuinely old
extension still does. Round 1 found the discriminator was **incomplete**: the new
`deadline()` is a SECOND producer of a data-bearing `internal` (`data.stalled`, no
`timeout_s`) and `owner_recover` reaches it, so the predicate now requires the
absence of BOTH keys — a timeout and a stall are both "the extension is wedged",
and only a key-less `internal` still means "this build predates ownership".

**P4 — a completed response the socket cannot carry is logged, not silently
dropped** (the 23 `RuntimeError('extension disconnected')` events in the live log
are this path).

**P5 — `link.send()` is bounded, including `send_lock` acquisition, and so is the
ping send.**

## Additional findings (not in the design record) — flagged for review rather than buried

**A1 — `cdp.ts attach()` for another extension's page.** A refusal with Chrome's
"Cannot access a chrome-extension:// URL of different extension" surfaced as a
generic `internal` and, unlike a failed `chrome.tabs.get`, did **not** prune the
surface — so every later command for that surface failed identically, including a
fresh `open`.

*Provenance, stated precisely:* this is a **live sighting from the reporter's own
browser** (the message, and the stickiness: a `scroll` timeout, then this message
on the retry, then the same on `open`). We could **not** reproduce it in our rig —
Chrome 153 let a second extension's `attach` succeed alongside ours — so the path
is **untested in the rig, not refuted**. The call sites that can throw it are
`chrome.debugger.attach` and, indirectly, the `ownAttachment` probe. Fix: a typed
`internal` + `data.undrivable_tab` (the `tab_crashed` pattern) **and** a surface
prune so the session recovers by opening a new tab.

**A2 — `worker.ts` uncaught rejection.** `void chrome.runtime.sendMessage({event:
"origin_prompt"})` with no popup open rejects with "Could not establish
connection. Receiving end does not exist." and surfaced in the worker console as
`Uncaught (in promise)`, captured from the operator's hands. A rejection must not
be able to surface as an uncaught error in the worker; contained via a
`fireAndForget()` helper, and audited across the other `void chrome.*` /
floating-promise call sites (`connState` writes, the pairing token write) which
had the same shape.

## Verification

**Gates** (worktree `~/local-operator-worktrees/bridge-wedge`, own venv, from
`origin/main` @ `20d8c596c`; all re-run on the round-1 head):

- `flake8 .` — clean
- `black --check .` (pinned `black==26.1.0` via `uvx`) — 1233 files unchanged
- `isort --check .` (pinned `isort==5.13.2` via `uvx`) — clean
- `pyright --pythonpath .venv/bin/python .` — **0 errors, 0 warnings**
- `pytest tests/unit -q` — **3 failed, 18633 passed, 18 skipped, 692 warnings in 5627.33s (1:33:47)**. The 3 failures are
  host artefacts, not this diff: `tui/test_analytics_panel.py` (viewport under load),
  `evaluation/evidence/test_store.py` (**OSError: ENOSPC** — the disk filled during the
  run), and `session/test_attach_frame_size.py` (backoff race). All 4 related tests
  pass in isolation on this same head at load ~12, and none touches
  browser_bridge/cli/guides.
- extension, exactly as `extension.yml` runs it — `tsc --noEmit` clean, `node --test tests/*.test.mjs` **170 passed / 0 failed**, `node build.mjs` ok, `python -m local_operator.browser_bridge.gen_ts --check` ok
- `pytest tests/e2e/test_browser_ownership.py -m e2e -n0` — **7 passed**
- real path, isolated root + real daemon + real CLI — **10/10 checks passed** (see the round-1 section)
- mutation sweep — **10/10 round-1 guards red cleanly when their fix is reverted, none hung** (see the round-1 section)


**Tests** — all 19 rows of the design record's §8.1 (daemon) and §8.2
(extension), plus the two additional findings. Each is proven to fail on the
pre-fix tree by mutating the fix and watching the row go red — **18 of 18 rows
proven**, with the raw run pasted in a follow-up comment. D4/E6 are the
characterisation rows the record flags, marked as such in their docstrings rather
than claimed as guards; D6 and E5 are the inverse guards ("still refuses where it
should"), proven red by making the change unconditional.

The tests assert **structural invariants**, never wall clocks: D2 asserts the
request never reached the wire (`sent == []`) rather than that it "failed fast";
D7 asserts the per-tab lock is free and the *next* command on that key answers;
E1–E3 assert the chain **drained** and the following command ran. That
second-call property is the one that fixes the incident — a bounded failure is
only useful if the next command works.

**What a green suite does NOT prove** (record §8.3, QA's matrix): that the pong
is really un-queued in a real MV3 worker under a real hang; that the ~1 s
fast-path reconnect fires on a real worker without a reconnect storm; that a real
pending approval survives a detector-driven teardown; and the mixed-version pairs
both directions. The CDP/scripting ceiling is no longer on this list: QA measured
real work at 7.49 s and 10.91 s, so the bound was **raised to 15 s** (still
strictly inside the 20 s `read`/`snapshot`/`screenshot` budget) rather than
defended at 10 s. The popup's new unresponsive card is pinned by a render test, not
by a Chrome screenshot: the popup is served BY the worker, so the state is usually
unopenable in real Chrome (record §11), and no headless engine may be installed on
this host.

**Isolation facts** for everything run locally: own worktree + own venv;
`LOCAL_OPERATOR_CONFIG_DIR`/`HOME` untouched default roots are never written by
the tests (they use `tmp_path`); no daemon was started on 4099; `lop browser
install`/`restart` was never run against `~/.local-operator`; the operator's
Chrome, the live bridge and `extension/dist` were not touched (the loaded build
is unchanged; `dist/` is gitignored and was rebuilt only inside this worktree).
No TUI or fork was booted, and `CMUX_*` was unset for every subprocess.

## Deviations from the design record

1. **`BridgeCommandError` moved to a new `extension/src/errors.ts`** (re-exported
   from `cdp.ts`, so no import site changed). Not cosmetic: `cdp.ts` registers a
   module-level `chrome.debugger.onDetach` listener, so `settle.ts` importing the
   class from it created a `cdp → settle → cdp` cycle; once `state.ts` needed the
   same class, bundling a storage-only module dragged the CDP layer (and its
   load-time side effect) into every such bundle, and the storage/grouping unit
   harnesses failed at load with `Cannot read properties of undefined (reading
   'onDetach')`. `deadline()` itself is in `settle.ts` as the record requires.
2. **`_drop_unproven_link` clears the link before it closes the socket** (the
   record writes `close → disconnect → publish`). `disconnect()` is what fails
   every pending future; `close()` is a send and can block on a peer that stopped
   draining — the exact P5 hazard. Ordering the close first makes the teardown the
   next thing that can hang. The close still goes out; a peer that never sees it is
   already the disconnected path.
3. **`repair()` reads `proven` too** (the record names `publish()` and
   `/health`). Leaving it on the bare socket would have had `/repair` dispatch a
   `tabs` RPC that now fails fast and then clear nothing — the record's own §9.6
   risk item.
4. **D7's structural half asserts the lock is free and the next command answers**,
   not `_tab_locks == {}` as the record phrases it: the per-TAB key is
   deliberately retained until `close` (evicting it between commands would let two
   sessions interleave on one tab).
5. **Two extra sites bounded beyond the record's table**, both by the record's own
   rule rather than against it: `chrome.alarms.clear` in `armNextExpiry` (an await
   inside the approval-store lane) and the pairing-token `chrome.storage.local.set`
   in the worker's message handler (a floating promise that can reject).
6. **`tests/unit/browser_bridge/test_daemon.py`'s heartbeat fixture** now stamps
   `link.last_frame_at`: its bare `object()` websocket stood in for a *connected*
   extension, and `publish()` reads `proven` now. The test's subject (recovery
   from a failed publish) is unchanged.

## Round 1 remediation (one commit round)

One commit, `a733b08a402ee747e3710431eb121f0593227056`, answers all three round-1 reports. Per-finding
dispositions are in the three remediation comments on this PR
(`### Agent review remediation — round 1`, `### QA remediation — round 1`,
`### Design review remediation — round 1`). In one place, the substance:

- **R1-1 (blocker)** — the `internal` + `stalled` producer no longer renders as a
  version mismatch on `owner_recover`; the predicate excludes both discriminators.
- **D1 (blocker)** — the `EXTENSION_UNRESPONSIVE` copy was rewritten to name only
  actions that measurably work, and the retry no longer lands on
  `extension_disconnected`: the daemon keeps answering `extension_unresponsive`
  (`phase: "dropped"`, `link_attached: false`) for the 60 s latch window. The
  shipped string is:

  > the browser extension is attached and paired but has stopped answering, so the
  > browser cannot be driven. Retry once in a few seconds. If the same action fails
  > again the worker is wedged and only a reload clears it: ask the user to toggle
  > the Local Operator extension OFF then ON in chrome://extensions — pairing is
  > preserved, but open tab handles, snapshot refs and pending site decisions are
  > lost, so re-'open' and re-'snapshot' afterwards. A daemon restart does not help.

- **D2 / R1-5 / Q1** — the drop reason is latched (`ExtensionLink.silent_drop_*`,
  `LINK_DROP_TTL_S = 60 s`), reported by `/health` (`extension_unresponsive`,
  `link_attached`, `link_silent_s`), and printed by `lop browser status` in both
  halves with the tense that is true (`…will drop and re-dial the link…` before the
  severing, `…dropped the link and is re-dialling it…` after), so a browser that is
  genuinely closed stays the only state carrying "not currently attached". The
  GUIDE's claim now matches what is shown.
- **R1-2 (major)** — the promotion rule carries `PING_INTERVAL_S * 1.5` of slack,
  with boundary tests on both sides.
- **R1-3 (major)** — all 11 bare `chrome.storage.local.*` awaits in
  `access-grants.ts` are bounded (same helper, same lane: `withSessionMutation` IS
  `withStore`), the `state.ts` comment now names the closed inventory instead of
  overstating the coverage, and the set is a single documented grep.
- **D4 (major)** — the popup consumes `extension_unresponsive` and renders a
  dedicated `#unresponsive` card with the measured toggle remedy instead of a green
"Connected." card over a mute worker, pinned by a render test across render N and
  N+1.
- **D5 (major)** — `internal` + `timeout_s` names the action, its budget and the
  remedy instead of a raw code.
- **R1-4, R1-6, R1-7, D3, D6, D7 (minors/nit)** — see the three comments; D7's
  "toggle OFF then ON" is now the wording everywhere including the GUIDE.
- **Q3 (decided with evidence, not split)** — the page-work ceilings were RAISED to
  15 s on QA's measurements and the load A/B (9/16 fixed vs 14/16 pre-fix at load
  190–290; 16/16 both at normal load), staying strictly inside the nesting
  invariant (`extension deadline < daemon budget`, 15 s < 20 s). Recorded in
  `settle.ts` and the record's §5.4 table with the numbers that drove it.

## Not addressed

Nothing in the round-1 reports is deferred. Round 2 adds four deferred items,
each recorded with the reason and the evidence that would promote it (in the
audit-remediation comment); no GitHub issue was opened for any of them:

1. **`onceGrants` late-write residue** (`A5`/`D4`) — a late `storage.set` could
   restore an already-spent one-shot grant. Bounded to one requester re-spending
   its own grant inside its own 10-minute TTL, and a consent-surface change that
   wants its own review round and repro.
2. **Bounding `liveSurfaces`' loop** — the pre-existing `8 x 5 s` worst case for
   `tabs`/`status`, now inside the admission window. A stalled `chrome.tabs.get`
   must not prune a live surface, so it needs its own pruning-semantics work.
3. **Admission-deadline check at the lane entry** — needs a generated daemon-budget
   constant that does not exist; the narrowing removes the long queue wait that made
   late allocation reachable, and the orphan already self-heals through the
   pre-handler journal write -> `owner_recover`.
4. **`D2-4`'s connected card for a paired, not-attached link** — recorded follow-up,
   as the designer framed it; the honest copy there is its own small piece of work
   and must not reuse the `disconnected` card's wording.

Round 4 adds one more deferred item, recorded with its repro and numbers in the
round-4 remediation comment:

5. **`D4-1` — the `_bridge_absent_result` demotion branch asserts a dead pid is
   running.** Reachable only when a daemon exits without clearing its own
   discovery file (`state.remove()` runs on a clean shutdown); the copy's terminal
   advice (`lop browser status`) is the surface that reports the truth, so it is
   a minor rather than a misdirection. The promotion evidence is a `pid_alive`
   split in that branch's copy. The `D3-1` connected-with-URL residual stays
   deferred as well (item 4's neighbour; its table is above under Round 3).

Two further things were **not** changed on purpose:

1. `docs/design/branding-bridge.md`'s popup microcopy list is left alone: it is a
   branding artifact with retired "Patch" naming whose connected/pairing copy
   already diverges from what ships, so adding a state to it would be inventing a
   contract nobody reads rather than documenting one.
2. QA's `Q4` was a deviation QA disclosed in its own round (one read-only
   `/health` to the operator's daemon from a cell with no discovery file) and is
   not this diff's; `Q2` was recorded with no action by QA itself.

The design record's rejected alternatives (a 4005 "recycle" close, timing out the
chain head, retrying inside the daemon, a `PROTO_VERSION` bump) are rejected on the
record's evidence and none is reintroduced here.



## Round 2 remediation (one commit round)

One commit, `bb039c18e24b631c0596c58a15b1c4c635a843d8`, applied **on top of**
`a733b08a4` rather than amending it, so the independent audit can scope exactly
`a733b08a4..bb039c18e`. Per-finding dispositions are in the four remediation
comments on this PR (agent review, QA, design, and the concurrency audit). The
substance:

- **Audit `A1` (major) — asynchronous completions are fenced to their connection
  generation, on both layers.** The daemon's `link.send` is scoped to the wire its
  caller captured and every teardown is checked against that wire across every
  await (including the ping path); the receive loop re-checks authority after each
  frame, so a superseded socket cannot stamp liveness or publish into the live
  link's records; the replacement is installed *before* the old socket's close is
  awaited; and the worker binds each dispatch's response and request-generated
  events to the wire the request arrived on, dropping (with a log) anything that
  would land on a different wire. Pre-fix, an old send's deadline closed a fresh
  HEALTHY link with 4000 and failed every new session's futures, and an old
  request's `tab_update` + response were delivered on the replacement socket.
- **Audit `A2` (major) — the silent-link teardown's close is bounded, and so are
  its siblings**: the later-connection-wins eviction close, `revoke()`'s 4003 close,
  and the two handshake sends. A never-resolving close no longer parks the RPC, the
  revoke or the accept path inside the recovery it performs.
- **Audit `A3` (major) — the AX lane is per target tab.** A global lane is only safe
  if `3 x ceiling <= ~15 s` (ceiling <= 5 s), and a legitimate heavy `screenshot`
  was measured at 10.91 s, so no measured-compatible ceiling makes a global lane
  safe. Same-tab exclusivity and drain-eviction are preserved.
- **Audit `A4` (major) — the shared lanes are scoped, D2 and D3 in the same
  commit.** Daemon no-tab commands key on `owner_proof` (per-TAB keys unchanged)
  and those keys are held for ADMISSION only; proof keys are evicted after use.
  Extension pool admission moves to `state.ts`'s `withAdmission`, wrapping exactly
  cap-read -> `tabs.create` -> `putSurface` — the surfaces map is what the cap
  counts — with attach, log capture, grouping, navigation and rollback outside it.
  The daemon's `__global__` key was the cap's only *current* guard (a proxy: the
  daemon does not know `MAX_SURFACES`), so removing it without moving the guard
  onto the data would be a regression; both land together.
- **Audit `A5` (minor) — UNPROVEN and non-gating, as the auditor itself frames it.**
  No guard is added and nothing claims native Chrome storage reordering. The
  per-call-class policy is written down at `settle.ts`'s `deadline()`: a deadline
  makes the op SETTLE, it does not cancel the mutation; five of six write classes
  name the mechanism that already reconciles a late write; the one genuine residue
  (`onceGrants`) is requester- and TTL-bounded and deferred with the evidence that
  would promote it; and the ordering hypothesis is recorded as unproven with the
  fixture that would settle it.
- **`R2-1`/`Q2-1` (major)** — a revoke clears the latched drop reason where the
  revocation is OBSERVED (the watcher that re-reads the pairing file), so the
  out-of-process `lop browser pair --reset` path clears it; within one
  `REVOKE_WATCH_S` tick.
- **`R2-2`/`D2-1` (major)** — the recovery command renders its failures through
  `format_error` with the human phrase `the browser tab recovery` and carries the
  typed code in `details`, so it stops answering with the raw `owner_recover timed
  out`; the guard now drives the tool boundary, where it used to pass vacuously.
- **`R2-3`/`Q2-4` (major/minor)** — see P2 above: the promotion rule's shape
  changed so it can fire for the methods it was introduced for, and the raised 15 s
  ceiling's real cost is disclosed rather than described as "gain".
- **`R2-5`/`Q2-3` (minor)** — the popup reads the unresponsive branch before its
  link-derived `paired` gate, so the latched half shows the honest card instead of
  the pairing form; `D2-2` aligns the card's loss list with the error copy;
  `D2-3` narrows the doc's reachability claim to what was measured.
- **`R2-4`, `R2-6`, `Q2-2` (minor/nit)** — comment and copy honesty: the key-less
  `internal` set is no longer claimed closed (`worker.ts`'s catch-all emits it from
  a current build too), `recent_drop_silence()` is read after the guard that gives
  it meaning, and the GUIDE's closed-browser line is scoped to the 60 s window.
- **Extension version → `0.1.11`** in `extension/manifest.json` and
  `extension/package.json`, because an extension-behaviour PR must carry the bump
  it ships. `pyproject.toml` is untouched.

**Gates on `bb039c18e`** (all re-run; full raw output in the audit comment):

- `flake8 local_operator tests` — clean
- `black --check local_operator tests` — 1060 files unchanged
- `isort --check-only local_operator tests` — clean
- `pyright --pythonpath .venv/bin/python .` — 0 errors, 0 warnings
- `pytest tests/unit -q` — from a clean full-tree run on this head
- `pytest tests/unit/browser_bridge -q -n0` — 251 passed
- extension, exactly as `extension.yml` runs it — `tsc --noEmit` clean,
  `node --test tests/*.test.mjs` 176 passed / 0 failed, `node build.mjs` ok,
  `gen_ts --check` ok
- `pytest tests/e2e/test_browser_ownership.py -m e2e -n0` — 7 passed
- mutation sweep — **17 of 17 new guards red cleanly when their fix is reverted,
  none hung** (no RC=124); raw output in the audit comment.

**Disclosed costs, so they are not re-derived as bugs later** (addendum `D5`):

1. The 20 s trio (`read`/`snapshot`/`screenshot`) has only ~1-2 s of margin against
   a single 15 s stall plus healthy work — a `snapshot` is three sequential cdps in
   one budget. Raising 20 s is a daemon-budget change with client-timeout
   consequences, so it is not done here.
2. `tabs`/`status` keep a PRE-EXISTING `8 x 5 s = 40 s` worst case in
   `liveSurfaces`, which `withAdmission` now pulls *inside* the admission window.
   Bounding that loop needs pruning-semantics work (a stalled `chrome.tabs.get`
   must not prune a live surface) and is deferred with the repro that would
   promote it.
3. A stalled `putSurface` can transiently over-admit by one (nine surfaces for as
   long as the write is in flight); it self-corrects on the next `liveSurfaces`.

**What a green suite still does NOT prove here**: the popup card is a DOM-level
render of the shipped module against captured `/health` payloads, not a Chrome
screenshot (the popup is served by the worker that stopped answering); the
concurrency lanes are exercised against synthetic transports and fixture gates, not
a real multi-owner browser session — QA's live multi-owner matrix is the place for
that, and it is requested in the round-2 comments rather than claimed here; and the
daemon's response phase being key-independent is the one claim I am asking the
auditor to confirm rather than asserting.

## Round 3 remediation (one commit round)

Commit `90615d76c709d56f827b78fdb85a9b6a748cf90a` on top of `bb039c18e` (a new commit, deliberately not amended, so the review and audit scope is exactly `bb039c18e..90615d76c`). It answers the round-3 agent review (`R3-1`–`R3-6`), the independent concurrency audit's round-2 re-audit (`A1`, `A4`), the design round (`D3-1`–`D3-3`) and QA's two minors (`Q3-1`, `Q3-2`).

**A1 (blocker) — a handshake that lost authority could still authorize a peer.** The authoritative install (identity, browser, latch, liveness, `paired`) now completes with no await between `attach()` and `publish_safely()`, and the superseded socket's bounded close moved below it, so a handshake that loses authority has nothing left to write. Pre-fix, a third handshake arriving inside that close window installed itself and the suspended one then stamped `paired: true` onto it: an unauthenticated peer whose token the daemon had just rejected was authorized and driven with a real command (`rpc` `not_paired` before, `ok` after). The `hello_ack` is separately fenced by `is_authoritative`, and `revoke()` now captures `(websocket, generation)` together and guards its trailing `disconnect()`, so a scoped revoke no longer tears down the replacement its own close await allowed to arrive.

**A4 (major) — the pending-future lifetime is cancellation-safe.** Registration happens before the admission lock (the answer may arrive while the caller is queued), so a caller cancelled while queued never reached the only cleanup there was; both dispatch paths now clean up from a `finally`, removing the future by **identity**. Key eviction is waiter-safe via a per-key caller count, because `asyncio.Lock.locked()` goes False the instant `release()` hands the lock to its first waiter — deciding on it evicted a lock another request was already queued on.

**R3-4 (major) — "superseded" and "torn down by a sibling" were one arm.** Two sessions timing out on one frozen worker is this PR's own common case: the first severs the link (socket nulled, generation unchanged), the second's fence then refused and answered "the extension replaced its connection" for an open, mute browser. One classifier, `_wire_loss()`, separates replaced / severed / gone, on **both** paths into that arm (the fence the reviewer reproduced, and the failed-future path a sibling's teardown sends a command down instead).

**D3-1 (major, design) — the popup's first-paint pin belongs to the card that was rendered.** Three measured pins (86 / 219 / 254px at 300x600) recorded by `show()`; the wedge state's reopen reflow goes **168.77px → 0.77px**, measured in a real headless Chrome render of the shipped markup, with the state sourced from the real module. Both existing pins were re-measured in the same pass (connected 0.16px, pairing -0.48px, fallback unchanged).

**D3-2 / D3-3 (design minors).** A running bridge with no browser attached is no longer reported as an unconfigured host — the demotion guard now renders the typed unresponsive copy and `error_code` from the latch, instead of "run `lop browser install`" — and the two phase-carrying fence answers keep their precise cause instead of rendering "no browser is attached… open your browser".

**Surface change to flag: the discovery file gained a field.** `state.py`'s `BridgeState` now carries `extension_unresponsive: bool = False`, published from `link.dropped_unproven()`. This is a deliberate widening and it needs a reviewer's eyes: `state.py` is read by **every** session's `liveness`/`available`/`advertisable`, and the field exists because the demotion guard runs on the ABSENT side of `liveness`, where `bridge_browser_reachable`'s contract forbids a socket probe — so the latch had to travel in the file the guard already reads. It is compatible in both directions (`extra="ignore"`; an older daemon's file reads as "no latch", the conservative answer).

**Record corrected (Q3-2).** `docs/design/browser-extension.md` §5.2 claimed the solicitation's non-answer lands "inside that method's own budget"; measured, it lands one probe window later — **budget + `PING_PROBE_TIMEOUT_S`**, i.e. 25.009s on a 20s method (reproduced 25.007s). The passage now states that arithmetic, so a bound sized from it cannot come out 5s short.

**Gates.** `flake8` 0 · `black --check` clean · `isort --check-only` clean · `pyright --pythonpath .venv/bin/python .` **0 errors** · `pytest tests/unit` **18656 passed, 20 skipped** · `pytest tests/unit/browser_bridge` 259 passed · extension `tsc --noEmit` clean · `node --test tests/*.test.mjs` **176/176** · `node build.mjs` clean · `gen_ts --check` clean · `pytest tests/e2e/test_browser_ownership.py -m e2e -n0` **7 passed** (node on PATH, `CMUX_*` unset, isolated HOME + config dir).

**Red-on-revert.** Every new guard was run against `bb039c18e` with only the implementation reverted (tests kept): 10 Python rows and 3 extension rows fail there for the finding's own reason, and pass here. The A1 row fails with `{"id":"after","ok":true,"result":{"driven":true}}`; the D3-2 row with `'lop browser install' not in …`; the sibling-teardown row with `{"code":"extension_disconnected",…,"data":{}}`.

### Deferred — D3-1 residual: the connected card WITH a driven URL

Measured, pre-existing, and **not fixed here** (provenance requested by the manager and measured across three revs, identical in all three: `20d8c596c`, `a733b08a4`, this head):

| connected card, URL in the trough | first paint | settled | reopen growth |
|---|---|---|---|
| `20d8c596c` (pre-PR base) | 210.0px | 257.3px | **+47.30px** |
| `a733b08a4` | 210.0px | 257.3px | **+47.30px** |
| `90615d76c` | 210.0px | 257.3px | **+47.30px** |
| same three revs, long-URL variant | 210.0px | 292.1px | **+82.08px** |

Corroborated by execution: both earlier revs record the boolean hint `"1"` for a connected render and ship the same 86px pin, and the trough predates this PR (`connected-detail` exists at `20d8c596c`, from `17b6b673f`). The mechanism wanted for the follow-up is to record the **settled card height** as the hint (or the trough's own rendered height) rather than a per-state constant, because the trough's height varies with its content (257.3px short URL vs 292.1px long) — a fourth constant would be wrong for most real pages.

## Round 4 remediation (one commit round)

Commit `f5499a8322554af5db8beaa2f11878333ebc6b4e` on top of `90615d76c709d56f827b78fdb85a9b6a748cf90a` (a new commit, deliberately not amended, so the review scope is exactly `90615d76c..f5499a8322554af5db8beaa2f11878333ebc6b4e`). It answers the round-4 agent review (`R4-1`, `R4-2`, `R4-3`, `R4-4`) and QA's `Q4-1`, which is `R4-3`'s defect seen from QA's own matrix, and adds the guard row the review's "missing coverage" section named. `pyproject.toml` is untouched and the extension stays at `0.1.11`.

**`R4-2` (major) — the approval marker now takes the same identity proof as the future.** `_forget_pending` removed its pending future by identity and popped `awaiting_origin` by id alone, so an old task's unwind deleted a **later** request's marker. Reproduced on `90615d76c` through the real path (production `extension()` + `_dispatch_serialized` + the real receive loop): a wedged peer's bounded `close()` parks after `forget_link_state()` has cleared both maps, the worker genuinely re-dials and re-pairs, a same-id request passes the busy guard and reaches the wire, the extension announces a real human approval for it — and the old unwind then prints `NEW_FUTURE_PRESERVED: true, NEW_APPROVAL_MARKER_PRESERVED: false`. The request loses the deadline extension `_await_response` exists to give it and fails at its **base** timeout while the user is still looking at the prompt. Fixed by moving the marker's pop inside the identity `if`; correct on every path, because the only caller that may legitimately clear another request's marker is the teardown, which clears the whole map.

**`R4-1` (major) — the per-tab `close` eviction now uses the same caller count.** Round 3 moved the admission-only arm onto the per-key caller count and left the sibling `close` arm testing `lock.locked()`, which is False the instant `release()` hands the per-tab lock to its first waiter. Reproduced through the real dispatching path (`key_evicted_while_B_was_queued: true`, `C_lock_is_a_SECOND_object: true`, `MUTUAL_EXCLUSION_LOST_FOR_TAB: true`): two commands interleaved into one tab's CDP session, which is the reason that key shape holds its lock for the whole command. The arm now increments before it awaits and releases through `_release_key`, with the decrement in a `finally` so a cancelled `close` cannot leak its count and pin the key.

**`R4-3` / `Q4-1` (minor) — a genuine replacement is reported as a replacement.** The delta gave `phase: replaced` to the two **timeout** fences, but a real replacement calls `forget_link_state()`, which fails every pending future immediately — so the command takes the generic `except` arm and rendered *"no browser is attached. Ask the user to open their browser"* for a browser that is open, paired and reconnected. Reproduced through production `extension()`; fixed by adding the same `replaced` test beside the `severed` test in **both** generic `except` arms.

**`R4-4` (nit) — the deferred connected-with-URL residual is named in the file.** `popup.ts`'s pin table now says the `connected` figure is the card with an empty trough, and names the residual with its measured numbers and the mechanism decision behind the deferral. Comment-only; no visual surface changes, so the round-3 design sign-off stays fresh on this head.

**Gates on `f5499a8322554af5db8beaa2f11878333ebc6b4e`:** `flake8` 0 · `black --check` clean (1233 files) · `isort --check-only` clean · `pyright` 0 errors · `pytest tests/unit` **18661 passed, 18 skipped** · `pytest tests/unit/browser_bridge tests/unit/tools/test_browser_tool.py` **368 passed** · extension `tsc --noEmit` clean · `node --test tests/*.test.mjs` **176/176** · `node build.mjs` clean · `gen_ts --check` clean · `pytest tests/e2e/test_browser_ownership.py -m e2e -n0` **7 passed** (node on PATH — an absent node skips all seven as a false pass, so the check is for 7 and not for exit 0).

**Red-on-revert and mutation.** Three rows are new, each red on `90615d76c` for its own finding's reason and green here. Mutation-tested in both directions: reverting the future's identity guard to a bare `pop(id)` — which left every pre-existing row green — now fails **exactly** the `R4-2` row; hoisting the marker pop back outside the `if` fails it too; restoring `locked()` on the `close` arm fails the `R4-1` row; deleting the `replaced` test fails the `R4-3` row; and deleting the `close` eviction outright fails the `R4-1` row's positive control, so the row defends the eviction's existence as well as its waiter-safety.

### Deferred — `D4-1` (recorded, not fixed)

`_bridge_absent_result` (`local_operator/tools/builtin.py:8190`) asserts a **dead** pid is running. With a real discovery file (`state.publish`) carrying a pid that is not alive and an `extension_id` from a real handshake, the branch renders *"the bridge daemon (pid 999999) is running and remembers this browser … run 'lop browser status' …"* (`pid_alive -> False`, `liveness -> ABSENT` with a non-`None` state, `bridge_browser_reachable -> False`, gate `current.extension_id` set). Reachable only when a daemon exits without clearing its own discovery file — `state.remove()` runs on a clean shutdown — and the sentence's terminal advice is the surface that reports the truth, so it is a minor and not this diff's surface. Promotion evidence would be a `pid_alive` split in that branch's copy. The `D3-1` connected-with-URL residual stays deferred with the provenance table above.
