### PR TITLE
chore(repo): add SanaKetabchi as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,9 +20,9 @@
 # syntax against GitHub's own CODEOWNERS validator
 # (`gh api repos/damianvtran/local-operator/codeowners/errors`, which
 # validates the default branch; the pre-change baseline on `main` returned an
-# empty error list). Both owners added 2026-09-10 -- `olafagbemi` and
-# `sherman-tsui` -- were confirmed as write collaborators the same day, so
-# every handle on the `*` line below is already effective.
+# empty error list). As of 2026-09-11 every handle on the `*` line below has
+# been confirmed a write collaborator that way, so the line is effective in
+# full -- five names, all live.
 #
 # 2026-09-10 ADDITIONS -- `olafagbemi` and `sherman-tsui` were added as
 # owners on 2026-09-10 by explicit operator decision, and each was invited
@@ -32,18 +32,21 @@
 # `gh api repos/damianvtran/local-operator/collaborators/<handle>/permission`
 # returns `write` for each, so both handles on the `*` line are effective.
 #
-# `SanaKetabchi` was on the same 2026-09-10 operator request and was invited
-# with `write` permission (invitation 332543898), but that invitation was
-# still PENDING as of 2026-09-10 21:50 UTC, so she was REMOVED from this
-# file the same day by operator decision: per the documented rule above a
-# pending handle is silently ignored by GitHub -- the exact failure mode
-# this file exists to prevent. She is NOT an owner. The invitation is left
-# open (do not cancel it; GitHub invitations expire seven days after
-# creation, 2026-09-17 for this one), and a later PR will add her if and
-# when she accepts. Her handle must not sit on the owners line "for later"
-# -- that is the silent-ignore failure described above. Re-check state with
-# `gh api repos/damianvtran/local-operator/collaborators` and
-# `gh api repos/damianvtran/local-operator/invitations`.
+# 2026-09-11 RESOLUTION -- `SanaKetabchi` was on the same 2026-09-10 operator
+# request and was invited with `write` permission (invitation 332543898,
+# issued 2026-09-10 15:54 UTC), but that invitation was still PENDING as of
+# 2026-09-10 21:50 UTC, so she was held off the owners line then by operator
+# decision: per the documented rule above a pending handle is silently
+# ignored by GitHub -- the exact failure mode this file exists to prevent.
+# That deferral was recorded in PR #911, which shipped the two accepted
+# owners over the same 2026-09-10 request and stated a later PR would add her
+# if and when she accepted. She has now ACCEPTED: invitation 332543898 is
+# consumed (`gh api repos/damianvtran/local-operator/invitations` returns an
+# empty list) and
+# `gh api
+# repos/damianvtran/local-operator/collaborators/SanaKetabchi/permission`
+# returns `write`, so as of 2026-09-11 her handle on the `*` line below is
+# effective. This PR is that promised follow-up, and it closes the deferral.
 #
 # Handle verification for the 2026-09-10 candidates, in the same
 # evidence-first spirit: all three are listed together in
@@ -62,4 +65,4 @@
 # non-owners because no such decision covers them.
 
 # Default owners for everything in the repository.
-* @damianvtran @bbqben @olafagbemi @sherman-tsui
+* @damianvtran @bbqben @olafagbemi @sherman-tsui @SanaKetabchi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,9 +20,10 @@
 # syntax against GitHub's own CODEOWNERS validator
 # (`gh api repos/damianvtran/local-operator/codeowners/errors`, which
 # validates the default branch; the pre-change baseline on `main` returned an
-# empty error list). As of 2026-09-11 every handle on the `*` line below has
-# been confirmed a write collaborator that way, so the line is effective in
-# full -- five names, all live.
+# empty error list). As of 2026-09-11 every handle on the `*` line below
+# resolves to a current collaborator with write -- or, for `damianvtran`,
+# admin -- access confirmed through that call, so the line is effective in
+# full: five names, all live.
 #
 # 2026-09-10 ADDITIONS -- `olafagbemi` and `sherman-tsui` were added as
 # owners on 2026-09-10 by explicit operator decision, and each was invited
@@ -43,10 +44,11 @@
 # if and when she accepted. She has now ACCEPTED: invitation 332543898 is
 # consumed (`gh api repos/damianvtran/local-operator/invitations` returns an
 # empty list) and
-# `gh api
-# repos/damianvtran/local-operator/collaborators/SanaKetabchi/permission`
-# returns `write`, so as of 2026-09-11 her handle on the `*` line below is
-# effective. This PR is that promised follow-up, and it closes the deferral.
+# `gh api repos/damianvtran/local-operator/collaborators/<handle>/permission`
+# (with her handle substituted for `<handle>`, exactly as in the 2026-09-10
+# block above) returns `write`, so as of 2026-09-11 her handle on the `*`
+# line below is effective. This PR is that promised follow-up, and it closes
+# the deferral.
 #
 # Handle verification for the 2026-09-10 candidates, in the same
 # evidence-first spirit: all three are listed together in


### PR DESCRIPTION
# PR Description

## Summary of Changes

Adds `@SanaKetabchi` as a code owner, per the operator request of 2026-09-10. Exactly one file changes: `.github/CODEOWNERS`.

- The default-owners rule stays a single `*` line, now listing all five owners: `@damianvtran @bbqben @olafagbemi @sherman-tsui @SanaKetabchi`.
- The comment block is updated so the file stops contradicting itself. It previously recorded, in a `SanaKetabchi` paragraph, that she "was REMOVED from this file the same day by operator decision", "is NOT an owner", and that "a later PR will add her if and when she accepts". **This is that PR**, so the paragraph now records the resolution instead:
  - The 2026-09-05/06 incident history (PRs #686 and #688–#696 merging at `reviewDecision: REVIEW_REQUIRED` with zero approvals because the ruleset required code-owner review while this file was absent) is **preserved intact**.
  - The GitHub docs quote ("The people you choose as code owners must have write permissions for the repository") and the `collaborators` / `codeowners/errors` verification commands are **preserved**.
  - The `olafagbemi` / `sherman-tsui` accepted-2026-09-10 record and the `sebkow` / `jcobhams` deliberately-not-owners paragraph are **preserved**.
  - The sentence claiming *"every handle on the `*` line below is already effective"* is re-anchored to 2026-09-11 and remains true with five handles.
  - The change is date-anchored (2026-09-11) rather than an undated "currently" that rots.

## Related Issue(s)

- Predecessor: #911 — shipped `@olafagbemi` and `@sherman-tsui` and **deliberately deferred `@SanaKetabchi`** because her write invitation was still pending. This PR closes that deferral. No issue; direct operator request (2026-09-10).

## Impact

- No code, no dependencies, no breaking changes. Single non-Python metadata file.
- **No version bump:** `pyproject.toml` is byte-identical to `origin/main` (it stays at the last released version; PRs never carry a bump).
- **The handle is now effective, which is the whole point.** GitHub docs ("About code owners"): *"The people you choose as code owners must have write permissions for the repository."* A handle without write permission is silently ignored, so the `*` line would look correct and match nobody — the exact failure mode this file exists to prevent. Her invitation is consumed and she is a live write collaborator, so the fifth handle resolves.
- **The control stays satisfiable throughout.** The `*` rule keeps `@damianvtran` and `@bbqben` plus the three now-effective 2026-09-10 additions; there is no window in which `require_code_owner_review` matches nobody.
- **Which file governs this PR.** GitHub docs: *"For code owners to receive review requests, the CODEOWNERS file must be on the base branch of the pull request."* This PR is therefore judged by `main`'s current four-owner file, not the five-owner version it introduces — the change cannot bootstrap its own approval.

## Testing Details

Live verification against the repository, run 2026-09-11 during this change:

| Check | Command | Result |
| --- | --- | --- |
| She is a live write collaborator | `gh api repos/damianvtran/local-operator/collaborators/SanaKetabchi/permission` | `{"permission":"write", ... "role_name":"write"}` |
| She resolves as a collaborator at all | `gh api repos/damianvtran/local-operator/collaborators/SanaKetabchi` | HTTP 204 (present) |
| Invitation consumed | `gh api repos/damianvtran/local-operator/invitations` | `[]` (invitation 332543898 no longer pending) |
| Syntax baseline on `main` | `gh api repos/damianvtran/local-operator/codeowners/errors` | `{"errors":[]}` |

**Syntax validation caveat.** `codeowners/errors` validates the **default branch only**, so it cannot validate this branch's version of the file before merge. The baseline above is `{"errors":[]}`; the post-merge re-check on `main` is the real syntax confirmation for the five-handle line. The change is a single added `@handle` on an existing rule, which is the syntax the file already uses four times.

**Python quality gates are N/A here.** `flake8`, `black --check`, `isort --check-only`, `pyright` and the unit suite are deliberately not run: this diff touches one non-Python metadata file, so they would report on unchanged code and buy zero signal. No claim of coverage beyond the table above.

**Draft status and auto-requests.** GitHub docs: *"Code owners are not automatically requested to review draft pull requests... When you mark a draft pull request as ready for review, code owners are automatically notified."* This PR opens as a **draft** per AGENTS.md ("Who may merge"): the standing practice is that humans come in only after the agent rounds are clean, and opening as a draft is also what keeps code owners from being auto-requested before then.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my changes work as intended. — N/A: metadata-only change, no test surface (see Testing Details).
- [ ] All new and existing tests pass. — N/A: Python gates deliberately not run on a non-Python metadata diff; see Testing Details.
- [ ] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass. — N/A: see above.
- [x] I have updated the documentation when required. — The `CODEOWNERS` comment block is the documentation for this file, and it is updated.
- [x] Security considerations are addressed (especially for code execution features). — This widens the approving set for `main` by an explicit operator decision; the accepted collaborator holds `write`, not `admin`.
- [x] I have linked all related issues.

## Screenshots (Optional)

N/A — no user-visible surface.

---

**Status: agent review and QA rounds are pending on this draft.** No human reviewers have been requested and no one is tagged; the PR stays draft until those rounds are clean and fresh on the head SHA.

Release: patch — repository governance only: adds @SanaKetabchi as a code owner. No user-visible change.
