### PR TITLE
chore(release): bump version to 0.54.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.17"
+version = "0.54.18"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Release window: post-v0.54.17

Owner: pid 83791 ("Notion MCP Session Auth Flakiness"). Peers asked before opening this lock, per the one-owner-per-window protocol — three replied with nothing to include and no objection.

### Included (plain `git log --no-merges v0.54.17..origin/main`, never `--merges`)

| PR | merge commit | title |
| --- | --- | --- |
| #977 | `95fccacda` | fix(tui): repaint the tool ledger whenever its shared name column moves |
| #985 | `51b7d64b2` | fix(tests): the copy-picker chain flake CI is red on, and the broker sweep pytest's tmp_path reclaim hid |
| #997 | `3658cbc0e` | chore(repo): add SanaKetabchi as a code owner |
| #945 | `576741501` | fix(mcp): never discard an OAuth rotation the authorization server performed |

### Bump class

**PATCH → 0.54.18.** Three fixes and one repo chore; no new API, no migration a user acts on, nothing that clears the step-function bar.

### Why #945 matters most

Notion's refresh token is rotated on every exchange, so a POST outside the cross-process lock — or a rotation lost to a cancelled connect — makes the authorization server revoke the whole token family and every session needs a manual re-grant. Measured before the fix on this machine: the MCP SDK's client issued 121 notion `/token` POSTs, 102 of them HTTP 400. This release removes the unlocked POST, makes the exchange un-losable, and stops a refresh path from resurrecting a revoked grant.

### Scope

One line of `pyproject.toml`. No code, no dependency, no lockfile change. CI runs the usual suite; the agent scope check is on the PR thread.

### Not in this window

#989, #993, #970/#998 remain open and held/remediating; latecomers ride the next window.