### PR TITLE
perf(tui): stop sending delta-grade frames to parked sidebar viewers

### DIFF
--- a/docs/SESSION_SIDEBAR.md
+++ b/docs/SESSION_SIDEBAR.md
@@ -80,6 +80,28 @@ source that leaves the screen during a gate does not lose its initiating prompt
 or the later result. Reconnect pages back through the previous durable frontier;
 a replay-changing generation produces an explicit presentation reset.
 
+## Parked-source event mute
+
+A prewarmed source stays subscribed so its conversation is warm, and everything
+it receives while nobody is looking is discarded app-side. The DELIVERY of those
+frames is not free — the owner serialises each frame once per connection, and the
+viewer decodes and deserialises it before the drop, with `message_update` frames
+carrying the accumulated message — so a parked viewer asks its owner to stop
+sending them at all.
+
+An upgraded runtime advertises `event-mute-v1`. The viewer sends **`event_mute`**
+when its controller parks and **`event_unmute`** on reveal; the owner then skips
+exactly `EVENT_MUTE_DROP_TYPES` (`message_update`, `tool_execution_update`,
+`subagent_progress`) for that one connection, and nothing else: turn boundaries,
+gates, notices, tool start/end, compaction and model changes keep flowing, since
+a parked source's state must still be right when it is revealed. The mute is per
+connection, idempotent, and re-asserted on reconnect (a fresh socket starts
+unmuted); a viewer whose owner does not advertise the capability sends nothing
+and reads the record's capability list as the pre-dial gate instead. Reveal is
+unchanged: the presentation rebuilds from history plus the canonical live seed
+and the remaining deltas resume, with the settled row's authoritative text
+healing anything that streamed during the parked window.
+
 ## Local workflows and compatibility
 
 The invoking TUI schedules `/loop`, while each iteration prompts its captured

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -50,7 +50,10 @@ from local_operator.mobile.types import (
     _projection_from_json,
 )
 from local_operator.session.runtime.registry import scan
-from local_operator.session.runtime.types import DESKTOP_WATCH_CAPABILITY
+from local_operator.session.runtime.types import (
+    DESKTOP_WATCH_CAPABILITY,
+    EVENT_MUTE_CAPABILITY,
+)
 
 #: How long to wait for an ack/error matching a request id. Mirrors the
 #: daemon's ``request`` timeout: long enough for a turn-boundary op (prompt
@@ -782,6 +785,7 @@ class AttachClient:
         self._req_seq = 0
         self._session_id = ""
         self._attention_supported = False
+        self._event_mute_supported = False
         self._connected = False
 
     @property
@@ -791,6 +795,34 @@ class AttachClient:
     @property
     def supports_completion_ack(self) -> bool:
         return self.connected and self._attention_supported
+
+    @property
+    def supports_event_mute(self) -> bool:
+        """Whether this owner advertised ``EVENT_MUTE_CAPABILITY``.
+
+        Read from the RECORD, at dial, the way ``_attention_supported`` is:
+        the owner's build cannot change while it lives, and a record is
+        rewritten on every start, so one read at connect is complete. An
+        owner without the string is exactly the pre-mute behaviour — it keeps
+        sending every frame and the parked controller keeps discarding them —
+        so the caller must gate the send on this and never send blind.
+        """
+        return self.connected and self._event_mute_supported
+
+    async def set_event_muted(self, muted: bool) -> bool:
+        """Ask the owner to stop (``True``) or resume delta-grade event frames.
+
+        Best-effort by contract: the mute is an optimisation over the parked
+        controller's app-side discard, so a refusal or a dead connection here
+        costs delivery, never correctness. Returns whether the owner acked;
+        callers that cannot wait (a synchronous park toggle) run this in a
+        task and ignore the result. The op is idempotent, which is what makes
+        the reconnect re-assert legal rather than a special case.
+        """
+        if not self.supports_event_mute:
+            return False
+        await self._request("event_mute" if muted else "event_unmute")
+        return True
 
     async def connect(self, record: SessionRecord, session_id: str) -> None:
         """Dial, authenticate as an attach client, and verify identity.
@@ -806,6 +838,7 @@ class AttachClient:
             raise ConnectionError(f"owner runs protocol v{record.protocol}; attach needs >= 2")
         self._session_id = session_id
         self._attention_supported = "completion-ack-v1" in record.capabilities
+        self._event_mute_supported = EVENT_MUTE_CAPABILITY in record.capabilities
         try:
             reader, writer = await asyncio.open_connection(
                 "127.0.0.1", record.control_port, limit=_READ_LIMIT_BYTES

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -873,6 +873,12 @@ class AttachedSession:
         self._takeover_target: Any | None = None
         self._streaming = False
         self._generation = 0
+        #: Whether the app-side controller asked this viewer to PARK its delta
+        #: grade event traffic (see :meth:`set_event_mute`). Remembered rather
+        #: than only sent, because the mute is per CONNECTION: a reconnect
+        #: starts unmuted and only this flag can put the mute back.
+        self._event_mute_requested = False
+        self._event_mute_tasks: set[asyncio.Task[None]] = set()
         self._name_state = ConversationName()
         self._model: ModelSpec | None = None
         # Double-Esc subagent cancel: the synchronous protocol method issues
@@ -2499,6 +2505,19 @@ class AttachedSession:
             client.close()
             raise ConnectionError("viewer disposed while attaching")
         self._client = client
+        # Re-assert a parking mute across a reconnect. A fresh connection is
+        # unmuted, so without this a parked source that redialed would resume
+        # paying full delivery for frames its controller discards. Best-effort
+        # like the toggle itself: the app-side drop still applies underneath.
+        if self._event_mute_requested:
+            try:
+                # Bounded, because this runs on the DIAL path: a wedged owner
+                # must not hold the redial open for the full request timeout
+                # over an optimisation. A lost re-assert costs delivery (the
+                # app-side drop still applies), never correctness.
+                await asyncio.wait_for(client.set_event_muted(True), timeout=5.0)
+            except Exception:  # noqa: BLE001 — a lost re-assert is a cost, not a defect
+                logger.debug("event mute re-assert failed", exc_info=True)
         if self._surface == "desktop":
             from local_operator.session.runtime.types import DESKTOP_WATCH_LEASE_S
 
@@ -5196,6 +5215,53 @@ class AttachedSession:
     @property
     def supports_completion_ack(self) -> bool:
         return bool(self._client and self._client.supports_completion_ack)
+
+    @property
+    def supports_event_mute(self) -> bool:
+        return bool(self._client and self._client.supports_event_mute)
+
+    def set_event_mute(self, muted: bool) -> None:
+        """Park/unpark the owner's delta-grade event relay (best-effort).
+
+        WHY THIS EXISTS. A parked source keeps its subscription so the
+        conversation stays warm, but every delta it receives is materialised
+        on this process's loop — socket read, JSON decode, event
+        deserialization — and then discarded by the parked controller. The
+        app-side drop is the semantic contract; the DELIVERY underneath it is
+        paid per parked viewer per frame, so the cheapest correct frame is the
+        one the owner never sends. This asks the owner to stop sending
+        delta-grade frames while parked — the same three types the parked
+        controller discards, nothing that carries state — and resumes them on
+        reveal, where the presentation rebuilds from history plus the canonical
+        live seed exactly as it already does after any parked gap.
+
+        SYNCHRONOUS ON PURPOSE (the park toggle's own shape): the send is
+        spawned rather than awaited, and a lost send is only a lost
+        optimisation because the app-side drop still applies. The REQUESTED
+        state is remembered, which is what a reconnect re-asserts — the mute
+        is per connection and a fresh socket starts unmuted. Call from the
+        app's loop, which is where parking happens; a viewer whose owner never
+        advertised the capability is a no-op (the pre-mute behaviour).
+        """
+        self._event_mute_requested = muted
+        client = self._client
+        if client is None or not client.supports_event_mute:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Never in the connect path's loop-less phases; a lost send is
+            # recoverable by the next park toggle or the next reconnect.
+            return
+        task = loop.create_task(self._send_event_mute(client, muted))
+        self._event_mute_tasks.add(task)
+        task.add_done_callback(self._event_mute_tasks.discard)
+
+    async def _send_event_mute(self, client: AttachClient, muted: bool) -> None:
+        try:
+            await client.set_event_muted(muted)
+        except Exception:  # noqa: BLE001 — a lost mute is a cost, never a defect
+            logger.debug("event mute send failed", exc_info=True)
 
     async def refresh_attention(self) -> dict[str, Any]:
         return dict(self.frontend_state.attention)

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -65,6 +65,8 @@ from local_operator.session.runtime.types import (
     ATTACH_MAX_CLIENTS,
     DESKTOP_WATCH_CAPABILITY,
     DESKTOP_WATCH_LEASE_S,
+    EVENT_MUTE_CAPABILITY,
+    EVENT_MUTE_DROP_TYPES,
     HEARTBEAT_INTERVAL_S,
     ClientKind,
     ClientLocality,
@@ -442,6 +444,13 @@ class _ClientConn:
     # frame. Daemon connections never set it; a v3 attach client that omitted
     # the flag keeps projection-only behaviour.
     wants_events: bool = False
+    #: An attach connection's raw event relay is MUTED: it asked (see
+    #: ``EVENT_MUTE_CAPABILITY``) to stop receiving delta-grade frames until it
+    #: unmutes. Per connection, not per session — the same owner serves each
+    #: viewer's own interest, so a parked viewer's mute never slows the one on
+    #: screen. Flipped by the ``event_mute``/``event_unmute`` ops (handled in
+    #: the control loop, which owns ``conn``) and read in ``_relay_on_loop``.
+    events_muted: bool = False
     # v5 canonical state is attach-only and independently negotiated so daemon
     # projection bytes never gain frontend frames.
     wants_frontend: bool = False
@@ -713,6 +722,10 @@ class RuntimeServer:
             # surface that is not there.
             capabilities=(
                 [DESKTOP_WATCH_CAPABILITY]
+                # Unconditional, unlike the handle-gated entries below: the
+                # mute is a property of the RELAY this server always runs, not
+                # of anything the handle implements.
+                + [EVENT_MUTE_CAPABILITY]
                 + ([FRONTEND_CAPABILITY] if hasattr(handle, "subscribe_frontend") else [])
                 + (["completion-ack-v1"] if hasattr(handle, "acknowledge_attention") else [])
                 + (["display-history-window-v1"] if hasattr(handle, "history_page") else [])
@@ -2109,6 +2122,30 @@ class RuntimeServer:
                 # ``retire_if_pristine``: both are lifecycle ops that must not
                 # trigger the post-ack refresh (the exemption list below).
                 detail = await self._refresh_if_idle()
+            elif op in ("event_mute", "event_unmute"):
+                # Raw-event interest, per connection, for a viewer that stops
+                # painting this session while parked (see
+                # ``EVENT_MUTE_CAPABILITY``). Handled here rather than in
+                # ``_dispatch`` for the same reason ``watch_job`` is: it
+                # mutates this connection's own relay state and never touches
+                # the session, and the dispatcher deliberately has no ``conn``.
+                #
+                # Delta-grade frames ONLY, and the set is deliberately the
+                # same one the viewer's parked ``EventController`` discards
+                # app-side: muting anything a client still needs for state
+                # (turn boundaries, gates, notices) would change what a
+                # reveal can reconstruct, and the unmute path rebuilds live
+                # text from history plus the canonical seed either way.
+                # Idempotent: re-asserting the current state is how a
+                # reconnected parked viewer gets its mute back.
+                #
+                # Attach-only, like ``desktop_watch``: the relay this mutes is
+                # never sent to daemon connections, so a daemon sending it is
+                # a client bug and the error frame is the honest reply.
+                if conn.kind != "attach":
+                    raise ValueError("event muting requires an attach connection")
+                conn.events_muted = op == "event_mute"
+                detail = "delta-grade events muted" if conn.events_muted else "events resumed"
             elif op in _PAYLOAD_OPS:
                 # Structured-answer ops reply with a ``result`` frame whose
                 # ``data`` the invoker renders locally (a slash command's typed
@@ -2897,10 +2934,18 @@ class RuntimeServer:
         """
         if self._closed.is_set():
             return
+        # A muted connection (``EVENT_MUTE_CAPABILITY``) is filtered PER EVENT,
+        # not dropped from the recipient snapshot: its interest is the delta
+        # grade only, and turn boundaries, gates, notices and so on must keep
+        # flowing or a parked viewer's state would silently rot while muted.
+        event_type = str(data.get("type") or "")
         recipients = [
             conn
             for conn in self._clients.values()
-            if conn.kind == "attach" and conn.wants_events and conn.events_ready
+            if conn.kind == "attach"
+            and conn.wants_events
+            and conn.events_ready
+            and not (conn.events_muted and event_type in EVENT_MUTE_DROP_TYPES)
         ]
         if not recipients:
             return

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -2207,6 +2207,12 @@ class RuntimeServer:
                 # push, and the handle is mid-dispose) or refused (nothing
                 # changed, so there is nothing to push).
                 "retire_now",
+                # Connection-local relay toggles, like ``watch`` above: they
+                # mutate only this connection's OWN event interest, never the
+                # session, so a refresh has nothing new to see and there is
+                # no changed state to push.
+                "event_mute",
+                "event_unmute",
             ):
                 await self._handle.refresh()
                 await self._push()

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -59,6 +59,55 @@ PROTOCOL_VERSION = 5
 DESKTOP_WATCH_CAPABILITY = "desktop-watch-v1"
 DESKTOP_WATCH_LEASE_S = 45.0
 
+#: Additive attach capability: this owner accepts ``event_mute``/``event_unmute``
+#: ops, which stop and resume DELTA-GRADE frames on an attach connection that
+#: already subscribed to the raw event relay (``"events": true``).
+#:
+#: The parking sidebar mints viewer connections it does not paint: every delta
+#: those viewers receive is materialised (socket read, JSON decode, event
+#: deserialization) and then discarded app-side, so the cheapest correct thing
+#: is for the owner not to send them at all while parked. Muting is strictly
+#: narrower than the app-side discard it replaces (the same delta-grade types;
+#: state-bearing events keep flowing), it is per CONNECTION, and it is
+#: reversible: the viewer unmutes on reveal and rebuilds from history plus the
+#: canonical live seed, exactly as the app-side drop already requires.
+#:
+#: Negotiated by capability string rather than a ``PROTOCOL_VERSION`` bump for
+#: the reason ``recall_steer`` documents: purely additive op, no frame shape
+#: changes, and an owner that does not know the op simply never sees it (the
+#: client gates the send on this string being present in the record).
+EVENT_MUTE_CAPABILITY = "event-mute-v1"
+
+#: Event types a MUTED attach connection stops receiving: the wire half of
+#: ``EVENT_MUTE_CAPABILITY``, and deliberately THE SAME SET the parked
+#: ``EventController`` discards app-side (``tui/events.py`` assigns its
+#: ``_PARKED_DROP_TYPES`` from this constant, so the two cannot drift).
+#:
+#: MEMBERSHIP RULE, all three clauses required: the event carries a fragment of
+#: something in flight, the owner's ``live_events`` seed already accumulates it
+#: (so a reveal rebuilds the same viewport through ``restore_live_projection``),
+#: AND it is emitted UNTHROTTLED, once per token or chunk. The third clause is
+#: what keeps the set finite, and it is why ``tool_call_compose`` is
+#: DELIBERATELY EXCLUDED despite satisfying the first two: it carries partial
+#: argument bytes of an in-flight call, but the harness already rate-limits it
+#: to one per ``COMPOSE_NOTICE_INTERVAL_S`` (0.2 s), so it is not volume traffic
+#: and muting it would buy nothing while costing a compose preview on reveal.
+#: Do not "complete" this set by adding it.
+#:
+#: Also deliberately absent: ``message_start``/``message_end`` (row identity and
+#: the settled row the dedupe and card pairing key on), every turn/agent
+#: boundary, tool start/end, compaction, retry, model change, and every
+#: delivery notice — those change state a parked source is still expected to
+#: have right. These three ARE the volume: at 12 streaming sessions they were
+#: ~229 events/s of the traffic measured on the reporting machine.
+EVENT_MUTE_DROP_TYPES = frozenset(
+    {
+        "message_update",  # one per assistant token
+        "tool_execution_update",  # one per streamed tool-output chunk
+        "subagent_progress",  # one per child progress beat
+    }
+)
+
 #: Which side of the owner relationship a control connection speaks for.
 #: ``daemon`` (the default when the auth frame omits ``client``) may rebind
 #: the owner's conversation; ``attach`` is a follower terminal that may

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -84,11 +84,15 @@ EVENT_MUTE_CAPABILITY = "event-mute-v1"
 #: ``_PARKED_DROP_TYPES`` from this constant, so the two cannot drift).
 #:
 #: MEMBERSHIP RULE, all three clauses required: the event carries a fragment of
-#: something in flight, the owner's ``live_events`` seed already accumulates it
-#: (so a reveal rebuilds the same viewport through ``restore_live_projection``),
-#: AND it is emitted UNTHROTTLED, once per token or chunk. The third clause is
-#: what keeps the set finite, and it is why ``tool_call_compose`` is
-#: DELIBERATELY EXCLUDED despite satisfying the first two: it carries partial
+#: something in flight, it leaves the viewport REBUILDABLE after a parked gap —
+#: either folded into the owner's ``live_events`` seed, which
+#: ``restore_live_projection`` replays (``message_update``), or, for the two
+#: types that seed does NOT fold, self-replacing: the first frame after unmute
+#: carries the whole accumulated state again (``tool_execution_update``
+#: re-sends its full output; ``subagent_progress`` describes the child's
+#: current step) — AND it is emitted UNTHROTTLED, once per token or chunk. The
+#: third clause is what keeps the set finite, and it is why ``tool_call_compose``
+#: is DELIBERATELY EXCLUDED despite satisfying the first two: it carries partial
 #: argument bytes of an in-flight call, but the harness already rate-limits it
 #: to one per ``COMPOSE_NOTICE_INTERVAL_S`` (0.2 s), so it is not volume traffic
 #: and muting it would buy nothing while costing a compose preview on reveal.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -6317,8 +6317,19 @@ class Session:
             # Replay-changing commits precede their public events. Publish the
             # scalar first so retained viewers cannot select a stale tail after
             # compaction, pruning, or a fold; unchanged events do no extra work.
+            #
+            # The read is `read_field`, NOT `store.state.history_generation`:
+            # the `state` property deep-copies every job, usage row and
+            # trajectory (it exists so no caller can mutate the store's own
+            # instance), so asking it for one int charged that clone on EVERY
+            # emitted event — every streaming delta — for every session with
+            # any subscriber. `history_generation` is in the store's
+            # ``_SHAREABLE_STATE_FIELDS`` allow-list precisely so this read
+            # can hand back the int itself. Symptom it caused: a parked
+            # sidebar source is a subscriber, so opening the sidebar re-armed
+            # the clone on sessions whose own terminal was elsewhere.
             replay_generation = self._transcript._history_generation
-            if store.state.history_generation != replay_generation:
+            if store.read_field("history_generation") != replay_generation:
                 store.mutate(history_generation=replay_generation)
             store.observe_event(self, event)
         for handler in list(self._handlers):

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -69,6 +69,7 @@ from local_operator.harness.types import (
     Usage,
     WakeDeliveredEvent,
 )
+from local_operator.session.runtime.types import EVENT_MUTE_DROP_TYPES
 from local_operator.tui.widgets.transcript import NoticeKind
 
 #: Streaming updates flush at ~30 fps (the coalesced cadence).
@@ -575,6 +576,24 @@ class EventController:
         if parked == self._parked:
             return
         self._parked = parked
+        # The app-side drop above is the semantic contract; the DELIVERY
+        # underneath it is not free — measured ~0.26 ms per delivered frame,
+        # linear in frames/s, scaling with payload bytes (the frames carry the
+        # accumulated message), on top of the owner serialising each frame per
+        # connection. So the parked state is pushed DOWN to the wire as well:
+        # a viewer whose owner advertises ``event-mute-v1`` asks it to stop
+        # sending the same delta-grade types until reveal, which removes the
+        # socket read, JSON decode and deserialization entirely. Best-effort
+        # and idempotent — a viewer on an older owner, or a lost op, simply
+        # keeps paying the delivery the app-side drop already covers.
+        #
+        # NOT the cause of the open-vs-closed TYPING gap (see the docstring:
+        # the ceiling arm retired viewer-side gating as that class). This is a
+        # throughput/CPU fix for what the parked subscription literally sends.
+        session = self._session
+        set_mute = getattr(session, "set_event_mute", None)
+        if callable(set_mute):
+            set_mute(parked)
         if parked:
             # A parked controller must not hold a 30 Hz timer for text nobody
             # can see; the buffer it would flush is dropped below anyway.
@@ -978,8 +997,12 @@ class EventController:
     }
 
     #: Event types a PARKED source drops outright (see :meth:`set_parked`).
-    #: Grouped with ``_HANDLERS`` because both are class-level dispatch tables
-    #: read by ``_on_event``, and this file keeps its class constants together.
+    #: The ROLE split: this is the app-side half of the same contract the wire
+    #: mute enforces, and the definition is SHARED with the server
+    #: (``EVENT_MUTE_DROP_TYPES``, ``session/runtime/types.py``) so the two
+    #: halves cannot drift — a parked viewer whose owner still sent a frame
+    #: would pay delivery for it, and one whose owner stopped sending a frame
+    #: this set does NOT contain would lose state on reveal.
     #:
     #: MEMBERSHIP RULE, all three clauses required: the event carries a
     #: fragment of something in flight, the owner's ``live_events`` seed
@@ -1002,13 +1025,7 @@ class EventController:
     #: These three ARE the volume: at 12 streaming sessions they were ~229
     #: events/s of the traffic measured, against a handful per turn for
     #: everything above.
-    _PARKED_DROP_TYPES: frozenset[str] = frozenset(
-        {
-            "message_update",  # one per assistant token
-            "tool_execution_update",  # one per streamed tool-output chunk
-            "subagent_progress",  # one per child progress beat
-        }
-    )
+    _PARKED_DROP_TYPES: frozenset[str] = EVENT_MUTE_DROP_TYPES
 
     # -- flush timer --------------------------------------------------------
     def _request_flush_timer(self) -> None:

--- a/scripts/diag/tui_growth.py
+++ b/scripts/diag/tui_growth.py
@@ -98,6 +98,43 @@ PARSER.add_argument(
 PARSER.add_argument("--tracemalloc", action="store_true")
 PARSER.add_argument("--profile", action="store_true")
 PARSER.add_argument(
+    "--sidebar",
+    choices=("open", "closed"),
+    default="open",
+    help="A/B control: 'closed' mirrors a user closing the sidebar (poll timer paused, "
+    "spinner timer paused, no prewarm), which is the state the report says is fast.",
+)
+PARSER.add_argument(
+    "--profile-idle",
+    action="store_true",
+    help="cProfile the idle window at each checkpoint and dump idle-<label>.prof, so the "
+    "steady-state loop CPU can be attributed to callers rather than guessed at.",
+)
+PARSER.add_argument(
+    "--stream",
+    type=int,
+    default=0,
+    help="How many parked sidebar owners emit live message_update deltas during the run "
+    "(0 = quiet). The operator's report names 'live streaming activity' at ~19 sessions; "
+    "--stream 12 --stream-rate 19 models #894's measured 229 ev/s across 12 sessions.",
+)
+PARSER.add_argument(
+    "--stream-rate",
+    type=float,
+    default=19.0,
+    help="Deltas per second per streaming session.",
+)
+PARSER.add_argument(
+    "--stream-chars",
+    type=int,
+    default=0,
+    help="Accumulated characters each streamed message carries. Real message_update "
+    "frames carry the FULL accumulated message (server.py: 'the expensive part of a "
+    "message_update is the accumulated message — hundreds of KB'), so 0 measures "
+    "only the per-frame overhead and 65536+ measures the delivery cost that grows "
+    "with answer length.",
+)
+PARSER.add_argument(
     "--no-cleanup-timer",
     action="store_true",
     help="stub OperatorApp._report_startup_cleanup (experiment: is the per-adopt timer chain "
@@ -255,6 +292,46 @@ def instrument() -> None:
         return await original_connect(cls, *args, **kwargs)
 
     AttachedSession.connect = classmethod(connect)  # type: ignore[method-assign]
+
+    # Sidebar paint traffic by kind, so "renders per tick/poll" is a counted
+    # number rather than inferred from CPU: a full refresh repaints the widget,
+    # a spinner tick may repaint one cell, and render_line is what the
+    # compositor actually asks for per visible row.
+    from local_operator.tui.events import EventController
+    from local_operator.tui.widgets.session_sidebar import SessionSidebar
+
+    wrap(SessionSidebar, "refresh", "sidebar.refresh")
+    wrap(SessionSidebar, "_advance_spinner", "sidebar.tick")
+    wrap(SessionSidebar, "render_line", "sidebar.render_line")
+
+    # Viewer-side event seam: what the app actually pays to receive, and how
+    # much of it a PARKED controller discards (the work #894 exists to drop).
+    original_on_event = EventController._on_event
+
+    def counted_on_event(self: Any, event: Any) -> None:
+        COUNTS["event_controller.on_event"] += 1
+        if (
+            self._parked
+            and not self._restoring_projection
+            and event.type in self._PARKED_DROP_TYPES
+        ):
+            COUNTS["event_controller.parked_drop"] += 1
+        return original_on_event(self, event)
+
+    EventController._on_event = counted_on_event  # type: ignore[method-assign]
+
+    # Frontend channel: per-update viewer-side handling. ``apply_update``
+    # rebuilds the whole canonical state, so its count per second is the
+    # quantity that decides whether the parked-source frontend channel is
+    # cheap or the dominant cost.
+    from local_operator.session.attached import AttachedSession as _AttachedSession
+    from local_operator.session.frontend_state import (
+        FrontendStateStore as _FrontendStateStore,
+    )
+
+    wrap(_AttachedSession, "_on_frontend_update", "attached._on_frontend_update")
+    wrap(_AttachedSession, "_apply_frontend_facades", "attached._apply_frontend_facades")
+    wrap(_FrontendStateStore, "apply_update", "frontend_store.apply_update")
 
 
 def rss_mb() -> float:
@@ -442,6 +519,7 @@ class Fixture:
         self.history = history
         self.busy = busy
         self.servers: dict[str, RuntimeServer] = {}
+        self.sessions: dict[str, Any] = {}
         self.ids: list[str] = []
 
     async def start(self) -> None:
@@ -464,6 +542,10 @@ class Fixture:
                 server._busy = True
                 server._republish()
             self.servers[sid] = server
+            # Kept alongside the server: the streaming generator needs to EMIT
+            # on the owner, and ``SessionHandle`` deliberately does not expose
+            # the private session (pyright declines the reach-through).
+            self.sessions[sid] = owner
 
     def find(self, _directory: Path, sid: str) -> tuple[Any, Any]:
         server = self.servers.get(sid)
@@ -577,27 +659,64 @@ async def checkpoint(
     return record
 
 
-async def idle_cost(app: OperatorApp, pilot: Any) -> dict[str, float]:
+async def idle_cost(app: OperatorApp, pilot: Any, label: str = "") -> dict[str, float]:
     """What the app burns doing NOTHING — the honest measure of "it feels slow".
 
     Loop-thread CPU over a fixed idle window (AGENTS.md "measure CPU, not wall
     time"): timers, polls and background tasks are the only things that can
     consume it, so a number that rises with switch count is background work
     the app acquired and never released.
+
+    DO NOT wait with ``pilot.pause`` here. ``Pilot._wait_for_screen`` posts a
+    ``call_later`` message to EVERY widget (and walks the tree to do it), so a
+    pause-driven window measures the HARNESS at ~7k messages/s across ~140
+    widgets — twice the signal, and it scales with widget count rather than
+    with anything the user runs. Plain ``asyncio.sleep`` leaves only the app's
+    own timers and socket work on the loop, which is what production idles on.
+
+    ``lag`` samples ``call_soon`` scheduling delay every 20 ms: the per-window
+    answer to "would a keystroke have waited behind background work".
     """
     seconds = ARGS.idle_seconds
     if seconds <= 0:
         return {}
+    loop = asyncio.get_running_loop()
+    lag_ms: list[float] = []
+    stopped = False
+
+    def poke(due: float) -> None:
+        if stopped:
+            return
+        lag_ms.append((loop.time() - due) * 1000)
+        loop.call_later(0.02, poke, loop.time() + 0.02)
+
+    poke(loop.time())
+    profiler = cProfile.Profile() if ARGS.profile_idle else None
     cpu0, wall0 = time.thread_time(), time.monotonic()
+    if profiler is not None:
+        profiler.enable()
     while time.monotonic() - wall0 < seconds:
-        await pilot.pause(0.02)
+        await asyncio.sleep(0.01)
     elapsed = time.monotonic() - wall0
     cpu = time.thread_time() - cpu0
+    stopped = True
+    if profiler is not None:
+        profiler.disable()
+        suffix = "-" + label.replace("=", "") if label else ""
+        profiler.dump_stats(str(ARGS.output / f"idle{suffix}.prof"))
+    lag_ms = lag_ms[1:]
+    lag_ms.sort()
     result = {
         "idle_cpu_ms_per_s": round(cpu / elapsed * 1000, 1),
         "idle_window_s": round(elapsed, 2),
     }
+    if lag_ms:
+        result["idle_lag_mean_ms"] = round(sum(lag_ms) / len(lag_ms), 2)
+        result["idle_lag_p90_ms"] = round(lag_ms[int(len(lag_ms) * 0.9)], 2)
+        result["idle_lag_max_ms"] = round(lag_ms[-1], 2)
     SERIES.setdefault("idle_cpu_ms_per_s", []).append(result["idle_cpu_ms_per_s"])
+    if lag_ms:
+        SERIES.setdefault("idle_lag_p90_ms", []).append(result["idle_lag_p90_ms"])
     return result
 
 
@@ -670,7 +789,10 @@ async def one_poll(app: OperatorApp, pilot: Any) -> dict[str, float]:
             await asyncio.wait_for(asyncio.shield(prefetch.wait()), 30)
         except Exception:
             pass
-    app._session_sidebar._advance_spinner()
+    if app._session_sidebar.display:
+        # Mirrors production: a closed sidebar pauses its spinner timer, so a
+        # closed-cell poll must not paint a frame a real user would never see.
+        app._session_sidebar._advance_spinner()
     await pilot.pause()
     result = {
         "poll_wall_ms": round((time.monotonic() - wall0) * 1000, 1),
@@ -870,13 +992,20 @@ async def run_uptime(fixture: Fixture) -> list[dict[str, Any]]:
             if ARGS.approve_all:
                 app._approvals_default_auto = True
                 app._set_approve_all(True)
-            app._set_sidebar_open(True)
+            sidebar_open = ARGS.sidebar == "open"
+            app._set_sidebar_open(sidebar_open)
             assert app._sidebar_timer is not None
             # The harness drives polls explicitly so cycles are countable.
             app._sidebar_timer.pause()
             await one_poll(app, pilot)
             for _ in range(20):
                 await pilot.pause()
+            stream_task = None
+            if ARGS.stream:
+                current = str(getattr(app._session, "session_id", ""))
+                parked = [sid for sid in fixture.ids if sid != current]
+                stream_ids = parked[: ARGS.stream]
+                stream_task = asyncio.create_task(stream_owners(fixture, stream_ids))
             if ARGS.tracemalloc:
                 tracemalloc.start(25)
             base_gc = gc_snapshot()
@@ -888,12 +1017,13 @@ async def run_uptime(fixture: Fixture) -> list[dict[str, Any]]:
             for p in range(1, ARGS.polls + 1):
                 timing = await one_poll(app, pilot)
                 # Extra spinner ticks between polls: the 2 s poll sees ~16
-                # spinner frames at 120 ms.
-                for _ in range(15):
+                # spinner frames at 120 ms. A closed sidebar has no spinner
+                # timer, so the closed control cell drives none of them.
+                for _ in range(15 if sidebar_open else 0):
                     app._session_sidebar._advance_spinner()
                     await pilot.pause()
                 if p % ARGS.checkpoint_every == 0 or p == ARGS.polls:
-                    idle = await idle_cost(app, pilot)
+                    idle = await idle_cost(app, pilot, label=f"P{p}")
                     keys = await keystroke_cost(app, pilot)
                     records.append(
                         await checkpoint(app, f"P={p}", base_gc, {**timing, **idle, **keys})
@@ -907,7 +1037,50 @@ async def run_uptime(fixture: Fixture) -> list[dict[str, Any]]:
                     out.extend("    " + line for line in stat.traceback.format()[-6:])
                 (ARGS.output / "tracemalloc.txt").write_text("\n".join(out) + "\n")
                 tracemalloc.stop()
+            if stream_task is not None:
+                stream_task.cancel()
+                try:
+                    await stream_task
+                except asyncio.CancelledError:
+                    pass
     return records
+
+
+async def stream_owners(fixture: Fixture, session_ids: list[str]) -> None:
+    """Emit live ``message_update`` deltas from parked owners at a real cadence.
+
+    The FULL production path, not a shortcut: ``session._emit`` -> the handle's
+    ``subscribe_events`` (JSON serialise) -> ``RuntimeServer`` relay -> viewer
+    socket -> ``AttachedSession`` -> ``EventController._on_event``, where a
+    PARKED controller must discard delta-grade events. This is the traffic the
+    operator's "live streaming activity" is made of, and the one the sidebar's
+    parked viewers subscribe to (the fan-in #894 exists to mute).
+
+    The fixture's owners are in-process, so the serialise/broadcast leg runs on
+    this loop as well; in production it lives in the owner's process. That
+    makes the absolute figure an overstatement of the TUI's own share by a
+    constant, which is why the quiet/streaming and open/closed DELTAS are the
+    numbers that mean something.
+    """
+    from local_operator.harness.types import Message, MessageUpdateEvent
+
+    # One round emits one event per streaming session; a round must therefore
+    # take 1/rate seconds for each session to sustain `rate` events/s.
+    gap = max(0.001, 1.0 / ARGS.stream_rate)
+    # Real frames carry the accumulated message. Grow it a little per delta so
+    # each frame is bigger than the last, like a real stream; the base size is
+    # what makes the parse cost visible at all.
+    base = max(0, ARGS.stream_chars)
+    counters: dict[str, int] = {sid: 0 for sid in session_ids}
+    while True:
+        for sid in session_ids:
+            owner = fixture.sessions[sid]
+            index = counters[sid]
+            counters[sid] = index + 1
+            message = Message.assistant("x" * (base + index % 64))
+            message.id = f"growth-stream-{sid}"
+            await owner._emit(MessageUpdateEvent(message=message, delta="x" * (index % 7 + 1)))
+        await asyncio.sleep(gap)
 
 
 FIXTURE: Fixture

--- a/tests/unit/session/test_emit_state_reads.py
+++ b/tests/unit/session/test_emit_state_reads.py
@@ -1,0 +1,62 @@
+"""The per-event fold gate must read one scalar, not deep-copy the state.
+
+``Session._emit`` runs on EVERY emitted event on a session with any
+subscriber -- and a parked sidebar source is a subscriber -- to keep the
+canonical ``history_generation`` in step. It used to ask for that one int
+through ``FrontendStateStore.state``, the property that deep-copies every job,
+usage row and trajectory so no caller can mutate the store's own instance:
+measured at ~0.3-1 ms of loop CPU per event on a modest state, scaling with
+the state's size, on the busiest path a streaming session has.
+
+The guard is structural, not a stopwatch: with the gate open (a real
+subscriber), emitting a plain event must not read ``state`` at all. If a
+future change reintroduces any full-state read on this path, this fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from local_operator.harness.types import Message, MessageUpdateEvent
+from local_operator.session.frontend_state import FrontendStateStore
+from tests.e2e.harness import ScriptedStream, build_session
+
+
+@pytest.mark.asyncio
+async def test_emit_reads_history_generation_without_cloning_the_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session = build_session(tmp_path / "sessions" / "emit-gate", ScriptedStream([]), cwd=tmp_path)
+
+    # Open the fold gate the way production does: a real subscriber on the
+    # canonical store. Without this the gate short-circuits and the test would
+    # pass vacuously.
+    session.subscribe_frontend(lambda update: None)
+    store = session._frontend_state_store
+    assert store is not None and store.has_subscribers
+
+    reads: list[int] = []
+    original = FrontendStateStore.state.fget
+    assert original is not None
+
+    def counted(self: FrontendStateStore):  # type: ignore[no-untyped-def]
+        reads.append(len(reads))
+        return original(self)
+
+    monkeypatch.setattr(FrontendStateStore, "state", property(counted))
+
+    message = Message.assistant("gate probe")
+    message.id = "emit-gate-1"
+    await session._emit(MessageUpdateEvent(message=message, delta="gate probe"))
+    await asyncio.sleep(0)
+
+    assert reads == [], (
+        "emitting one message_update read FrontendStateStore.state, which deep-copies "
+        "every job, usage row and trajectory: the history_generation compare must go "
+        "through read_field (the allow-listed scalar accessor)"
+    )
+
+    await session.dispose()

--- a/tests/unit/tui/test_event_mute_wire.py
+++ b/tests/unit/tui/test_event_mute_wire.py
@@ -1,0 +1,477 @@
+"""The wire mute: a parked viewer's owner stops SENDING delta-grade frames.
+
+``tests/unit/tui/test_parked_source_seam.py`` covers the app-side drop (what
+the parked controller does with frames that arrive). What THIS module covers is
+the layer under it, which the app-side drop cannot see: the delivery itself.
+
+WHY THE LAYER MATTERS. A parked source keeps its subscription so the
+conversation stays warm, and every delta it receives is materialised -- socket
+read, JSON decode, event deserialization -- and only then discarded. Measured
+on the reporting machine: ~0.26 ms per delivered-and-discarded frame, linear in
+frames/s (68 ms/s of loop CPU at 12 streaming sessions, 117 ms/s at double the
+rate), scaling with the frame's payload because ``message_update`` carries the
+ACCUMULATED message. The owner also serialises each frame once per connection.
+``event-mute-v1`` moves the drop to the sender: a parked viewer asks its owner
+to stop sending the same three delta-grade types (``EVENT_MUTE_DROP_TYPES``)
+and resumes them on reveal, where the presentation rebuilds from history plus
+the canonical live seed exactly as it already does after any parked gap.
+
+WHAT MUST NOT REGRESS, tested below one by one:
+
+* the suppression itself (a parked viewer receives no delta frame) -- this is
+  the pinned regression; it fails against a tree without the server-side
+  filter, where the frames arrive and are discarded app-side;
+* skew in both directions -- a new viewer against an owner that cannot mute,
+  and an old viewer against an owner that can;
+* a reconnect re-asserting the mute (the mute is per CONNECTION, and a fresh
+  socket starts unmuted);
+* reveal freshness -- the muted-then-revealed viewer ends with the same
+  settled state as an always-live one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+import pytest
+
+from local_operator.harness.types import (
+    AgentEndEvent,
+    AgentStartEvent,
+    AgentToolUpdate,
+    Message,
+    MessageUpdateEvent,
+    SubagentProgressEvent,
+    TextContent,
+    ToolExecutionUpdateEvent,
+)
+from local_operator.session.attached import AttachedSession
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.session.runtime.serving import ServingSessionHandle
+from local_operator.session.runtime.types import (
+    EVENT_MUTE_CAPABILITY,
+    EVENT_MUTE_DROP_TYPES,
+)
+from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
+from tests.unit.session.test_remote import _never_take_over
+
+#: How long to let loopback frames round-trip before reading a count. Waiting
+#: LONGER is always safe for the suppression assertions (they assert zero) and
+#: the arrival assertions only need the frames to have landed; this is a
+#: settle window, not a latency bound.
+_SETTLE = 0.35
+
+
+async def _settle() -> None:
+    deadline = asyncio.get_running_loop().time() + _SETTLE
+    while asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+
+async def _mute(viewer: AttachedSession, muted: bool) -> None:
+    """Toggle the wire mute and wait for the op to be acked.
+
+    ``set_event_mute`` is deliberately synchronous (the park toggle's shape);
+    it spawns the send. Awaiting the spawned tasks here is what makes the
+    wire-level assertions below deterministic instead of racing the op.
+    """
+    viewer.set_event_mute(muted)
+    for _ in range(10):
+        tasks = list(viewer._event_mute_tasks)
+        if not tasks:
+            return
+        await asyncio.gather(*tasks)
+        await asyncio.sleep(0)
+
+
+def _delta_grade(index: int) -> list[object]:
+    """One of EACH type in ``EVENT_MUTE_DROP_TYPES``, not just message_update."""
+    message = Message.assistant(f"token {index}")
+    message.id = f"mute-live-{index}"
+    return [
+        MessageUpdateEvent(message=message, delta=f"tok{index}"),
+        ToolExecutionUpdateEvent(
+            tool_call_id=f"mute-call-{index}",
+            tool_name="read",
+            partial_result=AgentToolUpdate(),
+        ),
+        SubagentProgressEvent(job_id=f"mute-job-{index}", label="child", progress="working"),
+    ]
+
+
+def _settled_message(index: int, text: str) -> Message:
+    return Message(
+        id=f"mute-settled-{index}",
+        role="assistant",
+        content=[TextContent(text=text)],
+        stop_reason="stop",
+    )
+
+
+@asynccontextmanager
+async def _remote(tmp_path: Path, name: str) -> AsyncIterator[AttachedSession]:
+    """A real owner runtime plus a real ``AttachedSession`` viewer over it."""
+    config = tmp_path / "config"
+    config.mkdir(exist_ok=True)
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / f"synthetic-{name}"
+    await seed_transcript(directory, [])
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    record = server._record
+    remote = await AttachedSession.connect(
+        record,
+        directory.name,
+        config_dir=config,
+        takeover_factory=_never_take_over,
+        display_window=True,
+    )
+    try:
+        yield remote
+    finally:
+        await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+class _WireLog:
+    """Counts what the owner enqueues for the viewer's connection, per type."""
+
+    def __init__(self) -> None:
+        self.types: list[str] = []
+
+
+@asynccontextmanager
+async def _counting_server(tmp_path: Path, name: str) -> AsyncIterator[tuple[Any, Any, _WireLog]]:
+    """Owner + handle + a log of frames ENQUEUED to attach connections.
+
+    Counting at ``_enqueue_client_frame`` is the wire layer the mute gates: it
+    cannot be fooled by a subscription that captured an older bound method, and
+    it is exactly what the owner would have written to the socket.
+    """
+    config = tmp_path / "config"
+    config.mkdir(exist_ok=True)
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / f"synthetic-{name}"
+    await seed_transcript(directory, [])
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+
+    log = _WireLog()
+    original = RuntimeServer._enqueue_client_frame
+
+    def counting(self, conn, frame):  # type: ignore[no-untyped-def]
+        if self is server and str(conn.kind) == "attach":
+            log.types.append(str((frame.get("data") or {}).get("type") or frame.get("op")))
+        return original(self, conn, frame)
+
+    RuntimeServer._enqueue_client_frame = counting  # type: ignore[method-assign]
+    try:
+        yield server, session, log
+    finally:
+        RuntimeServer._enqueue_client_frame = original  # type: ignore[method-assign]
+        server.close()
+        await handle.dispose()
+
+
+def _deltas(log: _WireLog) -> int:
+    return sum(1 for kind in log.types if kind in EVENT_MUTE_DROP_TYPES)
+
+
+def _state_events(log: _WireLog) -> int:
+    return sum(1 for kind in log.types if kind in {"agent_start", "agent_end"})
+
+
+@pytest.mark.asyncio
+async def test_muted_viewer_receives_no_delta_frames(tmp_path) -> None:
+    """THE PINNED REGRESSION: a parked viewer's owner stops sending deltas.
+
+    Against a tree without the server-side filter this fails: ``events_muted``
+    is never consulted, every delta is enqueued, delivered and materialised,
+    and the count below is non-zero. The state-event half is the guard in the
+    other direction -- muting everything would pass the first assertion while
+    silently rotting a parked viewer's turn state.
+    """
+    async with _counting_server(tmp_path, "mute-a") as (server, owner, log):
+        viewer = await AttachedSession.connect(
+            server._record,
+            "synthetic-mute-a",
+            config_dir=tmp_path / "config",
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        try:
+            assert viewer.supports_event_mute, (
+                "the owner must advertise the capability or the viewer cannot "
+                "negotiate the mute at all"
+            )
+            await _mute(viewer, True)
+            baseline = len(log.types)
+
+            for index in range(6):
+                for event in _delta_grade(index):
+                    await owner._emit(event)  # type: ignore[attr-defined]
+            await owner._emit(AgentStartEvent(generation=7))  # type: ignore[attr-defined]
+            await _settle()
+
+            new = log.types[baseline:]
+            assert sum(1 for kind in new if kind in EVENT_MUTE_DROP_TYPES) == 0, (
+                "a muted connection must receive no delta-grade frames; got "
+                f"{[kind for kind in new if kind in EVENT_MUTE_DROP_TYPES]}"
+            )
+            assert any(kind == "agent_start" for kind in new), (
+                "state-bearing events must keep flowing while muted, or a "
+                "parked viewer's turn state silently rots"
+            )
+
+            # And unmuting resumes the stream: the reveal path depends on it.
+            await _mute(viewer, False)
+            baseline = len(log.types)
+            for event in _delta_grade(99):
+                await owner._emit(event)  # type: ignore[attr-defined]
+            await _settle()
+            resumed = [kind for kind in log.types[baseline:] if kind in EVENT_MUTE_DROP_TYPES]
+            assert len(resumed) == len(
+                EVENT_MUTE_DROP_TYPES
+            ), f"deltas must resume after unmute; got {resumed}"
+        finally:
+            await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_mute_is_gated_on_the_capability_new_viewer_old_owner(tmp_path) -> None:
+    """Skew, new viewer x old owner: no capability, no send, no behaviour change.
+
+    An owner that predates ``event-mute-v1`` never advertised it, so the viewer
+    must not send the op. The observable contract is double: the request is
+    refused locally (``supports_event_mute`` False, no task spawned) and the
+    owner keeps delivering everything -- the pre-mute behaviour, which the
+    app-side drop already covers.
+    """
+    async with _counting_server(tmp_path, "mute-b") as (server, owner, log):
+        record = dataclasses.replace(
+            server._record,
+            capabilities=[
+                cap for cap in server._record.capabilities if cap != EVENT_MUTE_CAPABILITY
+            ],
+        )
+        assert EVENT_MUTE_CAPABILITY not in record.capabilities
+        viewer = await AttachedSession.connect(
+            record,
+            "synthetic-mute-b",
+            config_dir=tmp_path / "config",
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        try:
+            assert not viewer.supports_event_mute, (
+                "the viewer must read the capability from the RECORD: sending "
+                "the op blind would raise an error frame against an old owner"
+            )
+            baseline = len(log.types)
+            viewer.set_event_mute(True)  # must be a local no-op, not a send
+            assert not viewer._event_mute_tasks, "no op may be sent without the capability"
+            for index in range(3):
+                for event in _delta_grade(index):
+                    await owner._emit(event)  # type: ignore[attr-defined]
+            await _settle()
+            delivered = [kind for kind in log.types[baseline:] if kind in EVENT_MUTE_DROP_TYPES]
+            assert len(delivered) == len(_delta_grade(0)) * 3, (
+                "without the capability the owner must keep delivering exactly "
+                f"as before; got {delivered}"
+            )
+        finally:
+            await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_old_viewer_against_new_owner_keeps_full_delivery(tmp_path) -> None:
+    """Skew, old viewer x new owner: the default is unmuted, deltas flow.
+
+    A viewer that never sends the op (every shipped build at the time of
+    writing) must see byte-identical behaviour: ``events_muted`` defaults
+    False, the relay sends everything, and the app-side drop remains the only
+    filter. The capability string is advertised so NEW viewers can negotiate.
+    """
+    async with _counting_server(tmp_path, "mute-c") as (server, owner, log):
+        assert (
+            EVENT_MUTE_CAPABILITY in server._record.capabilities
+        ), "the mute must be advertised for clients that know how to ask"
+        viewer = await AttachedSession.connect(
+            server._record,
+            "synthetic-mute-c",
+            config_dir=tmp_path / "config",
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        try:
+            baseline = len(log.types)
+            for index in range(3):
+                for event in _delta_grade(index):
+                    await owner._emit(event)  # type: ignore[attr-defined]
+            await _settle()
+            delivered = [kind for kind in log.types[baseline:] if kind in EVENT_MUTE_DROP_TYPES]
+            assert len(delivered) == len(_delta_grade(0)) * 3
+        finally:
+            await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_reasserts_the_mute(tmp_path) -> None:
+    """The mute is per CONNECTION: a redial must put it back by itself.
+
+    Without the re-assert inside the dial path, a parked viewer that lost its
+    socket resumes paying full delta delivery for the rest of its parking --
+    silently, because the app-side drop keeps the UI correct. The state-event
+    half proves the NEW connection is live, so "no deltas" cannot pass merely
+    because nothing was reconnected.
+    """
+    async with _counting_server(tmp_path, "mute-d") as (server, owner, log):
+        viewer = await AttachedSession.connect(
+            server._record,
+            "synthetic-mute-d",
+            config_dir=tmp_path / "config",
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        try:
+            await _mute(viewer, True)
+
+            # Kill the socket and redial the way recovery does. The desired
+            # mute state is remembered on the viewer, not on the dead client.
+            client = viewer._client
+            assert client is not None
+            client.close()
+            await _settle()
+            pending = await viewer._dial(server._record)
+            if pending is not None:
+                await pending
+            await _settle()
+
+            baseline = len(log.types)
+            for index in range(4):
+                for event in _delta_grade(index):
+                    await owner._emit(event)  # type: ignore[attr-defined]
+            await owner._emit(AgentStartEvent(generation=8))  # type: ignore[attr-defined]
+            await _settle()
+            new = log.types[baseline:]
+            assert any(kind == "agent_start" for kind in new), (
+                "the redialed connection must be live for this test to mean "
+                "anything; no frames on the new socket at all"
+            )
+            assert sum(1 for kind in new if kind in EVENT_MUTE_DROP_TYPES) == 0, (
+                "a parked viewer that reconnected resumed receiving delta "
+                f"frames: {[kind for kind in new if kind in EVENT_MUTE_DROP_TYPES]}"
+            )
+        finally:
+            await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revealed_viewer_ends_with_the_same_settled_state_as_a_live_one(
+    tmp_path,
+) -> None:
+    """Reveal freshness: muted during a turn, equal state at its end.
+
+    The always-live viewer is the control: same owner, same events, never
+    muted. The muted one must end with the same settled row -- the full text,
+    not the fragment it saw before muting -- because the authoritative text
+    travels on the settled row and the reveal rebuilds from history.
+    """
+    async with _counting_server(tmp_path, "mute-e") as (server, owner, log):
+        live = await AttachedSession.connect(
+            server._record,
+            "synthetic-mute-e",
+            config_dir=tmp_path / "config",
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        muted = await AttachedSession.connect(
+            server._record,
+            "synthetic-mute-e",
+            config_dir=tmp_path / "config",
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        try:
+            await _mute(muted, True)
+
+            full_text = "The complete answer, settled while the viewer was parked."
+            partial = Message.assistant("The complete answ")
+            partial.id = "mute-e-live"
+            await owner._emit(AgentStartEvent(generation=9))  # type: ignore[attr-defined]
+            await owner._emit(  # type: ignore[attr-defined]
+                MessageUpdateEvent(message=partial, delta="The complete answ")
+            )
+            settled = _settled_message(0, full_text)
+            from local_operator.harness.types import MessageEndEvent
+
+            await owner._emit(MessageEndEvent(message=settled))  # type: ignore[attr-defined]
+            await owner._emit(  # type: ignore[attr-defined]
+                AgentEndEvent(aborted=False, error=None)
+            )
+            await _settle()
+
+            await _mute(muted, False)
+            await _settle()
+
+            assert live.history_message_count == muted.history_message_count, (
+                "the revealed viewer must hold the same number of durable rows "
+                "as the always-live one"
+            )
+            assert muted.history_message_count >= 1
+            texts = [str(getattr(row, "text", "") or "") for row in muted.display_history_window()]
+            assert any(full_text in text for text in texts), (
+                "the settled row must carry the FULL text after reveal, not the "
+                "fragment the muted viewer saw before the mute: got "
+                f"{[text[:60] for text in texts]}"
+            )
+        finally:
+            await live.dispose()
+            await muted.dispose()
+
+
+@pytest.mark.asyncio
+async def test_controller_park_toggles_the_wire_mute(tmp_path) -> None:
+    """The controller is the caller: ``set_parked`` must drive the session API.
+
+    Pins the app-side wiring so deleting the ``set_event_mute`` call from
+    ``EventController.set_parked`` cannot pass unnoticed even though the wire
+    contract above stays green.
+    """
+    async with _remote(tmp_path, "mute-f") as viewer:
+        calls: list[bool] = []
+        original = viewer.set_event_mute
+
+        def spy(muted: bool) -> None:
+            calls.append(muted)
+            original(muted)
+
+        viewer.set_event_mute = spy  # type: ignore[method-assign]
+
+        from local_operator.tui.events import EventController
+
+        # The real constructor: ``set_parked`` must exercise the production
+        # object, and a park toggle is a synchronous call on the app's loop.
+        controller = EventController(viewer, None)
+
+        controller.set_parked(True)
+        controller.set_parked(False)
+        controller.set_parked(False)  # idempotent: no third call
+
+        assert calls == [True, False], (
+            "parking must ask the owner to mute and reveal to unmute, and an "
+            f"unchanged state must not re-send: got {calls}"
+        )

--- a/tests/unit/tui/test_event_mute_wire.py
+++ b/tests/unit/tui/test_event_mute_wire.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator
@@ -475,3 +476,53 @@ async def test_controller_park_toggles_the_wire_mute(tmp_path) -> None:
             "parking must ask the owner to mute and reveal to unmute, and an "
             f"unchanged state must not re-send: got {calls}"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_daemon_connection_cannot_mute_its_events(tmp_path) -> None:
+    """The mute is attach-only, and a daemon asking for it gets the error frame.
+
+    ``event_mute`` inverts the guard ``desktop_watch`` has
+    (``test_server.py``'s ``test_desktop_visibility_...``): the relay the mute
+    gates is never sent to daemon connections, so a daemon sending this op is
+    a client bug and the honest reply is an error frame rather than a silent
+    no-op. Pins the ``conn.kind != "attach"`` branch — deleting it leaves the
+    rest of this module green, because every other test here dials through a
+    real attach viewer.
+    """
+    config = tmp_path / "config"
+    config.mkdir(exist_ok=True)
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / "synthetic-mute-daemon"
+    await seed_transcript(directory, [])
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    record = server._record
+    reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port, limit=1 << 20)
+    try:
+        # No ``client`` field: that is the daemon default (absent-means-daemon),
+        # which is exactly the connection class the guard must refuse.
+        writer.write(json.dumps({"key": record.control_key}).encode() + b"\n")
+        await writer.drain()
+        welcome = json.loads(await asyncio.wait_for(reader.readline(), timeout=5))
+        assert welcome["op"] == "projection"
+
+        writer.write(json.dumps({"op": "event_mute", "req": 71}).encode() + b"\n")
+        await writer.drain()
+        for _ in range(20):
+            frame = json.loads(await asyncio.wait_for(reader.readline(), timeout=5))
+            if frame.get("op") == "error" and frame.get("req") == 71:
+                break
+        else:
+            raise AssertionError("a daemon event_mute was answered without an error frame")
+        assert (
+            "attach" in frame["message"]
+        ), f"the refusal must name the connection class it requires: {frame['message']!r}"
+    finally:
+        writer.close()
+        server.close()
+        await handle.dispose()


### PR DESCRIPTION
# perf(tui): stop sending delta-grade frames to parked sidebar viewers

## Summary

Opening the sidebar prewarms sessions by attaching real viewer connections it
does not paint. Every delta those viewers received was materialised on the
receiving process's loop — socket read, JSON decode, pydantic deserialization —
and then discarded by the parked controller. This PR moves the discard to the
SENDER: a parked viewer asks its owner to stop sending the same three
delta-grade event types until it is revealed, via a new `event-mute-v1`
capability and the `event_mute`/`event_unmute` ops. It also fixes a per-event
full-state deep copy in `Session._emit` that a parked subscriber re-armed on
sessions whose own terminal was elsewhere.

`Release: patch — perf fix, no new user-visible surface (parked-viewer plumbing plus one full-state-copy removal); no API/config/behaviour change for released viewers.`

## Diagnosis

Reproduced with `scripts/diag/tui_growth.py` (extended in this PR: `--sidebar`,
`--stream/--stream-rate/--stream-chars`, `--profile-idle`, clean
`asyncio.sleep` idle windows with loop-lag sampling, per-channel counters),
N=19 live owners, 12 parked sidebar sources, loop-thread CPU (`thread_time`)
over fixed idle windows on the reporting machine. Host load during these runs
was 50-220 (shared box; single runs vary, the ordering is stable across
repeats):

| cell (3 s idle window) | before: loop CPU ms/s |
|---|---|
| sidebar closed, quiet | 15.1 / 13.7 / 13.3 |
| sidebar open, quiet (12 parked sources) | 24.7 / 28.1 / 14.6 |
| 12 sources streaming @19 ev/s, parked viewers attached | 36.9 / 67.3 / 57.9 |
| the same stream with viewers released | 26.8 / 25.2 / 23.9 |
| 12 sources streaming @38 ev/s, parked viewers attached | Δ +117 ms/s vs released |
| parked + 228 ev/s, 64 KB payloads | 107.3 |
| parked + 228 ev/s, 256 KB payloads | 223.5 |

The parked-viewer term scales with viewers × frames/s × payload bytes and
vanishes the instant the sidebar closes, matching the report. Attribution
(cProfile + counters + a wire-level ceiling arm):

- **Delivery**: each delta was enqueued per parked connection (two `json.dumps`
  per frame per connection: the size-check in `relay_frame_or_degraded` and the
  drain's write), read, `json.loads`-ed, pydantic-deserialized, dispatched —
  and only then dropped. #894 dropped the LAST hop (the Textual message mint
  and app reduction); its own comment says "the cost this closes is the
  delivery, not the handler". Measured here, the delivery is ~95% of the
  per-frame cost and remained. The payload term is `message_update` carrying
  the accumulated message (server.py: "hundreds of KB").
- **Owner path**: `Session._emit` read `store.state.history_generation` — the
  `FrontendStateStore.state` property deep-copies every job, usage row and
  trajectory — on EVERY emitted event whenever the session had any subscriber.
  A parked sidebar source is a subscriber, so opening the sidebar re-armed a
  full-state clone per event. Profile of one 3 s idle window with 12 streaming
  sources: `frontend_state.py:2743(state)` 318 calls, 0.345 s cumulative, all
  from `_emit` (13,674 `deepcopy` calls).

Rejected: viewer-side pre-deserialize drop (pydantic is ~0.005 ms/frame at
256 KB against 0.22 ms of JSON — a fake fix); deferring the event subscription
entirely (reopens the server-side buffering hazard #894 documents and would
slow every reveal); changing what the frames carry (protocol contract).

## Wire contract

- **Capability**: `event-mute-v1`, advertised unconditionally on the runtime
  record (it is a property of the relay, not of the handle). `PROTOCOL_VERSION`
  is unchanged, following the `recall_steer` precedent for additive ops.
- **Ops**: `event_mute` / `event_unmute`, per connection, idempotent, attach
  clients only; they mutate the connection's relay state and never touch the
  session, so they live in the control loop beside `watch_job` rather than in
  `_dispatch`.
- **Exactly what is skipped while muted**: `EVENT_MUTE_DROP_TYPES` —
  `message_update` (one per assistant token), `tool_execution_update` (one per
  streamed tool-output chunk), `subagent_progress` (one per child beat). That
  is deliberately the same set the parked `EventController` already discards
  app-side, now defined once and shared, so the halves cannot drift.
  `message_start`/`message_end`, every turn/agent boundary, tool start/end,
  compaction, retry, model change and delivery notices are NOT muted: a parked
  source's state must still be right when revealed.
- **Reveal semantics**: unchanged from #894 — the presentation rebuilds from
  history plus the canonical `live_events` seed and the remaining deltas
  resume; the settled row's authoritative text heals anything that streamed
  during the parked window. Worst case at the unmute boundary: tokens that
  stream during the unmute round-trip are absent from the live block until the
  message's end adopts the full text — the same healing path the parked drop
  already relies on.
- **Reconnect**: the mute is per CONNECTION, so the viewer remembers the
  requested state and the dial path re-asserts it (bounded at 5 s so a wedged
  owner cannot hold a redial open over an optimisation).
- **Skew both ways**: new viewer × old owner — the capability is read from the
  record at dial; without it the viewer refuses locally and sends nothing
  (pre-mute behaviour, app-side drop still covers it). Old viewer × new owner —
  `events_muted` defaults False; delivery is byte-identical to today.

## Changes

1. Wire mute: `session/runtime/types.py`, `session/runtime/server.py`,
   `session/attached.py`, `mobile/attach_client.py`, `tui/events.py`,
   `docs/SESSION_SIDEBAR.md`.
2. `_emit` scalar read: `read_field("history_generation")` (the allow-listed
   accessor) instead of the deep-copying `state` property
   (`session/session.py`).
3. Tests: `tests/unit/tui/test_event_mute_wire.py`,
   `tests/unit/session/test_emit_state_reads.py`.
4. Harness: `scripts/diag/tui_growth.py` (the switches and counters above).

## Benchmarks (before → after, same machine, same harness)

Idle loop CPU ms/s, N=19, 12 parked sources, three checkpoints per cell,
interleaved repeats:

| cell | before (origin/main @ 20d8c596c) | after (this PR) |
|---|---|---|
| open quiet | 24.7 / 28.1 / 14.6 | 28.5 / 14.3 / 14.0 · 25.9 / 13.7 / 12.4 |
| closed quiet | 15.1 / 13.7 / 13.3 | 13.7 / 13.6 / 17.1 · 10.7 / 15.6 / 16.4 |
| open, 12 × 19 ev/s (228 ev/s) | 36.9 / 67.3 / 57.9 | 35.3 / 29.2 / 30.1 · 36.8 / 36.7 / 31.5 |
| closed, same stream | 26.8 / 25.2 / 23.9 | 26.5 / 26.2 / 30.6 · 24.2 / 24.9 / 27.4 |
| open, 228 ev/s, 64 KB payloads | 107.3 | 38.5 / 37.7 |
| open, 228 ev/s, 256 KB payloads | 223.5 | 35.9 / 37.4 |

- **Open ≈ closed at the same stream** after the fix (29-37 vs 24-31 ms/s,
  within run noise), against a 34-43 ms/s gap before. The flat payload rows are
  the decisive signal: 256 KB frames cost the same as tiny ones because they
  are never sent, parsed or validated.
- Parked-viewers-vs-released isolation probe, same stream both arms:
  before Δ +68 ms/s at 228 ev/s and +117 ms/s at 456 ev/s; after Δ +25 ms/s at
  both rates. The residual is the in-process fixture's owner-side per-event
  fold (canonical `live_events` upkeep), which production pays in the OWNER
  process, not the TUI — the wire delivery itself is gone, pinned by the
  wire-level test below.
- Keystroke medians (pilot-driven; this host's load 50-220 makes them noisy —
  reported for shape, not as a bound): before open-stream 88-120 ms vs closed
  65-68; after open-stream 106-186 vs closed 90-146, all inside the same
  run-to-run spread on a box whose closed-quiet medians moved 70-108 ms
  between repeats.
- Host contention: load average 50-220 throughout (shared machine, ~19 agent
  sessions). Every cell is A/B on the same machine in the same session, and
  each is repeated; medians above.

## Test evidence

- **Unit, TUI suite**: 7073 passed, 12 skipped.
- **Unit, rest of tree**: 11552 passed, 6 skipped.
- **e2e**: `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest
  tests/e2e -m e2e -n0 -q` → 107 passed, 7 skipped.
- **Gates**: flake8 `.` clean; black 26.1.0 `--check .` clean; isort 5.13.2
  `--check .` clean; pyright 0 errors.
- **Mutation proofs** (the technique AGENTS.md prescribes — revert the fix,
  watch the test fail): neutralising the relay filter fails
  `test_muted_viewer_receives_no_delta_frames` (18 frames delivered) and
  `test_reconnect_reasserts_the_mute` (12 frames); restoring
  `store.state.history_generation` fails the clone guard with the deep copy
  named. Both reverted and re-run green afterwards.
- **Functional probes on the real path**: a parked controller receives 0
  delta frames and 2 state events through a real socket pair; after unmute the
  deltas resume; the reveal-freshness test ends with the same durable row as
  an always-live viewer.
- **CI**: all checks green on 14b2a13cf (cli-sanity needed one rerun: the live-LLM smoke turn did not create test.txt on the first attempt — no mechanism from this diff).

## Risks and limits

- The mute is an optimization over an existing drop; correctness never depends
  on an op landing (the app-side drop remains underneath).
- Mixed-version estates are exercised in both directions by tests.
- The `_emit` change swaps a public property read for the store's documented
  allow-listed accessor; the allow-list is enforced, not documented.

## Reviewer/QA probes

- Delete the relay filter (or the op branch): the pinned wire test must fail.
- Revert `read_field` to `store.state`: the clone guard must fail.
- Park/unpark repeatedly against a live streaming owner and confirm the
  reveal shows the full message (settled row), and that an owner with several
  parked viewers shows no per-frame fan-out for them.
- Probe the unmute boundary explicitly: park mid-stream, reveal, confirm no
  permanent text gap after the message settles.

