### PR TITLE
fix(evaluation): record every refused reply by class, and name the accepted shape

### DIFF
--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -2220,8 +2220,15 @@ def _failure_detail(error: BaseException, redactions: RedactionSet | None = None
     return "\n".join(lines)
 
 
-def _rejection_detail(rejected: Any, redactions: RedactionSet | None = None) -> str:
+def _rejection_detail(rejected: Any, redactions: RedactionSet | None) -> str:
     """The rejection artifact: why the reply was refused AND what it said.
+
+    ``redactions`` is REQUIRED rather than defaulted, exactly as in
+    ``_diagnostic``: this is the one artifact that publishes raw model output,
+    so the UNSAFE call -- publishing unscanned -- must not be the shorter one to
+    write. Every call site therefore has to state which of the two cases it is:
+    the episode's set, or an explicit ``None`` meaning "this rendering is
+    in-process only and never reaches evidence".
 
     Three parts in a fixed order a script can rely on: the harness's model-facing
     diagnostic, then the CLASS KEY and per-attempt STREAM SHAPE when the client
@@ -2249,7 +2256,7 @@ def _rejection_detail(rejected: Any, redactions: RedactionSet | None = None) -> 
     sections = [rejected.diagnostic]
     class_key = getattr(rejected, "class_key", None)
     if isinstance(class_key, str) and class_key:
-        sections.append(f"class: {class_key}")
+        sections.append(f"class: {_header_value(class_key)}")
     shape = getattr(rejected, "stream_shape", None)
     if shape is not None:
         sections.append(
@@ -2257,7 +2264,7 @@ def _rejection_detail(rejected: Any, redactions: RedactionSet | None = None) -> 
             f"content_deltas={shape.content_deltas} "
             f"reasoning_deltas={shape.reasoning_deltas} "
             f"tool_call_deltas={shape.tool_call_deltas} "
-            f"stop={shape.stop}"
+            f"stop={_header_value(shape.stop)}"
         )
     # ``evidence_reply`` is the boundary that may carry the reply into evidence;
     # ``reply`` is the history rendering and is the fallback for a client that
@@ -2270,6 +2277,22 @@ def _rejection_detail(rejected: Any, redactions: RedactionSet | None = None) -> 
     rendered = rejected_reply_evidence(reply, redactions)
     sections.extend(["", "--- rejected reply ---", rendered])
     return "\n".join(sections)
+
+
+def _header_value(value: str) -> str:
+    """A value safe to place inside a one-line artifact header.
+
+    The stop marker and the class key are TEXT, and the artifact's reader relies
+    on a fixed section order: a marker carrying a newline would otherwise open a
+    line that reads like another header, and a control character could hide the
+    rest of the section behind a terminal's interpretation of it. Escaped rather
+    than truncated -- the builder's 64-character bound does not neutralise a
+    short injection -- and ``unicode_escape`` leaves an ordinary ASCII marker
+    byte-identical to what the provider sent, so ``stop=stop`` still reads as
+    the marker itself.
+    """
+
+    return value.encode("unicode_escape").decode("ascii")
 
 
 def _diagnostic(error: BaseException, redactions: RedactionSet | None) -> str:

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -1042,8 +1042,16 @@ class EpisodeRunner:
             # whether the turn was a mistyped keyboard action or a stray
             # sentence after the JSON. Without the reply, diagnosing a
             # rejection class costs a whole re-run of a paid episode.
+            #
+            # The episode's redaction set is forwarded because this is the one
+            # artifact that publishes raw model output: the scan has to happen
+            # before the bound, and only this side of the boundary holds the
+            # resolved canaries. The class key and stream shape ride along for
+            # a reader counting rejection classes and telling an empty reply
+            # apart from a discarded one.
             detail = self._publish(
-                _rejection_detail(rejected).encode("utf-8"), media_type="text/plain"
+                _rejection_detail(rejected, self._redactions).encode("utf-8"),
+                media_type="text/plain",
             )
             self._append(
                 "error",
@@ -2212,21 +2220,56 @@ def _failure_detail(error: BaseException, redactions: RedactionSet | None = None
     return "\n".join(lines)
 
 
-def _rejection_detail(rejected: Any) -> str:
+def _rejection_detail(rejected: Any, redactions: RedactionSet | None = None) -> str:
     """The rejection artifact: why the reply was refused AND what it said.
 
-    Two sections rather than one blob, so a reader (or a script mining a batch
-    of bundles for rejection classes) can tell the harness's diagnostic apart
-    from the model's own words. A client that did not capture the reply --
-    every implementation of the protocol is free not to -- degrades to the
-    diagnostic alone rather than emitting an empty section that reads as "the
-    model said nothing".
+    Three parts in a fixed order a script can rely on: the harness's model-facing
+    diagnostic, then the CLASS KEY and per-attempt STREAM SHAPE when the client
+    recorded them, and finally the model's own words. The first line is unchanged
+    from before this artifact learned to carry classes, so anything reading a
+    rejection artifact's first line keeps working.
+
+    The class key is what makes a batch of bundles countable: deriving a
+    rejection class from Pydantic prose after the fact is guesswork, and the
+    prose used to be the only thing recorded. The stream shape answers the one
+    question the reply cannot: a refusal whose reply is empty may have been
+    EMPTY or DISCARDED, and the delta counts tell those apart.
+
+    The reply is redaction-scanned and bounded by
+    :func:`rejected_reply_evidence`, which fails closed and WHOLE -- so a reply
+    that cannot be cleared is replaced by a marker rather than being published
+    in part, and the diagnostic above it still makes the rejection readable.
+    A client that did not capture the reply -- every implementation of the
+    protocol is free not to -- degrades to the diagnostic (and class) alone
+    rather than emitting an empty section that reads as "the model said nothing".
     """
 
-    reply = getattr(rejected, "reply", None)
+    from local_operator.evaluation.runner.public_reply import rejected_reply_evidence
+
+    sections = [rejected.diagnostic]
+    class_key = getattr(rejected, "class_key", None)
+    if isinstance(class_key, str) and class_key:
+        sections.append(f"class: {class_key}")
+    shape = getattr(rejected, "stream_shape", None)
+    if shape is not None:
+        sections.append(
+            "stream: "
+            f"content_deltas={shape.content_deltas} "
+            f"reasoning_deltas={shape.reasoning_deltas} "
+            f"tool_call_deltas={shape.tool_call_deltas} "
+            f"stop={shape.stop}"
+        )
+    # ``evidence_reply`` is the boundary that may carry the reply into evidence;
+    # ``reply`` is the history rendering and is the fallback for a client that
+    # never recorded the two separately.
+    reply = getattr(rejected, "evidence_reply", None)
+    if reply is None:
+        reply = getattr(rejected, "reply", None)
     if not reply:
-        return rejected.diagnostic
-    return f"{rejected.diagnostic}\n\n--- rejected reply ---\n{reply}"
+        return "\n".join(sections)
+    rendered = rejected_reply_evidence(reply, redactions)
+    sections.extend(["", "--- rejected reply ---", rendered])
+    return "\n".join(sections)
 
 
 def _diagnostic(error: BaseException, redactions: RedactionSet | None) -> str:

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -112,6 +112,37 @@ class EpisodeTurn(ProtocolModel):
     ask_answer: str | None = None
 
 
+class StreamShape(ProtocolModel):
+    """The shape of ONE attempt's provider stream, counted per event kind.
+
+    Recorded beside a refusal because the counts are the only thing that says
+    whether an empty-looking reply was empty: a turn with a large
+    ``reasoning_deltas`` and zero ``content_deltas`` produced work on the
+    reasoning channel, while all-zero counts under a normal ``stop`` mean the
+    provider sent nothing at all. Without them a reader of the evidence cannot
+    tell a model that thought and said nothing from a client that discarded
+    what it said -- which is why :class:`StreamReasoningDelta` exists at all.
+
+    Counts of EVENTS, not of tokens or characters: the wire client emits one
+    delta per provider chunk, so these are bounded by the provider's own
+    chunking, and ``stop`` is the provider's raw terminal marker (never
+    normalised, since the marker is exactly what a reader needs to bucket the
+    attempt).
+    """
+
+    content_deltas: SafeCount = 0
+    reasoning_deltas: SafeCount = 0
+    tool_call_deltas: SafeCount = 0
+    #: The provider's raw terminal marker, recorded VERBATIM and deliberately a
+    #: plain ``str`` rather than a ``StrictIdentifier``. The vocabulary here
+    #: belongs to the provider: a marker our identifier pattern would reject
+    #: (``function_call``, a vendor's ``SAFETY``, a future wire client's
+    #: normalisation) would make this record fail validation and turn a refusal
+    #: into a crash -- on a path whose whole job is to describe the refusal. The
+    #: builder truncates it, so it cannot grow the artifact unbounded either.
+    stop: str = "unspecified"
+
+
 class DecisionRejected(Exception):
     """The provider answered, and was billed, but the reply is not a usable batch.
 
@@ -152,6 +183,9 @@ class DecisionRejected(Exception):
         prompt_cache_key: str | None = None,
         context_tokens: int | None = None,
         compaction: CompactionRecord | None = None,
+        class_key: str | None = None,
+        evidence_reply: str | None = None,
+        stream_shape: StreamShape | None = None,
     ) -> None:
         super().__init__(diagnostic)
         self.diagnostic = diagnostic
@@ -163,7 +197,33 @@ class DecisionRejected(Exception):
         # "something with a `key` field" and "trailing junk after the JSON";
         # the replies themselves were discarded, so the failure class could
         # not be diagnosed without paying for the run again.
+        #
+        # ``reply`` is the HISTORY rendering of that reply: the words replayed
+        # back as the assistant's own turn so the correction has something to
+        # correct. It is bounded, and for a reply that touched the reserved
+        # envelope it is the placeholder instead of the reply, because that
+        # text is unvalidated and may carry notes the episode's redaction set
+        # forbids replaying. ``evidence_reply`` below is the OTHER boundary --
+        # see its own comment -- and the two must be allowed to differ.
         self.reply = reply
+        # The reply as EVIDENCE may publish it: raw, and bounded and
+        # redaction-scanned by the publisher rather than here, because the
+        # scan needs the episode's resolved-secret set (``episode.py`` has it;
+        # this exception is constructed where the reply is refused).
+        #
+        # Separate from ``reply`` on purpose. Withholding the model's own words
+        # from the bundle made the rejection classes unreadable -- in the
+        # MiniMax campaign 273 of 280 rejection artifacts carried the
+        # placeholder instead of the reply -- while the reason for withholding
+        # (unvalidated notes must not be replayed as history, and no secret may
+        # reach evidence) applies to only one of the two boundaries.
+        self.evidence_reply = evidence_reply
+        # The class the refusal was bucketed into, and the stream that produced
+        # it. Both ride into the rejection artifact so a reader can group
+        # rejections without re-deriving the class from prose, and so an empty
+        # reply can be told apart from a discarded one.
+        self.class_key = class_key
+        self.stream_shape = stream_shape
         # The served route matters even for a rejected reply: a fallback that
         # answered badly still moved the run off its pinned route.
         self.route = route

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -24,10 +24,12 @@ is documented on :meth:`_ContextBuilder.build`.
 from __future__ import annotations
 
 import base64
+import difflib
 import json
 import re
 import textwrap
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, get_args, get_origin
 
@@ -44,14 +46,19 @@ from local_operator.evaluation.runner.model import (
     EpisodeTurn,
     ModelDecision,
     ModelUsage,
+    StreamShape,
+)
+from local_operator.evaluation.runner.public_reply import MAX_PUBLIC_OBSERVATIONS_CHARS
+from local_operator.evaluation.runner.public_reply import (
+    MAX_REJECTED_REPLY_CHARS as _MAX_REJECTED_REPLY_CHARS,
 )
 from local_operator.evaluation.runner.public_reply import (
-    MAX_PUBLIC_OBSERVATIONS_CHARS,
     PUBLIC_REPLY_TOOL_DESCRIPTION,
     REJECTED_PUBLIC_REPLY,
     REPLY_VERSION,
     decode_public_reply,
     is_public_reply,
+    is_quotable_key,
     looks_like_public_reply,
     public_reply_contract,
     public_reply_schema,
@@ -83,10 +90,10 @@ DEFAULT_KEEP_RECENT_FRAMES = 3
 DEFAULT_REBUILD_EVERY_FRAMES = 8
 
 #: Longest slice of a rejected reply replayed into the context as the model's
-#: own words before the correction. The reply has to be there -- the model
-#: must see WHAT it said to fix it -- but a runaway reply (a provider's
-#: max-token wall of prose) must not cost the whole window on the retry.
-MAX_REJECTED_REPLY_CHARS = 4_000
+#: own words before the correction. Declared in ``public_reply.py`` because the
+#: EVIDENCE rendering of the same reply is bounded by it while publishing, in a
+#: module that must not import this client.
+MAX_REJECTED_REPLY_CHARS = _MAX_REJECTED_REPLY_CHARS
 
 #: Longest run of tolerated trailing noise quoted into the observable warning
 #: when a decision parses as a leading JSON value followed by junk. The point
@@ -213,6 +220,625 @@ def _type_name(annotation: Any) -> str:
     if len(args) == 1:
         return _type_name(args[0])
     return "value"
+
+
+# ---------------------------------------------------------------------------
+# Refusal diagnosis: which class a refused reply belongs to, and what the model
+# is told about it.
+# ---------------------------------------------------------------------------
+#
+# Two outputs, one classification. The CLASS KEY is recorded in the rejection
+# artifact so a batch of bundles can be grouped without re-deriving the class
+# from prose; the HINT replaces the validator's own text in the message the
+# model receives, because a validator states the field it refused and the model
+# needs the shape it must send instead. The repo has already measured the
+# difference that makes: naming the defect recovered 9/10 where a bare rule
+# recovered 4/10 (``decode_public_reply``).
+#
+# Classification reads the DIAGNOSTIC STRING rather than the exception object,
+# and that is deliberate rather than a shortcut. The string is the one input
+# both paths share: at run time the client has the exception and the text it
+# renders, and offline the only thing a sealed bundle kept is that text -- the
+# reply itself was replaced by the placeholder or left out entirely in 273 of
+# the MiniMax campaign's 280 rejection artifacts (counted 2026-09-12). One
+# classifier, both paths, so the offline histogram measures the same function
+# the runner runs.
+#
+# It keys on two kinds of marker, in this order: the harness's OWN message
+# templates, which are ours to keep stable, and pydantic's error TYPE CODES
+# (``[type=extra_forbidden]``), which are a documented API. Never on validator
+# wording, which is pydantic's to change.
+
+#: Nothing matched. A distinct key rather than an exception: a refusal whose
+#: message changed shape must still be recordable and still produce a hint.
+REJECTION_CLASS_UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RejectionEvidence:
+    """What one refusal is called, what the model is told, and what is kept.
+
+    One value rather than three derived at three call sites, so the class key
+    in the bundle is by construction the class the hint was built for, and a
+    test can pin the pair.
+    """
+
+    class_key: str
+    hint: str
+    #: The reply as evidence may publish it: raw, for the publisher to scan and
+    #: bound (it holds the episode's redaction set; this module must not).
+    evidence_reply: str | None
+    stream_shape: StreamShape | None
+
+
+def classify_rejection(reason: str) -> str:
+    """Name the class of a refused reply from its diagnostic text.
+
+    Ordered most specific first, because several markers co-occur: a Pydantic
+    ``ValidationError`` always ends its rendering with a summary entry, so an
+    ``extra_forbidden`` on a real field is reported alongside a ``too_short``
+    on the emptied ``actions`` tuple. The first marker is the one the model
+    must act on.
+    """
+
+    if "outside model-visible frame" in reason:
+        return "out-of-frame-coordinate"
+    if "unknown frame_id" in reason:
+        return "unknown-frame-id"
+    if "unknown key:" in reason:
+        return "unknown-key"
+    if "type=extra_forbidden" in reason:
+        return "extra-action-key"
+    if "type=tuple_type" in reason:
+        # The wrapper shape: the model sent ``{"item": [...]}`` where the
+        # protocol takes the array itself.
+        return "keys-not-array"
+    if "type=union_tag_invalid" in reason:
+        return "unknown-action-kind"
+    if "is not valid JSON" in reason or "duplicate-free JSON object" in reason:
+        return "malformed-json"
+    if "unsupported model reply version" in reason:
+        return "unsupported-reply-version"
+    if (
+        "reserved envelope" in reason
+        or "model reply requires exactly" in reason
+        or "action_batch requires exactly" in reason
+        or "public_observations must be" in reason
+    ):
+        return "envelope-shape"
+    if "second action batch" in reason:
+        return "second-batch"
+    if "no tool call and no text" in reason:
+        return "empty-reply"
+    if "bind to a different observation_id" in reason or "does not bind to the current" in reason:
+        return "observation-binding"
+    if "non-empty actions array" in reason or "decision must be a JSON object" in reason:
+        return "batch-shape"
+    if (
+        "supports only ASCII" in reason
+        or "is limited to" in reason
+        or "not supported by this adapter" in reason
+    ):
+        # The adapter's own negotiated restriction, which ``ActionSurface``
+        # already phrases with the alternative it CAN carry.
+        return "adapter-capability"
+    if "type=" in reason or "validation error" in reason:
+        return "field-invalid"
+    return REJECTION_CLASS_UNKNOWN
+
+
+#: Markers whose message ALREADY states the defect and the accepted shape, and
+#: was measured doing it. The hint keeps them verbatim: the envelope diagnostic
+#: in ``decode_public_reply`` names the keys carried and omitted and recovered
+#: 9/10 on the model that produced this corpus, and the adapter, empty-reply and
+#: second-batch messages name the limit, the alternative and the rule. Rewriting
+#: one of these would throw away the only part of this that was ever measured.
+#:
+#: Every one of them is the harness's OWN sentence. A class whose diagnostic
+#: comes from a Pydantic rendering is never preserved: that rendering embeds
+#: ``input_value=`` and a docs URL, which must not reach the model.
+_PRESERVED_HINTS = frozenset(
+    {
+        "envelope-shape",
+        "second-batch",
+        "batch-shape",
+        "adapter-capability",
+        "empty-reply",
+    }
+)
+
+#: Key names a model reaches for that the validator refuses, mapped to the name
+#: it accepts. Only ever emitted when the target is in ``surface.named_keys``,
+#: so a removed key cannot leave a suggestion pointing at nothing. The first
+#: three are the synonyms the system prompt already names as wrong; the rest
+#: are the OS key names (``super``, ``win``, ``cmd``, ``option``) that mean a
+#: named key the prompt lists under a different word.
+_KEY_ALIASES = {
+    "return": "ENTER",
+    "control": "CTRL",
+    "escape": "ESC",
+    "closes": "ESC",
+    "del": "DELETE",
+    "super": "META",
+    "win": "META",
+    "windows": "META",
+    "cmd": "META",
+    "command": "META",
+    "option": "ALT",
+    "spacebar": "SPACE",
+    "page_up": "PAGEUP",
+    "page_down": "PAGEDOWN",
+    "caps": "CAPSLOCK",
+    "pgup": "PAGEUP",
+    "pgdn": "PAGEDOWN",
+}
+
+#: Extraction patterns over a diagnostic. The first finds a Pydantic LOCATION
+#: line (``actions.0.wait.frame_id``), which names a field and a literal kind and
+#: never a value; the rest pull the harness's own rule sentence and a refused
+#: name out of Pydantic's rendering without keeping the rendering.
+_ACTION_FIELD_PATH = re.compile(r"^actions(?:\.([A-Za-z0-9_-]+))*$", re.MULTILINE)
+_VALUE_ERROR_RULE = re.compile(r"Value error, (.+?) \[type=")
+_UNKNOWN_KEY_NAME = re.compile(r"unknown key: '(.*?)' \[type=")
+_QUOTED_TAG = re.compile(r"Input tag '(.*?)' found using 'kind'")
+_MAX_RULE_CHARS = 200
+
+
+def rejection_evidence(
+    reply_text: str,
+    reason: str,
+    observation: Observation,
+    surface: ActionSurface,
+    stream_shape: StreamShape | None,
+) -> RejectionEvidence:
+    """Classify one refused reply and derive both messages from it.
+
+    PURE: every input is data the attempt has already produced, and the only
+    effect is the returned value. Evidence recording therefore cannot change
+    which decisions are made -- pinned by
+    ``test_recording_the_rejection_does_not_change_the_decision_sequence``,
+    which runs the same scripted defective-then-corrected reply with this
+    called and with it replaced by a stub.
+    """
+
+    class_key = classify_rejection(reason)
+    return RejectionEvidence(
+        class_key=class_key,
+        hint=rejection_hint(class_key, reason=reason, observation=observation, surface=surface),
+        evidence_reply=reply_text or None,
+        stream_shape=stream_shape,
+    )
+
+
+def rejection_hint(
+    class_key: str,
+    *,
+    reason: str,
+    observation: Observation,
+    surface: ActionSurface = LEGACY_ACTION_SURFACE,
+) -> str:
+    """The model-facing correction for one refusal class.
+
+    Every branch states the accepted shape, literal, or bound -- never the
+    validator's rendering of the value it refused. That is the same rule
+    ``_diagnostic`` applies, for the same reason: a Pydantic ``str()`` embeds
+    ``input_value=<head>...<tail>`` and a docs URL, and the one boundary that
+    carries secret bytes would otherwise be quoted straight into the model's
+    next request. A test asserts it per class.
+    """
+
+    if class_key in _PRESERVED_HINTS:
+        return reason
+    if class_key == "malformed-json":
+        return (
+            "the reply was not one complete JSON object -- it may have been cut "
+            "off, wrapped in a code fence, or written in a native tool-call "
+            "syntax. Reply with exactly one JSON object and nothing else: "
+            f"{_example_json(surface, observation)}"
+        )
+    if class_key == "unsupported-reply-version":
+        return (
+            'the reply declared a "reply_version" this harness does not serve. '
+            f'The only accepted value is "{REPLY_VERSION}"'
+        )
+    if class_key == "extra-action-key":
+        return _extra_action_key_hint(reason, surface, observation)
+    if class_key == "unknown-action-kind":
+        return _unknown_action_kind_hint(reason, surface)
+    if class_key == "unknown-key":
+        return _unknown_key_hint(reason, surface)
+    if class_key == "keys-not-array":
+        return (
+            f'"{_keys_field_name(surface)}" takes {_keys_shape(surface)} written directly, '
+            f"e.g. {json.dumps(_keys_example(surface))} -- not an object wrapping the "
+            "names. Do not add a container of your own."
+        )
+    if class_key == "out-of-frame-coordinate":
+        # Appended rather than replaced: the message already names the
+        # coordinate the model chose, which is the half it needs to see to
+        # recognise its own mistake. What it lacked was the BOUND -- "outside
+        # the frame" does not say which pixels are inside it.
+        return f"{reason}. {_coordinate_bounds(observation)}"
+    if class_key == "unknown-frame-id":
+        return f"{reason}. {_frame_id_hint(observation)}"
+    if class_key == "observation-binding":
+        return (
+            "every action must carry the "
+            f'"observation_id" of the observation being answered: "{observation.observation_id}"'
+        )
+    if class_key == "field-invalid":
+        return _field_invalid_hint(reason, observation, surface)
+    # Anything unmatched: state the accepted envelope so the model has the shape
+    # even when the class is one this build has never seen.
+    return (
+        "the reply was refused before anything was executed. Reply with exactly "
+        f"one JSON object and nothing else: {_example_json(surface, observation)}"
+    )
+
+
+def _example_json(surface: ActionSurface, observation: Observation) -> str:
+    """One concrete accepted reply, built from the enforced envelope schema.
+
+    Read from ``public_reply_schema`` rather than hand-written, so the example
+    cannot advertise a key or a version the decoder would refuse -- the same
+    guarantee ``_action_schema_lines`` gives the system prompt.
+    """
+
+    schema = public_reply_schema(surface)
+    required = list(schema["required"])
+    # The prompt's own order first, then anything the schema requires that this
+    # build does not know: the example stays readable, and a fourth envelope key
+    # still cannot be omitted from it.
+    ordered = [
+        key for key in ("reply_version", "action_batch", "public_observations") if key in required
+    ]
+    ordered += [key for key in required if key not in ordered]
+    example: dict[str, Any] = {}
+    for key in ordered:
+        properties = schema["properties"][key]
+        if key == "reply_version":
+            example[key] = properties["const"]
+        elif key == "action_batch":
+            example[key] = {"actions": [_example_action(surface, observation)]}
+        else:
+            example[key] = ""
+    return json.dumps(example)
+
+
+def _example_action(surface: ActionSurface, observation: Observation) -> dict[str, Any]:
+    """One concrete action of the first kind this surface admits.
+
+    Values are placeholders EXCEPT the two the model most often gets wrong and
+    which are knowable here: the observation id and the frame id. Both are
+    taken from the observation in hand, so the example is executable shape, not
+    prose about it.
+    """
+
+    model = surface.models[0]
+    fields = model.model_fields
+    action: dict[str, Any] = {"kind": fields["kind"].default}
+    for name, field in fields.items():
+        if name == "kind":
+            continue
+        action[name] = _example_field_value(name, field, observation)
+    return action
+
+
+def _example_field_value(name: str, field: Any, observation: Observation) -> Any:
+    if name == "observation_id":
+        return observation.observation_id
+    if name == "frame_id":
+        frames = list(observation.frames)
+        return frames[0].frame_id if frames else "<frame_id>"
+    choices = get_args(field.annotation)
+    if choices and all(isinstance(choice, str) for choice in choices):
+        return choices[0]
+    rendered = _type_name(field.annotation)
+    if rendered == "int":
+        return 0
+    if rendered == "str":
+        return "<text>"
+    return "<value>"
+
+
+def _type_name_is_array(annotation: Any) -> bool:
+    return get_origin(annotation) in (tuple, list, set, frozenset)
+
+
+def _keys_shape(surface: ActionSurface) -> str:
+    """The accepted shape of the key-chord field, read from the field itself.
+
+    Drift-pinned the same way the system prompt is: mutating ``KeyAction``'s
+    ``keys`` annotation changes what this renders, so a protocol change cannot
+    leave the correction telling the model to send a shape the validator refuses
+    (``test_the_hint_is_derived_from_the_schema``). Falls back to the shape the
+    protocol documents today when a surface somehow carries no key action.
+    """
+
+    field = _action_field(surface, "key", "keys")
+    if field is None:
+        return "an array of key names"
+    return _field_shape(field, name="keys")
+
+
+def _keys_field_name(surface: ActionSurface) -> str:
+    for name in ("keys", "key"):
+        if _action_field(surface, "key", name) is not None:
+            return name
+    return "keys"
+
+
+def _keys_example(surface: ActionSurface) -> list[str]:
+    """Three key names the validator accepts, one of them a printable key.
+
+    Derived from the surface's vocabulary so the example cannot name a key the
+    enforcement set does not carry. The single printable character is the case
+    a model most often misses: ``"grave"`` is refused, ``"`"`` is not.
+    """
+
+    named = {key.upper() for key in surface.named_keys}
+    example = [key.lower() for key in ("CTRL", "ALT") if key in named]
+    return [*example, "t"]
+
+
+def _action_field(surface: ActionSurface, kind: str, name: str) -> Any | None:
+    for model in surface.models:
+        if model.model_fields["kind"].default != kind:
+            continue
+        return model.model_fields.get(name)
+    return None
+
+
+def _action_kind_of(model: Any) -> str:
+    return str(model.model_fields["kind"].default)
+
+
+def _field_shape(field: Any, *, name: str) -> str:
+    """The accepted shape of one action field, read from its own constraints.
+
+    Best-effort by design and bounded to what a model can act on: the literal
+    set, the array element kind, or the numeric/length bound. Anything else
+    degrades to the JSON type name rather than to a guess.
+    """
+
+    choices = get_args(field.annotation)
+    if choices and all(isinstance(choice, str) for choice in choices):
+        return "one of " + ", ".join(json.dumps(choice) for choice in choices)
+    if _type_name_is_array(field.annotation):
+        if name == "keys":
+            return "an array of key names"
+        return "an array"
+    if _type_name(field.annotation) == "int":
+        lower = _bound(field, "ge")
+        upper = _bound(field, "le")
+        if lower is not None and upper is not None:
+            return f"an integer from {lower} to {upper}"
+        return "an integer"
+    if _type_name(field.annotation) == "str":
+        lower = _bound(field, "min_length")
+        upper = _bound(field, "max_length")
+        if lower == 1 and upper is not None:
+            return f"a non-empty string of at most {upper} characters"
+        if lower is not None and upper is not None:
+            return f"a string of {lower} to {upper} characters"
+        return "a string"
+    return "a value"
+
+
+def _bound(field: Any, attribute: str) -> int | None:
+    for constraint in field.metadata:
+        value = getattr(constraint, attribute, None)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _field_invalid_hint(reason: str, observation: Observation, surface: ActionSurface) -> str:
+    """Name the field the validator refused and the shape it accepts.
+
+    The one class of hint built from a Pydantic LOCATION: the rendered path is
+    ``actions.<index>.<kind>.<field>``, which is a field name and a literal
+    kind, never the value -- the location is safe for the same reason
+    ``_diagnostic`` keeps it.
+
+    A protocol rule that belongs to the whole batch rather than to one field
+    (``scroll requires a non-zero delta``) is quoted from the ``Value error,``
+    line, bounded. Quoting the rule is what keeps this class from degrading into
+    "something was wrong somewhere": the rule is the harness's own sentence
+    about why, and it is the only part of Pydantic's rendering that survives
+    here. ``input_value=`` and the docs URL around it do not.
+    """
+
+    rule = _VALUE_ERROR_RULE.search(reason)
+    quoted_rule = rule.group(1)[:_MAX_RULE_CHARS] if rule is not None else ""
+    path = _first_field_path(reason)
+    if len(path) >= 3 and path[0] == "actions":
+        kind = path[2]
+        name = path[3] if len(path) > 3 else ""
+        field = _action_field(surface, kind, name) if name else None
+        if field is not None:
+            return (
+                f'"{name}" in a "{kind}" action was refused: it takes '
+                f"{_field_shape(field, name=name)}. "
+                f"The kind's full shape is {_action_line(surface, kind)}."
+            )
+        rule_text = f" The rule it broke: {quoted_rule}." if quoted_rule else ""
+        return (
+            f'a "{kind}" action was refused.{rule_text} '
+            f"Its accepted shape is {_action_line(surface, kind)}."
+        )
+    if quoted_rule:
+        # A batch-level rule from one of the protocol's own model validators.
+        # Bounded, and quoted from the harness rather than from Pydantic's
+        # rendering, which is what would carry ``input_value=`` and the URL.
+        return f"the batch was refused by a protocol rule: {quoted_rule}"
+    return (
+        "the reply was refused before anything was executed. Accepted shape: "
+        f"{_example_json(surface, observation)}"
+    )
+
+
+def _extra_action_key_hint(reason: str, surface: ActionSurface, observation: Observation) -> str:
+    """Name the field that is not accepted, and where it IS accepted.
+
+    The useful half is not "extra inputs are not permitted" -- the model knows
+    something was refused -- but WHICH key, and which action kind the field it
+    sent actually belongs to. The common real case is a field borrowed from a
+    neighbouring kind (``frame_id`` on a ``wait``), so naming the kinds that
+    take it turns an opaque refusal into a one-line correction.
+    """
+
+    path = _first_field_path(reason)
+    if len(path) < 4 or path[0] != "actions":
+        return _example_json_hint(surface, observation, "an extra field in an action")
+    kind, name = path[2], path[3]
+    owners = sorted(
+        _action_kind_of(model)
+        for model in surface.models
+        if name in model.model_fields and _action_kind_of(model) != kind
+    )
+    parts = [f'"{name}" is not a field of a "{kind}" action']
+    if owners:
+        parts.append(
+            f"it belongs to the {', '.join(json.dumps(owner) for owner in owners)} "
+            f'action kind(s) -- check that "{kind}" is the kind you meant'
+        )
+    parts.append(f'a "{kind}" action takes exactly {_action_line(surface, kind)}')
+    return ". ".join(parts)
+
+
+def _action_line(surface: ActionSurface, kind: str) -> str:
+    """One action kind's accepted fields, from the models the prompt uses."""
+
+    for model in surface.models:
+        if _action_kind_of(model) == kind:
+            fields = [
+                f'"{name}": {_field_shape(field, name=name)}'
+                for name, field in model.model_fields.items()
+                if name != "kind"
+            ]
+            return "{" + ", ".join(fields) + "}"
+    return 'a JSON object whose "kind" is one of the accepted action kinds'
+
+
+def _unknown_action_kind_hint(reason: str, surface: ActionSurface) -> str:
+    kinds = sorted(_action_kind_of(model) for model in surface.models)
+    tag = _QUOTED_TAG.search(reason)
+    sent = tag.group(1) if tag is not None else ""
+    accepted = ", ".join(json.dumps(kind) for kind in kinds)
+    parts = [
+        f'"{sent}" is not an accepted action kind.' if sent else "The action kind was refused."
+    ]
+    nearest = _near_match(sent, kinds)
+    if nearest is not None:
+        parts.append(f'Did you mean "{nearest}"?')
+    parts.append(f"The accepted kinds are {accepted}.")
+    return " ".join(parts)
+
+
+def _unknown_key_hint(reason: str, surface: ActionSurface) -> str:
+    """Name the accepted key for the one the model sent.
+
+    The refused name is echoed ONLY when it renders to itself and fits the
+    whole-or-nothing bound (``is_quotable_key``), the same rule the envelope
+    diagnostic applies to unexpected keys: a model-supplied name is unbounded
+    text, and truncating it would leave a rendering whose length depends on its
+    own alphabet.
+    """
+
+    match = _UNKNOWN_KEY_NAME.search(reason)
+    sent = match.group(1) if match is not None else ""
+    named = {key.upper() for key in surface.named_keys}
+    parts = []
+    if sent and is_quotable_key(sent):
+        parts.append(f"{sent!r} is not an accepted key name")
+        nearest = _near_match(sent.upper(), sorted(named))
+        if nearest is not None:
+            parts.append(f"use {json.dumps(nearest.lower())} instead")
+    else:
+        parts.append("The reply used an unknown key name")
+    parts.append(
+        f"the key-chord field takes {_keys_shape(surface)} written directly, "
+        f"e.g. {json.dumps(_keys_example(surface))}; named keys are "
+        "case-insensitive, and a single printable character is accepted as itself"
+    )
+    return ". ".join(parts)
+
+
+def _coordinate_bounds(observation: Observation) -> str:
+    """The frame's own inclusive pixel bounds, from the observation's geometry.
+
+    Stated rather than clamped. An out-of-frame coordinate is honest model
+    error -- clamping would move the pointer to a pixel the model never chose,
+    which is the ``type``-to-``paste_text`` mistake with a worse consequence --
+    so the only thing this changes is what the model is told: the bounds of the
+    frame it is looking at, read from that frame rather than assumed.
+    """
+
+    frames = list(observation.frames)
+    if not frames:
+        return "the action's x and y must lie inside the frame it names"
+    geometry = frames[0].geometry.model_visible
+    return (
+        f'the accepted bounds are "x" 0..{geometry.width - 1} and '
+        f'"y" 0..{geometry.height - 1} for frame "{frames[0].frame_id}" '
+        f"({geometry.width}x{geometry.height}); do not rescale the screenshot or "
+        "assume another resolution"
+    )
+
+
+def _frame_id_hint(observation: Observation) -> str:
+    frames = list(observation.frames)
+    if not frames:
+        return "the current observation carries no frames, so no frame_id is accepted"
+    ids = ", ".join(json.dumps(frame.frame_id) for frame in frames)
+    return f"the only accepted frame ids on this observation are {ids}"
+
+
+def _example_json_hint(surface: ActionSurface, observation: Observation, refused: str) -> str:
+    return f"{refused} was refused. Accepted shape: {_example_json(surface, observation)}"
+
+
+def _first_field_path(reason: str) -> tuple[str, ...]:
+    """The first Pydantic location rendered in the diagnostic, split on dots."""
+
+    match = _ACTION_FIELD_PATH.search(reason)
+    return tuple(match.group(0).split(".")) if match is not None else ()
+
+
+def _near_match(sent: str, candidates: Sequence[str]) -> str | None:
+    """The closest accepted name, or nothing -- never a wrong suggestion.
+
+    A near-miss suggestion that is wrong is worse than none: told "did you mean
+    END" for ``return``, a model presses End, which is a real key that does
+    something else. So the common cases are decided outright -- by the alias map
+    for key synonyms, by containment for a name built on an accepted one
+    (``right_click`` against ``click``) -- and ``difflib`` only sees what is
+    left, at a cutoff high enough that it returns nothing rather than a distant
+    guess.
+
+    The containment rule requires four characters, which is what keeps
+    ``F1``..``F24`` out of it: ``F25`` must not be answered with "use f2".
+    """
+
+    alias = _KEY_ALIASES.get(sent.casefold())
+    if alias is not None and alias in candidates:
+        return alias
+    lowered = sent.casefold()
+    contained = sorted(
+        (
+            candidate
+            for candidate in candidates
+            if len(candidate) >= 4
+            and (candidate.casefold() in lowered or lowered in candidate.casefold())
+        ),
+        key=len,
+        reverse=True,
+    )
+    if contained:
+        return contained[0]
+    close = difflib.get_close_matches(sent, candidates, n=1, cutoff=0.8)
+    return close[0] if close else None
 
 
 def _paste_instructions(surface: ActionSurface) -> str:
@@ -636,6 +1262,12 @@ _NORMAL_CONTENT_STOPS = frozenset({"stop", "length", "toolUse"})
 #: sent.
 _UNSPECIFIED_STOP = "unspecified"
 
+#: Longest provider terminal marker recorded in a stream shape. The marker is
+#: provider-owned text of no fixed vocabulary, so it is TRUNCATED rather than
+#: validated: a marker that failed a pattern would fail the record, and this
+#: record exists to describe a refusal, not to become one.
+_MAX_STOP_MARKER_CHARS = 64
+
 
 class ProviderStreamAbortedError(RuntimeError):
     """The stream ended abnormally without producing any usable content.
@@ -922,6 +1554,29 @@ class _ContextBuilder:
         self._messages = list(messages)
 
 
+@dataclass(frozen=True)
+class _StreamOutcome:
+    """Everything one provider attempt produced, including its shape.
+
+    A named record rather than a wider tuple: the shape adds three counters
+    that would sit beside ``tool_call_count`` (which counts CALLS, not delta
+    events) in a nine-element positional return, and two adjacent integers with
+    different meanings is exactly the kind of thing a positional unpack gets
+    wrong silently.
+    """
+
+    text: str
+    usage: ModelUsage
+    cost_micros: int
+    stop_reason: str
+    provider_request_id: str
+    context_tokens: int | None
+    stream_error: str | None
+    channel_reply: str | None
+    tool_call_count: int
+    shape: StreamShape
+
+
 class ProviderModelClient:
     """Drives a real provider through the session stream function.
 
@@ -1032,17 +1687,21 @@ class ProviderModelClient:
             tool_choice="auto" if self._model_spec.supports_tools else "none",
             prompt_cache_key=self._prompt_cache_key,
         )
-        (
-            text,
-            usage,
-            cost_micros,
-            stop_reason,
-            provider_request_id,
-            context_tokens,
-            stream_error,
-            channel_reply,
-            tool_call_count,
-        ) = await self._stream(request)
+        # Named rather than positional: the outcome carries a shape record
+        # beside nine fields, and a tuple unpack would put two same-typed
+        # integers (``tool_call_count`` and the delta counters) in reach of a
+        # reordering that no type checker can see.
+        outcome = await self._stream(request)
+        text = outcome.text
+        usage = outcome.usage
+        cost_micros = outcome.cost_micros
+        stop_reason = outcome.stop_reason
+        provider_request_id = outcome.provider_request_id
+        context_tokens = outcome.context_tokens
+        stream_error = outcome.stream_error
+        channel_reply = outcome.channel_reply
+        tool_call_count = outcome.tool_call_count
+        stream_shape = outcome.shape
         if channel_reply:
             # The model answered on the offered channel. Its arguments ARE the
             # envelope, so the raw JSON goes to the same decoder the prose path
@@ -1173,14 +1832,31 @@ class ProviderModelClient:
             # decides whether to re-call, so a re-call for the same observation
             # is corrective by construction. The billing provenance rides on
             # the exception so the runner can write this attempt's triple.
-            diagnostic = _rejection_prompt(str(error), observation)
+            #
+            # The reason the model is shown is a CLASS-SPECIFIC HINT, not the
+            # validator's own rendering. A Pydantic message names the field it
+            # refused and embeds ``input_value=`` plus a docs URL; what the
+            # model needs is the shape the field accepts, and the harness knows
+            # it (``rejection_hint``). Classification and the hint come from one
+            # call so the class recorded in the bundle is by construction the
+            # class the hint was written for.
+            evidence = rejection_evidence(
+                text, str(error), observation, action_surface, stream_shape
+            )
+            diagnostic = _rejection_prompt(evidence.hint, observation)
             # Invalid notes are not factual memory. For envelope failures do
-            # not quote their unvalidated (possibly secret) text on retries or
-            # in evidence. Classification cannot rely on successful decoding
-            # (a truncated reply fails) or literal keys (JSON Unicode escapes
-            # bypass the substring test), so the reserved-key scan is
-            # escape-aware and fails closed (F1, review round 1). Raw legacy
-            # rejection text is retained only where no reserved key appears.
+            # not quote their unvalidated (possibly secret) text on retries.
+            # Classification cannot rely on successful decoding (a truncated
+            # reply fails) or literal keys (JSON Unicode escapes bypass the
+            # substring test), so the reserved-key scan is escape-aware and
+            # fails closed (F1, review round 1). Raw legacy rejection text is
+            # retained only where no reserved key appears.
+            #
+            # This is the HISTORY boundary only. Evidence publishes the reply
+            # itself (``evidence_reply``), through its own escape-aware scan at
+            # the publishing site: withholding it from the bundle made 241 of
+            # the campaign's rejection artifacts unreadable, and a
+            # reader of a bundle is not the model being corrected.
             shown = text
             try:
                 rejected_value, _ = json.JSONDecoder().raw_decode(text.lstrip())
@@ -1194,6 +1870,12 @@ class ProviderModelClient:
                 # Truncated with the same bound the context replay uses: a
                 # runaway reply must not be able to inflate the bundle either.
                 reply=shown[:MAX_REJECTED_REPLY_CHARS],
+                class_key=evidence.class_key,
+                # Raw and UNBOUNDED here: the publisher scans the whole reply
+                # before applying the bound, because a reply cut first and
+                # scanned afterwards returns clean over a severed canary.
+                evidence_reply=evidence.evidence_reply,
+                stream_shape=evidence.stream_shape,
                 route=self._route,
                 usage=usage,
                 cost_micros=cost_micros,
@@ -1302,12 +1984,10 @@ class ProviderModelClient:
             # The summary request offers no tools (``_summary_request`` sends
             # ``tool_choice="none"`` with an empty list), so the channel fields
             # are inert here — a summary is prose by definition.
-            text, usage, cost, _stop, _rid, _ctx, _err, _channel, _calls = await self._stream(
-                self._summary_request(prompt)
-            )
-            summary_usage = usage
-            summary_cost = cost
-            return text
+            summary = await self._stream(self._summary_request(prompt))
+            summary_usage = summary.usage
+            summary_cost = summary.cost_micros
+            return summary.text
 
         before = len(messages)
         result = await run_compaction_pass(
@@ -1584,9 +2264,7 @@ class ProviderModelClient:
             replayable=True,
         )
 
-    async def _stream(
-        self, request: Any
-    ) -> tuple[str, ModelUsage, int, str, str, int | None, str | None, str | None, int]:
+    async def _stream(self, request: Any) -> _StreamOutcome:
         text = ""
         usage = ModelUsage()
         cost_micros = 0
@@ -1596,6 +2274,15 @@ class ProviderModelClient:
         provider_request_id = "unknown"
         context_tokens: int | None = None
         stream_error: str | None = None
+        # Per-event counters, kept for the rejection artifact. They are what
+        # makes "the model generated nothing visible" distinguishable from
+        # "the client dropped what it generated": a refusal with a large
+        # reasoning count and no content is the model, all-zero counts are the
+        # wire. Counting EVENTS rather than characters, because the wire
+        # clients emit one delta per provider chunk.
+        content_deltas = 0
+        reasoning_deltas = 0
+        tool_call_deltas = 0
         # Reply-channel calls, accumulated per stream index because a provider
         # delivers a call's name and its arguments across many deltas. Assembly
         # is the harness loop's, so the two agree on what a provider's fragments
@@ -1603,8 +2290,15 @@ class ProviderModelClient:
         channel_calls: dict[int, dict[str, Any]] = {}
         async for event in self._stream_fn(request, None):
             if event.type == "text_delta":
+                content_deltas += 1
                 text += event.delta
+            elif event.type == "reasoning_delta":
+                # Counted, never read into ``text``: private reasoning is not a
+                # decision channel, and treating it as one would parse a
+                # model's thinking as its answer.
+                reasoning_deltas += 1
             elif event.type == "tool_call_delta":
+                tool_call_deltas += 1
                 state = channel_calls.setdefault(event.index, {"name": "", "arg_parts": []})
                 if event.name:
                     state["name"] += event.name
@@ -1645,20 +2339,31 @@ class ProviderModelClient:
         # instead); the empty string when it did and sent nothing usable, which
         # is a rejection the decoder must still report.
         channel_reply = envelope_from_tool_call(calls, name=REPLY_CHANNEL_TOOL_NAME)
-        return (
-            text,
-            usage,
-            cost_micros,
-            stop_reason,
-            provider_request_id,
-            context_tokens,
-            stream_error,
-            channel_reply,
+        return _StreamOutcome(
+            text=text,
+            usage=usage,
+            cost_micros=cost_micros,
+            stop_reason=stop_reason,
+            provider_request_id=provider_request_id,
+            context_tokens=context_tokens,
+            stream_error=stream_error,
+            channel_reply=channel_reply,
             # Every call the stream carried, including any the model made to a
             # name we never offered. Recorded in the evidence bundle rather
             # than acted on: a model reaching for a tool that does not exist is
             # a signal about the prompt, not something to salvage.
-            len(calls),
+            tool_call_count=len(calls),
+            shape=StreamShape(
+                content_deltas=content_deltas,
+                reasoning_deltas=reasoning_deltas,
+                tool_call_deltas=tool_call_deltas,
+                # The provider's RAW marker, never the normalized stop: a
+                # reader bucketing attempts needs ``length``/``toolUse``/whatever
+                # the wire said, and ``_UNSPECIFIED_STOP`` when it said nothing
+                # about how it ended. Truncated because the vocabulary is the
+                # provider's and this artifact must stay bounded.
+                stop=stop_reason[:_MAX_STOP_MARKER_CHARS],
+            ),
         )
 
 

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -8,6 +8,7 @@ text path as interactive sessions; private reasoning is never an input here.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Mapping, get_args
 from urllib.parse import unquote
 
@@ -37,7 +38,7 @@ _MAX_EXTRA_KEY_CHARS = 40
 _MAX_EXTRA_KEYS_SHOWN = 5
 
 
-def _is_quotable_key(key: str) -> bool:
+def is_quotable_key(key: str) -> bool:
     """Whether an unexpected key may be named back to the model verbatim.
 
     Conservative by construction: the key must be short, and must render to
@@ -53,6 +54,38 @@ def _is_quotable_key(key: str) -> bool:
 
 
 REJECTED_PUBLIC_REPLY = "(model reply rejected; no public observations accepted)"
+
+#: Longest slice of a rejected reply that may be replayed into the model's
+#: history or published as evidence. The reply has to be there -- the model
+#: must see WHAT it said to fix it, and a reader must see it to diagnose the
+#: class -- but a runaway reply (a provider's max-token wall of prose) must not
+#: cost the whole window on the retry or the whole bundle on the artifact.
+#:
+#: One bound for both boundaries, declared here rather than beside the client
+#: because ``episode.py`` applies it while publishing the artifact and must not
+#: import the provider-backed client to reach it.
+MAX_REJECTED_REPLY_CHARS = 4_000
+
+#: Appended to a reply cut by :data:`MAX_REJECTED_REPLY_CHARS`.
+REJECTED_REPLY_TRUNCATED = "\n[... reply truncated]"
+
+#: Published in place of a rejected reply whose text cannot be cleared for
+#: evidence. Whole-or-nothing: a reply is either published in full (bounded) or
+#: replaced by this marker, never published in part, because a partial rendering
+#: is exactly what makes a canary stop matching the alarm that exists to catch
+#: it.
+REJECTED_REPLY_WITHHELD = (
+    "(rejected reply withheld: it carried text the episode's redaction set forbids in evidence)"
+)
+
+#: JSON's own escape for a non-ASCII or escaping-sensitive character. Decoded
+#: before a redaction scan for the same reason percent escapes are: the model's
+#: reply reaches evidence as WIRE bytes, and a canary spelt ``\\u0068unter2``
+#: matches no substring check on the raw text. Deliberately a plain pass over
+#: the string rather than a JSON parse: the interesting replies are exactly the
+#: ones that do not parse (that is why they were rejected), so a scan that only
+#: understood well-formed JSON would be blind on the shapes it exists for.
+_JSON_UNICODE_ESCAPE = re.compile(r"\\u([0-9a-fA-F]{4})")
 
 #: What the reply-channel function tells the model it is for. Kept beside the
 #: envelope it describes so the two cannot drift, and deliberately short: it
@@ -73,10 +106,13 @@ def is_public_reply(value: Any) -> bool:
 def looks_like_public_reply(payload: str) -> bool:
     """Whether a REJECTED reply appears to attempt the reserved envelope.
 
-    Used only to withhold unvalidated output from corrective history and
-    rejection evidence; acceptance is unaffected and stays with the strict
-    decoder. A literal substring test is bypassed by legal JSON Unicode escapes
-    (``public_\\u006fbservations``), and full decoding fails on truncated
+    Used only to withhold unvalidated output from CORRECTIVE HISTORY; acceptance
+    is unaffected and stays with the strict decoder. The rejection ARTIFACT is a
+    separate boundary with its own escape-aware scan (see
+    :func:`rejected_reply_evidence`) -- withholding the reply from the bundle as
+    well made the rejection classes unreadable, and the two boundaries have
+    different jobs. A literal substring test is bypassed by legal JSON Unicode
+    escapes (``public_\\u006fbservations``), and full decoding fails on truncated
     framing — exactly the combination that leaked an encoded known note before
     review round 1 (F1). So scan the raw string-literal SPANS for reserved
     keys: fully decodable names are compared after unescaping, and any
@@ -185,7 +221,7 @@ def decode_public_reply(payload: str) -> dict[str, Any]:
                 # Quoting whole-or-nothing removes both: nothing is ever
                 # reshaped on the way out, so a redaction canary still matches
                 # and the rendered length is bounded by the charset itself.
-                safe = [key for key in extra if _is_quotable_key(key)]
+                safe = [key for key in extra if is_quotable_key(key)]
                 summary = ", ".join(repr(key) for key in safe[:_MAX_EXTRA_KEYS_SHOWN])
                 withheld = len(extra) - len(safe[:_MAX_EXTRA_KEYS_SHOWN])
                 if withheld and summary:
@@ -222,6 +258,80 @@ def decode_public_reply(payload: str) -> dict[str, Any]:
     if not isinstance(batch, dict) or set(batch) != {"actions"}:
         raise ValueError("model reply action_batch requires exactly an actions array")
     return value
+
+
+def rejected_reply_evidence(reply: str | None, redactions: RedactionSet | None) -> str:
+    """A rejected reply as evidence may publish it: scanned, then bounded.
+
+    The model's own words about a refused turn are the one thing that makes a
+    rejection class diagnosable after the fact, and they were the thing the
+    bundle threw away: 273 of the MiniMax campaign's 280 rejection artifacts
+    replaced the reply with the placeholder (counted 2026-09-12). The reply is
+    therefore published here, on a boundary of its own.
+
+    ORDER IS THE SECURITY PROPERTY, exactly as in ``_diagnostic``: every
+    rendering is scanned BEFORE the bound is applied. ``RedactionSet`` is a
+    substring check, so a reply cut first and scanned afterwards returns clean
+    over a canary that was severed by the cut -- and ``publish_artifact``'s own
+    scan then agrees for the same reason, sealing the fragment into the bundle.
+
+    Fails closed and WHOLE: any hit replaces the entire reply with
+    :data:`REJECTED_REPLY_WITHHELD` rather than masking the matching span. A
+    partial masking still narrows a secret and, worse, leaves a rendering whose
+    length depends on the secret's own alphabet. The reply was refused anyway --
+    nothing executable is lost -- and the artifact still carries the class key
+    and the diagnostic, so a withheld reply is still a readable rejection.
+
+    ``redactions`` is required-not-defaulted at the call site for the reason
+    ``_diagnostic`` gives: the UNSAFE call must not be the shorter one to write.
+    An explicit ``None`` states that this rendering never reaches evidence.
+    """
+
+    if not reply:
+        return ""
+    if redactions is not None and not _reply_is_clear(reply, redactions):
+        return REJECTED_REPLY_WITHHELD
+    if len(reply) > MAX_REJECTED_REPLY_CHARS:
+        return reply[:MAX_REJECTED_REPLY_CHARS] + REJECTED_REPLY_TRUNCATED
+    return reply
+
+
+def _reply_is_clear(reply: str, redactions: RedactionSet) -> bool:
+    """Whether every rendering of a reply is free of the episode's canaries.
+
+    Four renderings, cheapest first, because the canary can be hidden in each
+    of them and the reply is untrusted bytes:
+
+    * the raw text (the plaintext, base64 and hex canaries ``assert_clear``
+      checks directly);
+    * percent escapes, decoded;
+    * ``\\uXXXX`` escapes, decoded -- the F1 shape, which is a legal JSON
+      spelling of any character and would otherwise walk straight past a
+      substring test;
+    * the DECODED JSON value when the reply happens to parse, which hands
+      ``assert_clear`` the structure rather than the text (it walks mappings
+      and lists, so a canary nested in an action is seen).
+
+    A decoding failure is not a failure to scan: the raw and escaped
+    renderings are always checked, which is what makes this safe on the
+    truncated replies that are the common case here.
+    """
+
+    unquoted = unquote(reply)
+    unescaped = _JSON_UNICODE_ESCAPE.sub(lambda match: chr(int(match.group(1), 16)), reply)
+    renderings: list[Any] = [reply, unquoted, unescaped, unquote(unescaped)]
+    try:
+        renderings.append(json.loads(reply))
+    except (ValueError, RecursionError):
+        # Truncated or malformed is the EXPECTED case for a rejected reply, and
+        # the raw/escaped renderings above still cover it.
+        pass
+    for rendering in renderings:
+        try:
+            redactions.assert_clear(rendering)
+        except ValueError:
+            return False
+    return True
 
 
 def redact_public_reply(payload: str, redactions: RedactionSet) -> str:

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -87,6 +87,21 @@ REJECTED_REPLY_WITHHELD = (
 #: understood well-formed JSON would be blind on the shapes it exists for.
 _JSON_UNICODE_ESCAPE = re.compile(r"\\u([0-9a-fA-F]{4})")
 
+#: An escaped backslash, i.e. one level of JSON escaping applied to a backslash
+#: that is itself the start of an escape. Removing it is what makes escapes
+#: COMPOSE: a canary that was escaped and then carried inside a JSON string
+#: arrives as ``\\\\u0066``, and only a scan that drops a backslash level (and
+#: then decodes the escape underneath) sees the canary. Lookahead-bound so a
+#: trailing ``\\`` at the end of a truncated reply is left alone.
+_DOUBLE_BACKSLASH = re.compile(r"\\\\(?=.)")
+
+#: How many levels :func:`_escape_chain` decodes before giving up. One level is
+#: the F1 shape; two cover an escaped canary inside a JSON string; three is one
+#: more than any observed reply needs. Bounded because every level costs a pass
+#: over the reply, and a reply made of backslashes would otherwise make the scan
+#: quadratic.
+_MAX_ESCAPE_LEVELS = 3
+
 #: What the reply-channel function tells the model it is for. Kept beside the
 #: envelope it describes so the two cannot drift, and deliberately short: it
 #: rides in the request's cache prefix on every call of every episode.
@@ -299,39 +314,129 @@ def rejected_reply_evidence(reply: str | None, redactions: RedactionSet | None) 
 def _reply_is_clear(reply: str, redactions: RedactionSet) -> bool:
     """Whether every rendering of a reply is free of the episode's canaries.
 
-    Four renderings, cheapest first, because the canary can be hidden in each
-    of them and the reply is untrusted bytes:
-
-    * the raw text (the plaintext, base64 and hex canaries ``assert_clear``
-      checks directly);
-    * percent escapes, decoded;
-    * ``\\uXXXX`` escapes, decoded -- the F1 shape, which is a legal JSON
-      spelling of any character and would otherwise walk straight past a
-      substring test;
-    * the DECODED JSON value when the reply happens to parse, which hands
-      ``assert_clear`` the structure rather than the text (it walks mappings
-      and lists, so a canary nested in an action is seen).
-
-    A decoding failure is not a failure to scan: the raw and escaped
-    renderings are always checked, which is what makes this safe on the
+    Fails closed: the answer is a yes only after every rendering below has been
+    scanned, and a reply that cannot be DECODED is not a failure to scan -- the
+    text renderings are always checked, which is what makes this safe on the
     truncated replies that are the common case here.
     """
 
-    unquoted = unquote(reply)
-    unescaped = _JSON_UNICODE_ESCAPE.sub(lambda match: chr(int(match.group(1), 16)), reply)
-    renderings: list[Any] = [reply, unquoted, unescaped, unquote(unescaped)]
-    try:
-        renderings.append(json.loads(reply))
-    except (ValueError, RecursionError):
-        # Truncated or malformed is the EXPECTED case for a rejected reply, and
-        # the raw/escaped renderings above still cover it.
-        pass
-    for rendering in renderings:
+    for rendering in _reply_renderings(reply):
         try:
             redactions.assert_clear(rendering)
         except ValueError:
             return False
     return True
+
+
+def _reply_renderings(reply: str) -> list[Any]:
+    """Every rendering of a rejected reply that a canary could be hiding in.
+
+    The reply reaches evidence as WIRE bytes and has already been refused, so it
+    can be anything: malformed, truncated, a well-formed envelope whose notes
+    were never validated, or a reply that is itself JSON carrying JSON. Each of
+    those hides a canary behind a different decoding:
+
+    * the raw text, where ``assert_clear`` catches its own plaintext, base64,
+      percent and hex variants;
+    * the text under one or more levels of decoding -- percent escapes, JSON
+      ``\\uXXXX`` escapes, and the removal of an escaped backslash. The escape
+      case is the F1 shape: a legal JSON spelling of any character, invisible to
+      a substring test. Successive levels are needed because escaping composes --
+      an escaped string carried as a JSON string arrives with ``\\\\u0066``,
+      where the canary only appears once a backslash level AND the escape have
+      both been decoded;
+    * the DECODED JSON value when the reply parses, which hands ``assert_clear``
+      the structure rather than the text (it walks mappings and lists, so a
+      canary nested in an action is seen), and the same decodings applied to
+      every string INSIDE that value, which is where an inner JSON document's
+      own escapes live.
+
+    Decoding stops at :data:`_MAX_ESCAPE_LEVELS`. Nesting deeper than that is
+    NOT covered, and this is the sole barrier on the path that publishes raw
+    model output, so the limit is stated rather than implied: a canary escaped
+    more than three times over -- a shape no observed reply has produced, and
+    one that would have to be constructed deliberately -- would be published.
+    """
+
+    renderings: list[Any] = []
+    texts = [reply]
+    try:
+        value = json.loads(reply)
+    except (ValueError, RecursionError):
+        # Truncated or malformed is the EXPECTED case for a rejected reply; the
+        # text renderings below cover it.
+        value = None
+    if value is not None:
+        renderings.append(value)
+        texts.extend(_string_leaves(value))
+    for text in texts:
+        renderings.extend(_escape_chain(text))
+    return renderings
+
+
+def _escape_chain(text: str, *, levels: int = _MAX_ESCAPE_LEVELS) -> list[str]:
+    """``text`` and every decoding of it up to ``levels`` levels deep.
+
+    Breadth-first over three decoders per level, so combinations are covered
+    rather than one branch of them: a reply can be percent-escaped inside a
+    JSON escape, and each decoder composes with the others. Bounded because
+    each level costs a full pass and a reply built from backslashes would make
+    an unbounded walk quadratic; the frontier also shrinks naturally, as every
+    decoder only ever removes characters or leaves the text alone.
+    """
+
+    chain = [text]
+    seen = {text}
+    frontier = [text]
+    for _ in range(levels):
+        next_frontier: list[str] = []
+        for current in frontier:
+            for decode in _ESCAPE_DECODERS:
+                decoded = decode(current)
+                if decoded == current or decoded in seen:
+                    continue
+                seen.add(decoded)
+                chain.append(decoded)
+                next_frontier.append(decoded)
+        if not next_frontier:
+            break
+        frontier = next_frontier
+    return chain
+
+
+def _decode_unicode_escape(match: re.Match[str]) -> str:
+    return chr(int(match.group(1), 16))
+
+
+def _collapse_backslash_escape(match: re.Match[str]) -> str:
+    return match.group(0)[1:]
+
+
+def _string_leaves(value: Any) -> list[str]:
+    """Every string a decoded JSON value carries, keys included."""
+
+    leaves: list[str] = []
+    if isinstance(value, str):
+        leaves.append(value)
+    elif isinstance(value, Mapping):
+        for key, nested in value.items():
+            leaves.append(str(key))
+            leaves.extend(_string_leaves(nested))
+    elif isinstance(value, (list, tuple)):
+        for nested in value:
+            leaves.extend(_string_leaves(nested))
+    return leaves
+
+
+#: One decode of one level of escaping. Applied breadth-first by
+#: :func:`_escape_chain`, in this order, because the three compose: a payload can
+#: percent-escape inside a JSON escape, and an escaped string carried as a JSON
+#: string needs a backslash level removed before its escapes mean anything.
+_ESCAPE_DECODERS = (
+    lambda text: _JSON_UNICODE_ESCAPE.sub(_decode_unicode_escape, text),
+    unquote,
+    lambda text: _DOUBLE_BACKSLASH.sub(_collapse_backslash_escape, text),
+)
 
 
 def redact_public_reply(payload: str, redactions: RedactionSet) -> str:

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -2148,6 +2148,29 @@ class StreamTextDelta(BaseModel):
     delta: str
 
 
+class StreamReasoningDelta(BaseModel):
+    """A fragment of the provider's private reasoning channel.
+
+    Reasoning has always been COLLECTED -- the OpenAI-compatible wire client
+    accumulates ``reasoning_content``/``reasoning`` to replay it in later
+    requests -- but it was never SURFACED, so a turn that spent its whole
+    output budget thinking looked identical to a client that dropped what it
+    was handed. That ambiguity is not academic: a rejection of "the model
+    emitted nothing" cannot be distinguished from "we discarded the model's
+    output" without it, and the two call for opposite responses (re-prompt the
+    model / fix the client).
+
+    Emitted on the reasoning channel only. It is deliberately NOT reasoning
+    rendered anywhere user-visible: private reasoning never enters the
+    transcript or the model-visible context, and no consumer is required to
+    act on this event. It exists so a caller that wants to know whether the
+    model produced anything can ask.
+    """
+
+    type: Literal["reasoning_delta"] = "reasoning_delta"
+    delta: str
+
+
 class StreamToolCallDelta(BaseModel):
     type: Literal["tool_call_delta"] = "tool_call_delta"
     index: int
@@ -2191,6 +2214,10 @@ class StreamModelEvent(BaseModel):
 StreamEvent = (
     StreamStartEvent
     | StreamTextDelta
+    # Beside the text delta it is the sibling of: one channel carries the
+    # answer, the other carries the work behind it, and a consumer that
+    # ignores this one sees exactly the stream it saw before.
+    | StreamReasoningDelta
     | StreamToolCallDelta
     | StreamUsageEvent
     | StreamEndEvent

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -47,6 +47,7 @@ from local_operator.harness.types import (
     ModelSpec,
     StreamEndEvent,
     StreamEvent,
+    StreamReasoningDelta,
     StreamStartEvent,
     StreamTextDelta,
     StreamToolCallDelta,
@@ -2486,6 +2487,17 @@ class OpenAICompatClient:
                     fragment = delta.get(reasoning_key)
                     if isinstance(fragment, str) and fragment:
                         reasoning_parts.setdefault(reasoning_key, []).append(fragment)
+                        # SURFACED as well as collected. The reasoning is kept
+                        # for replay whether or not anyone listens, but a
+                        # caller that sees no ``text_delta`` has no way to tell
+                        # "the model thought and said nothing" from "the client
+                        # threw away what it said" without this event -- the
+                        # ambiguity behind a "reply carried no tool call and no
+                        # text" rejection that could as easily have been ours.
+                        # Emitted on the reasoning channel only, so every
+                        # consumer that ignores it renders exactly the turn it
+                        # rendered before.
+                        yield StreamReasoningDelta(delta=fragment)
                 text = delta.get("content")
                 if text:
                     replay_text.append(text)

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -35,6 +35,7 @@ from local_operator.harness.types import (
     RenderedStreamError,
     StreamEvent,
     StreamModelEvent,
+    StreamReasoningDelta,
     StreamStartEvent,
 )
 from local_operator.model.effort import EFFORT_ORDER, resolve_effort_in
@@ -2719,17 +2720,31 @@ async def stream_with_failover(
                     # ``forwarded_any`` gates retry, and it means exactly one
                     # thing: the caller has SEEN output that cannot be un-shown,
                     # so replaying this attempt would stream deltas twice.
-                    # A ``StreamStartEvent`` shows the user nothing — it is a
-                    # boundary marker announcing that the provider began — so
-                    # counting it would make every failure that lands after
-                    # acceptance but before the first token non-retryable
-                    # (Anthropic 529s, in-band error chunks on a 200 stream),
-                    # bypassing credential rotation and the whole fallback
-                    # chain. It would also misreport a pre-content transport
-                    # death as a MID-STREAM loss, which is what
-                    # ``is_mid_stream_connectivity_loss`` infers from this very
-                    # flag. Nothing has been rendered, so nothing blocks a retry.
-                    if not isinstance(event, StreamStartEvent):
+                    # Two events show the user nothing and are carved out for
+                    # that reason:
+                    #
+                    # * ``StreamStartEvent`` is a boundary marker announcing that
+                    #   the provider began. Counting it would make every failure
+                    #   that lands after acceptance but before the first token
+                    #   non-retryable (Anthropic 529s, in-band error chunks on a
+                    #   200 stream), bypassing credential rotation and the whole
+                    #   fallback chain. It would also misreport a pre-content
+                    #   transport death as a MID-STREAM loss, which is what
+                    #   ``is_mid_stream_connectivity_loss`` infers from this very
+                    #   flag.
+                    # * ``StreamReasoningDelta`` carries the model's private
+                    #   reasoning, which NOTHING renders: the loop appends text
+                    #   only for its visible channel, no frontend handler exists,
+                    #   and the transcript never sees it. Counting it would
+                    #   reintroduce exactly the bug above, but only for models
+                    #   that think before they answer -- the reasoning families
+                    #   this harness runs -- so a pre-content 5xx after the first
+                    #   reasoning chunk would stop rotating credentials and stop
+                    #   walking the fallback chain, and a pre-content transport
+                    #   death would be misreported as a mid-stream loss.
+                    #
+                    # Nothing has been rendered, so nothing blocks a retry.
+                    if not isinstance(event, (StreamStartEvent, StreamReasoningDelta)):
                         forwarded_any = True
                     yield stamped
                 # This selector just answered: from here on an unknown-model

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -1061,9 +1061,12 @@ async def test_a_rejection_without_a_captured_reply_records_the_diagnostic_alone
     from local_operator.evaluation.runner.episode import _rejection_detail
     from local_operator.evaluation.runner.model import DecisionRejected
 
-    assert _rejection_detail(DecisionRejected("refused")) == "refused"
-    assert _rejection_detail(DecisionRejected("refused", reply="")) == "refused"
-    assert "--- rejected reply ---" in _rejection_detail(DecisionRejected("refused", reply="{}"))
+    # ``None`` is the explicit "in-process rendering, never evidence" case the
+    # signature requires a caller to state (``_diagnostic``'s rule).
+    assert _rejection_detail(DecisionRejected("refused"), None) == "refused"
+    assert _rejection_detail(DecisionRejected("refused", reply=""), None) == "refused"
+    detail = _rejection_detail(DecisionRejected("refused", reply="{}"), None)
+    assert "--- rejected reply ---" in detail
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -23,6 +23,7 @@ from typing import Any, AsyncIterator, Callable
 
 import pytest
 
+from local_operator.evaluation.action_surface import LEGACY_ACTION_SURFACE
 from local_operator.evaluation.adapters.api import observation_content_id
 from local_operator.evaluation.evidence.models import RouteIdentity
 from local_operator.evaluation.protocol import (
@@ -31,6 +32,7 @@ from local_operator.evaluation.protocol import (
     Observation,
     TypeAction,
 )
+from local_operator.evaluation.receipts import RedactionSet
 from local_operator.evaluation.runner.model import DecisionRejected, EpisodeTurn
 from local_operator.evaluation.runner.provider_client import (
     MAX_REJECTED_REPLY_CHARS,
@@ -46,6 +48,7 @@ from local_operator.harness.types import (
     ImageContent,
     ModelSpec,
     StreamEndEvent,
+    StreamReasoningDelta,
     StreamTextDelta,
     StreamUsageEvent,
     TextContent,
@@ -114,6 +117,7 @@ class ScriptedStream:
         chunk: int = 7,
         provider_payload: dict[str, Any] | None = None,
         error: str | None = None,
+        reasoning: tuple[str, ...] = (),
     ) -> None:
         self.text = text
         self.usage = usage
@@ -125,6 +129,11 @@ class ScriptedStream:
         # marker, so a fake that cannot carry one cannot exercise the refusal
         # path at all -- which is how that path shipped unhandled.
         self.error = error
+        # The private reasoning channel, delivered before the visible one.
+        # Scripted for the same reason as ``error``: a turn that spent its
+        # whole output budget thinking produces NO visible text, and a fake that
+        # cannot carry reasoning cannot tell that apart from an empty stream.
+        self.reasoning = reasoning
         self.requests: list[Any] = []
 
     def __call__(self, request: Any, signal: Any) -> AsyncIterator[Any]:
@@ -132,6 +141,8 @@ class ScriptedStream:
         return self._events()
 
     async def _events(self) -> AsyncIterator[Any]:
+        for fragment in self.reasoning:
+            yield StreamReasoningDelta(delta=fragment)
         # Delivered in fragments because a provider streams text in pieces; a
         # client that reads only the first delta would still pass a whole-string
         # fake and then fail against every real provider.
@@ -2045,6 +2056,412 @@ async def test_an_over_long_rejected_reply_is_bounded_on_the_exception(
 
     assert info.value.reply is not None
     assert len(info.value.reply) == MAX_REJECTED_REPLY_CHARS
+
+
+def _screen_observation(
+    root: Path, sequence: int = 0, *, width: int = 1280, height: int = 720
+) -> Observation:
+    """A framed observation whose model-visible size is a real screen's.
+
+    ``_framed_observation`` publishes a 1x1 frame, which is all the frame-id
+    contract needs and useless for a coordinate bound: a hint derived from it
+    would say "0..0" and a test asserting that would pin nothing. The frame
+    BYTES are reused from that helper (so ``verify_artifact`` still accepts
+    them); only the geometry the model is told about changes.
+    """
+
+    from local_operator.evaluation.protocol import FrameGeometry, FrameSize
+
+    base = _framed_observation(root, sequence)
+    frame = base.frames[0].model_copy(
+        update={
+            "frame_id": "screen",
+            "geometry": FrameGeometry(
+                native=FrameSize(width=width, height=height),
+                model_visible=FrameSize(width=width, height=height),
+            ),
+        }
+    )
+    provisional = base.model_copy(update={"frames": (frame,), "observation_id": "provisional"})
+    return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
+
+
+def _defective_reply(case: str, current: Observation) -> str:
+    """One reply per refusal class, shaped like the sealed corpus it comes from.
+
+    Every payload here is a shape a real model produced (the MiniMax campaign's
+    sealed rejections, or the episodes named beside the parser that refused
+    them), so this table measures the hint against the traffic it exists for
+    rather than against invented edge cases.
+    """
+
+    observation_id = current.observation_id
+    if case == "malformed-json":
+        return "Sure, here you go: {"
+    if case == "fenced-json":
+        return '```json\n{"actions": [{"kind": "finish"}]}\n```'
+    if case == "unsupported-reply-version":
+        return json.dumps(
+            {
+                "reply_version": "2.0",
+                "action_batch": {"actions": []},
+                "public_observations": "",
+            }
+        )
+    if case == "envelope-shape":
+        return json.dumps({"reply_version": "1.0", "action_batch": {"actions": []}})
+    if case == "extra-action-key":
+        return json.dumps(
+            {
+                "actions": [
+                    {
+                        "kind": "wait",
+                        "observation_id": observation_id,
+                        "frame_id": "screen",
+                        "duration_ms": 1000,
+                    }
+                ]
+            }
+        )
+    if case == "unknown-key":
+        return json.dumps(
+            {
+                "actions": [
+                    {"kind": "key", "observation_id": observation_id, "keys": ["ctrl", "Return"]}
+                ]
+            }
+        )
+    if case == "keys-not-array":
+        return json.dumps(
+            {
+                "actions": [
+                    {
+                        "kind": "key",
+                        "observation_id": observation_id,
+                        "keys": {"item": ["ctrl", "alt", "t"]},
+                    }
+                ]
+            }
+        )
+    if case == "unknown-action-kind":
+        return json.dumps(
+            {"actions": [{"kind": "right_click", "observation_id": observation_id, "x": 1, "y": 1}]}
+        )
+    if case == "coordinate":
+        return json.dumps(
+            {
+                "actions": [
+                    {
+                        "kind": "click",
+                        "observation_id": observation_id,
+                        "frame_id": "screen",
+                        "x": 17752,
+                        "y": 900,
+                    }
+                ]
+            }
+        )
+    if case == "unknown-frame-id":
+        return _click_payload(current, "1")
+    if case == "field-invalid":
+        return json.dumps(
+            {"actions": [{"kind": "type", "observation_id": observation_id, "text": ""}]}
+        )
+    if case == "second-batch":
+        return _click_payload(current, "screen") + _click_payload(current, "screen")
+    if case == "observation-binding":
+        # A batch whose action names ANOTHER observation. The defect arrives
+        # through Pydantic's model validator, which is the case that must not
+        # keep its rendering: it carries ``input_value=<the whole batch>``.
+        return finish_payload(observation(1))
+    raise AssertionError(f"unknown case {case}")
+
+
+# The model-facing message per class: the class it is bucketed into, and the
+# thing it MUST say. A hint that only reported "something was wrong" would
+# satisfy the class assert and fail the model it is written for, so both are
+# pinned here, and the hygiene rule (no ``input_value=``, no docs URL) is
+# asserted for every row rather than for a representative one.
+_REJECTION_HINT_CASES = [
+    ("malformed-json", "malformed-json", ['"reply_version": "1.0"', '"action_batch"']),
+    ("fenced-json", "malformed-json", ["not one complete JSON object", "code fence"]),
+    (
+        "unsupported-reply-version",
+        "unsupported-reply-version",
+        ['The only accepted value is "1.0"'],
+    ),
+    ("envelope-shape", "envelope-shape", ["omitted 'public_observations'"]),
+    ("extra-action-key", "extra-action-key", ['"frame_id"', '"wait"', '"duration_ms"']),
+    ("unknown-key", "unknown-key", ["not an accepted key name", '"enter"', "array of key names"]),
+    ("keys-not-array", "keys-not-array", ['["ctrl", "alt", "t"]', "not an object"]),
+    ("unknown-action-kind", "unknown-action-kind", ['"right_click"', 'Did you mean "click"?']),
+    ("coordinate", "out-of-frame-coordinate", ['"x" 0..1279', '"y" 0..719']),
+    ("unknown-frame-id", "unknown-frame-id", ["unknown frame_id '1'", "only accepted frame ids"]),
+    ("field-invalid", "field-invalid", ['"text" in a "type" action', "non-empty string"]),
+    ("second-batch", "second-batch", ["second action batch"]),
+    (
+        "observation-binding",
+        "observation-binding",
+        ['"observation_id" of the observation being answered'],
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "class_key", "expected"),
+    _REJECTION_HINT_CASES,
+    ids=[row[0] for row in _REJECTION_HINT_CASES],
+)
+async def test_a_refused_reply_is_told_what_to_send_instead(
+    tmp_path: Path, case: str, class_key: str, expected: list[str]
+) -> None:
+    """The model-facing correction names the defect AND the accepted shape.
+
+    What it must never carry is the validator's own rendering: a Pydantic
+    ``str()`` embeds ``input_value=<the value it refused>`` and a docs URL, and
+    on the one path where a value can be a resolved secret that is the value
+    quoted into the next request. ``_diagnostic`` strips both for the episode
+    outcome; this is the same rule at the boundary the MODEL reads.
+    """
+
+    current = _screen_observation(tmp_path, 0)
+    stream = RecordingStream(lambda _message: _defective_reply(case, current))
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream, tmp_path).decide(current, _turns(current))
+
+    rejected = info.value
+    assert rejected.diagnostic.startswith("Your previous reply was rejected:")
+    assert rejected.class_key == class_key
+    for fragment in expected:
+        assert fragment in rejected.diagnostic, fragment
+    assert "input_value=" not in rejected.diagnostic
+    assert "errors.pydantic.dev" not in rejected.diagnostic
+    assert "[type=" not in rejected.diagnostic
+
+
+@pytest.mark.asyncio
+async def test_a_rejection_records_the_shape_of_the_stream_that_produced_it(
+    tmp_path: Path,
+) -> None:
+    """An empty reply and a discarded one are different failures.
+
+    A turn that spent its whole budget on the reasoning channel arrives as an
+    empty reply; a client that dropped what the provider sent arrives as the
+    same empty reply. The counts are the only thing in the bundle that tells
+    them apart -- and ``reasoning_deltas`` is the number the wire clients never
+    used to emit at all.
+    """
+
+    current = _screen_observation(tmp_path, 0)
+    stream = ScriptedStream("", reasoning=("weighing ", "the options"))
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream, tmp_path).decide(current, _turns(current))
+
+    shape = info.value.stream_shape
+    assert shape is not None
+    assert shape.content_deltas == 0
+    assert shape.reasoning_deltas == 2
+    assert shape.tool_call_deltas == 0
+    assert shape.stop == "stop"
+    assert info.value.class_key == "empty-reply"
+
+
+def test_the_example_the_hint_hands_the_model_actually_parses(tmp_path: Path) -> None:
+    """An example that does not parse is the defect, restated.
+
+    The whole point of showing the accepted shape is that the model can copy it,
+    so the example is generated from the enforced schema and then FED BACK
+    THROUGH the real decoder here. A hand-written example would drift out of the
+    protocol silently; a drifted generated one fails this test instead -- the
+    same argument ``_action_schema_lines`` makes for the system prompt.
+    """
+
+    from local_operator.evaluation.runner.provider_client import _example_json
+
+    current = _screen_observation(tmp_path, 0)
+    example = _example_json(LEGACY_ACTION_SURFACE, current)
+
+    decision = parse_decision(example, current, route=ROUTE)
+
+    assert decision.action_batch.actions[0].observation_id == current.observation_id
+    assert decision.public_reply == example
+
+
+def test_the_key_example_in_the_hint_is_an_accepted_chord() -> None:
+    """The keys example is admissible, not merely illustrative.
+
+    ``["ctrl", "alt", "t"]`` is what the hint shows for the field a model most
+    often wraps in an object. It is built from the surface's own vocabulary, and
+    asserted here through the validator that will judge the model's next reply:
+    an example the parser refuses would teach the model the very rejection this
+    hint exists to end.
+    """
+
+    from local_operator.evaluation.protocol import KeyAction
+    from local_operator.evaluation.runner.provider_client import _keys_example
+
+    keys = _keys_example(LEGACY_ACTION_SURFACE)
+    action = KeyAction(observation_id="obs-1", keys=tuple(keys))
+
+    assert list(action.keys) == ["CTRL", "ALT", "t"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("marker", "recorded"),
+    [("function_call", "function_call"), ("x" * 200, "x" * 64)],
+    ids=["vendor-vocabulary", "unbounded-marker"],
+)
+async def test_an_unusual_stop_marker_is_recorded_rather_than_rejected(
+    tmp_path: Path, marker: str, recorded: str
+) -> None:
+    """The terminal marker is the PROVIDER's vocabulary, not ours.
+
+    Recording it must not be able to fail the record: a marker our identifier
+    rules would refuse, or one far longer than any real one, has to land in the
+    bundle as-is (truncated) rather than raising out of the rejection path --
+    that path exists to describe a refusal, and turning it into a crash would be
+    strictly worse than the missing field it replaces.
+    """
+
+    current = _screen_observation(tmp_path, 0)
+    stream = ScriptedStream("not json at all", stop_reason=marker)
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream, tmp_path).decide(current, _turns(current))
+
+    assert info.value.stream_shape is not None
+    assert info.value.stream_shape.stop == recorded
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_envelope_is_published_but_not_replayed(tmp_path: Path) -> None:
+    """The two boundaries differ, and both are load-bearing.
+
+    History must keep the placeholder: an envelope reply's notes are
+    unvalidated text that may carry a credential, and replaying it re-opens the
+    F1 channel. Evidence must keep the REPLY: withholding it made 273 of the
+    MiniMax campaign's 280 rejection artifacts unreadable, which is how a
+    reader got the class distribution wrong. So the same rejection carries both.
+    """
+
+    from local_operator.evaluation.runner.episode import _rejection_detail
+    from local_operator.evaluation.runner.public_reply import REJECTED_PUBLIC_REPLY
+
+    current = _screen_observation(tmp_path, 0)
+    reply = _defective_reply("unsupported-reply-version", current)
+    # The second reply is what makes the placeholder observable: the corrective
+    # history is what the NEXT request carries, so the client has to be asked
+    # again before anything can be read off the wire.
+    replies = iter([reply, _click_payload(current, "screen")])
+    stream = RecordingStream(lambda _message: next(replies))
+    client = _client(stream, tmp_path)
+
+    with pytest.raises(DecisionRejected) as info:
+        await client.decide(current, _turns(current))
+    await client.decide(current, _turns(current))
+
+    rejected = info.value
+    # The history boundary: the placeholder, and the reply is NOT in it.
+    replay = "\n".join(message.text for message in stream.requests[-1].messages)
+    assert REJECTED_PUBLIC_REPLY in replay
+    assert reply not in replay
+    assert rejected.reply == REJECTED_PUBLIC_REPLY
+    # The evidence boundary: the reply itself, with the class that was recorded
+    # for it and the shape of the stream that carried it.
+    artifact = _rejection_detail(rejected, RedactionSet.from_resolved_values([]))
+    assert reply in artifact
+    assert "class: unsupported-reply-version" in artifact
+    assert "stream: content_deltas=" in artifact
+
+
+@pytest.mark.asyncio
+async def test_the_published_rejected_reply_is_bounded(tmp_path: Path) -> None:
+    """A provider's max-token wall of prose must not reach the bundle whole.
+
+    The bound is asserted on the ARTIFACT, not on the exception: the exception
+    carries the reply raw so that the publisher can scan it before cutting it.
+    """
+
+    from local_operator.evaluation.runner.episode import _rejection_detail
+    from local_operator.evaluation.runner.public_reply import REJECTED_REPLY_TRUNCATED
+
+    current = _screen_observation(tmp_path, 0)
+    stream = RecordingStream("x" * (MAX_REJECTED_REPLY_CHARS * 3))
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream, tmp_path).decide(current, _turns(current))
+
+    artifact = _rejection_detail(info.value, RedactionSet.from_resolved_values([]))
+    section = artifact.split("--- rejected reply ---\n", 1)[1]
+    assert section.endswith(REJECTED_REPLY_TRUNCATED)
+    assert len(section) <= MAX_REJECTED_REPLY_CHARS + len(REJECTED_REPLY_TRUNCATED)
+
+
+@pytest.mark.asyncio
+async def test_recording_a_rejection_does_not_change_the_decision_sequence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Evidence recording is a pure function of data the attempt already has.
+
+    The reply, the class and the stream shape are all collected from an attempt
+    that has already been billed and refused, so capturing them cannot change
+    which decisions the model is asked for. Run twice over the same scripted
+    defective-then-corrected pair -- the second time with the recorder stubbed
+    to keep nothing -- the accept/reject sequence and every request byte must be
+    identical. What differs is the artifact ''content'', never the conversation.
+    """
+
+    import local_operator.evaluation.runner.provider_client as client_module
+
+    real_recorder = client_module.rejection_evidence
+
+    def recorder_off(*args: Any, **kwargs: Any) -> Any:
+        recorded = real_recorder(*args, **kwargs)
+        return type(recorded)(
+            class_key=recorded.class_key,
+            hint=recorded.hint,
+            evidence_reply=None,
+            stream_shape=None,
+        )
+
+    def rendered(request: Any) -> dict[str, Any]:
+        """One request as bytes, minus the per-construction message UUIDs.
+
+        ``Message`` defaults its ``id`` to a fresh UUID, so two identical runs
+        differ there and nowhere else. Normalising it to the message's index
+        keeps the comparison a byte comparison of everything the provider
+        would read -- content, roles, tools, system blocks, sampling fields.
+        """
+
+        payload = json.loads(request.model_dump_json())
+        for index, message in enumerate(payload["messages"]):
+            message["id"] = str(index)
+        return payload
+
+    async def scripted_sequence() -> tuple[list[str], list[dict[str, Any]]]:
+        current = _screen_observation(tmp_path, 0)
+        replies = iter([_click_payload(current, "1"), _click_payload(current, "screen")])
+        stream = RecordingStream(lambda _message: next(replies))
+        client = _client(stream, tmp_path)
+        with pytest.raises(DecisionRejected):
+            await client.decide(current, _turns(current))
+        sequence = ["rejected"]
+        decision = await client.decide(current, _turns(current))
+        assert decision.action_batch.actions[0].frame_id == "screen"  # type: ignore[union-attr]
+        sequence.append("accepted")
+        return sequence, [rendered(request) for request in stream.requests]
+
+    recorded_sequence, recorded_requests = await scripted_sequence()
+    monkeypatch.setattr(client_module, "rejection_evidence", recorder_off)
+    unrecorded_sequence, unrecorded_requests = await scripted_sequence()
+
+    assert recorded_sequence == ["rejected", "accepted"]
+    assert unrecorded_sequence == recorded_sequence
+    assert unrecorded_requests == recorded_requests
 
 
 def test_prompt_teaches_how_to_type_and_how_to_press_keys() -> None:

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -366,8 +366,25 @@ async def test_a_rejected_envelope_reaches_the_bundle_with_its_class(
         lambda raw, secret: raw.replace("fixture", "\\u0066ixture"),
         lambda raw, secret: raw.replace(secret, quote(secret, safe="")),
         lambda raw, secret: raw.replace(secret, base64.b64encode(secret.encode()).decode()),
+        # Escaping COMPOSES, so the scan has to decode more than one level. Both
+        # shapes below were reproduced by the round-1 review as surviving a
+        # single-level scan: the first carries an ESCAPED BACKSLASH before the
+        # escape (a canary inside a JSON string), the second escapes every
+        # character and then escapes the escapes again.
+        lambda raw, secret: raw.replace(secret, secret.replace("fixture", "\\\\u0066ixture")),
+        lambda raw, secret: raw.replace(
+            secret,
+            "".join(f"\\u{ord(character):04x}" for character in secret).replace("\\", "\\\\"),
+        ),
     ],
-    ids=["plain", "json-unicode-escape", "percent", "base64"],
+    ids=[
+        "plain",
+        "json-unicode-escape",
+        "percent",
+        "base64",
+        "json-escaped-twice",
+        "per-character-double-escape",
+    ],
 )
 def test_a_reply_carrying_a_canary_is_withheld_whole_from_evidence(transform: Any) -> None:
     """Evidence publishes the reply ONLY through an escape-aware scan.
@@ -425,6 +442,32 @@ def test_an_unsafe_reply_degrades_without_losing_the_rejection() -> None:
     # The history rendering is NOT what evidence shows: the placeholder belongs
     # to the correction, and pasting it here would read as "the model said this".
     assert REJECTED_PUBLIC_REPLY not in detail
+
+
+def test_a_marker_that_imitates_a_header_cannot_open_another_section() -> None:
+    """Provider-owned text goes into the header ESCAPED, never raw.
+
+    The artifact promises a fixed section order that a script can read, and the
+    stop marker is the one part of that header the harness does not author. A
+    marker carrying a newline would otherwise write a line that reads like
+    another header (or hide the rest of the section), so non-printables are
+    escaped rather than truncated -- a 64-character bound does not neutralise a
+    short injection.
+    """
+
+    rejected = DecisionRejected(
+        "Your previous reply was rejected: refused",
+        reply="{}",
+        class_key="malformed-json",
+        stream_shape=StreamShape(content_deltas=1, stop="stop\nclass: extra-action-key"),
+    )
+
+    detail = _rejection_detail(rejected, None)
+
+    assert [line for line in detail.splitlines() if line.startswith("class: ")] == [
+        "class: malformed-json"
+    ]
+    assert "stop\\nclass: extra-action-key" in detail
 
 
 def test_reserved_key_scan_preserves_legacy_rejection_replay() -> None:

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -27,8 +27,12 @@ from local_operator.evaluation.evidence.models import (
 )
 from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.receipts import RedactionSet
-from local_operator.evaluation.runner.episode import EpisodeRunner
-from local_operator.evaluation.runner.model import DecisionRejected, EpisodeTurn
+from local_operator.evaluation.runner.episode import EpisodeRunner, _rejection_detail
+from local_operator.evaluation.runner.model import (
+    DecisionRejected,
+    EpisodeTurn,
+    StreamShape,
+)
 from local_operator.evaluation.runner.provider_client import (
     DecisionParseError,
     _ContextBuilder,
@@ -40,10 +44,12 @@ from local_operator.evaluation.runner.public_reply import (
     _MAX_EXTRA_KEYS_SHOWN,
     MAX_PUBLIC_OBSERVATIONS_CHARS,
     REJECTED_PUBLIC_REPLY,
+    REJECTED_REPLY_WITHHELD,
     decode_public_reply,
     looks_like_public_reply,
     public_reply_contract,
     redact_public_reply,
+    rejected_reply_evidence,
 )
 from local_operator.harness.types import ImageContent, Message, ModelSpec, TextContent
 from tests.unit.evaluation.runner.conftest import (
@@ -288,6 +294,137 @@ async def test_f1_runner_repro_leaves_no_secret_in_bundle_or_replay(
             canary.encode() in path.read_bytes() for path in root.rglob("*") if path.is_file()
         )
     assert verify_bundle(root).valid
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_envelope_reaches_the_bundle_with_its_class(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The reply is evidence even when it is NOT replayable history.
+
+    An envelope-shaped reply is withheld from the corrective history because its
+    notes are unvalidated text; the bundle is a different boundary, and
+    withholding it there is what made 273 of the campaign's 280 rejection
+    artifacts unreadable. Both halves are asserted on the same run: the
+    artifact carries the reply and the class key, the next request carries the
+    placeholder, and neither carries the other's rendering.
+    """
+
+    rejected_reply = json.dumps(
+        {
+            "reply_version": "9.9",
+            "action_batch": {"actions": json.loads(type_payload(observation()))["actions"]},
+            "public_observations": "visible fact",
+        }
+    )
+    calls = 0
+
+    def reply(message: Message) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return rejected_reply
+        return _wait_reply(message)
+
+    config = build_config(tmp_path)
+    stream = RecordingStream(reply)
+    client = _client(stream, config.artifact_root)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=selector(tmp_path),
+        model=client,
+        launch=lambda _: FakeAdapter(tmp_path, episode_id),
+        rescue=_rescue_ok,
+        # No canaries: this run is about the boundary, not about redaction --
+        # the F1 tests above cover the withheld case.
+        redactions=RedactionSet.from_resolved_values(()),
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None and len(stream.requests) >= 2
+    texts = [
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in root.rglob("*")
+        if path.is_file()
+    ]
+    assert any(
+        rejected_reply in text and "class: unsupported-reply-version" in text for text in texts
+    ), "the rejected reply and its class are in the bundle"
+    replay = "\n".join(message.text for message in stream.requests[1].messages)
+    assert REJECTED_PUBLIC_REPLY in replay
+    assert rejected_reply not in replay
+    assert verify_bundle(root).valid
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        lambda raw, secret: raw,
+        lambda raw, secret: raw.replace("fixture", "\\u0066ixture"),
+        lambda raw, secret: raw.replace(secret, quote(secret, safe="")),
+        lambda raw, secret: raw.replace(secret, base64.b64encode(secret.encode()).decode()),
+    ],
+    ids=["plain", "json-unicode-escape", "percent", "base64"],
+)
+def test_a_reply_carrying_a_canary_is_withheld_whole_from_evidence(transform: Any) -> None:
+    """Evidence publishes the reply ONLY through an escape-aware scan.
+
+    The reply reaches evidence as WIRE bytes, so a canary can be spelt with JSON
+    unicode escapes, percent escapes, or an encoding, and a substring check on
+    the raw text sees none of them. It is also the shape that is most likely to
+    be TRUNCATED (that is usually why it was refused), so the scan cannot lean
+    on a JSON parse -- the raw and unescaped renderings are checked regardless.
+
+    Withheld WHOLE, never partially: ``assert_clear`` matches a substring, so
+    publishing a masked or cut rendering is how a canary stops matching the
+    alarm that exists to catch it.
+    """
+
+    secret = "fixture/canary-evidence-911"
+    redactions = RedactionSet.from_resolved_values([secret])
+    raw = envelope(type_payload(observation()), secret)
+    reply = transform(raw, secret)
+    if reply != raw:
+        # The point of the case: a substring check on the raw text sees nothing.
+        assert secret not in reply
+
+    published = rejected_reply_evidence(reply, redactions)
+
+    assert published == REJECTED_REPLY_WITHHELD
+    assert secret not in published
+    assert reply not in published
+
+
+def test_an_unsafe_reply_degrades_without_losing_the_rejection() -> None:
+    """Withholding the reply must not withhold the rejection.
+
+    A withheld section is still a readable one because the diagnostic, the class
+    and the stream shape are all harness-owned text -- which is what lets the
+    evidence boundary differ from the history boundary without making a bundle
+    unreadable.
+    """
+
+    rejected = DecisionRejected(
+        "Your previous reply was rejected: the reply declared a bad version",
+        reply=REJECTED_PUBLIC_REPLY,
+        evidence_reply='{"public_observations": "fixture-canary"}',
+        class_key="unsupported-reply-version",
+        stream_shape=StreamShape(content_deltas=2, reasoning_deltas=3, stop="stop"),
+    )
+    redactions = RedactionSet.from_resolved_values(["fixture-canary"])
+
+    detail = _rejection_detail(rejected, redactions)
+
+    assert REJECTED_REPLY_WITHHELD in detail
+    assert "fixture-canary" not in detail
+    assert "class: unsupported-reply-version" in detail
+    assert "reasoning_deltas=3" in detail
+    # The history rendering is NOT what evidence shows: the placeholder belongs
+    # to the correction, and pasting it here would read as "the model said this".
+    assert REJECTED_PUBLIC_REPLY not in detail
 
 
 def test_reserved_key_scan_preserves_legacy_rejection_replay() -> None:

--- a/tests/unit/evaluation/runner/test_public_reply_transport.py
+++ b/tests/unit/evaluation/runner/test_public_reply_transport.py
@@ -199,8 +199,8 @@ async def test_loopback_sse_factory_public_memory_and_secret_retention(
         assert public_fact in "\n".join(m.text for m in history)
 
         async def summarize(prompt: str) -> str:
-            text, *_ = await client._stream(client._summary_request(prompt))
-            return text
+            summary = await client._stream(client._summary_request(prompt))
+            return summary.text
 
         compacted = await asyncio.wait_for(
             run_compaction_pass(

--- a/tests/unit/evaluation/runner/test_rejection_classes.py
+++ b/tests/unit/evaluation/runner/test_rejection_classes.py
@@ -1,0 +1,289 @@
+"""Refusal CLASSES: the taxonomy, its drift pin, and the sealed corpus.
+
+The class key is what makes a rejection countable. Before it existed the only
+thing a bundle recorded was the validator's prose, and deriving a class from
+prose after the fact is guesswork -- the MiniMax campaign's rejections were
+mis-read once already for exactly this reason. So the taxonomy is pinned two
+ways: against the real parsers (in ``test_provider_client``, per class, through
+the client) and against the sealed artifacts a paid run actually produced
+(here), which is the corpus a future reader will want to reproduce.
+
+The offline replay needs no credentials and spends nothing: it only reads
+bundles that are already on disk, and it SKIPS when they are not.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from pydantic.fields import FieldInfo
+
+from local_operator.evaluation.action_surface import LEGACY_ACTION_SURFACE
+from local_operator.evaluation.protocol import KeyAction
+from local_operator.evaluation.runner.provider_client import (
+    REJECTION_CLASS_UNKNOWN,
+    _action_schema_lines,
+    classify_rejection,
+    rejection_hint,
+)
+from tests.unit.evaluation.runner.test_provider_client import observation
+
+#: Where a campaign's sealed bundles live on the machine that ran it. Overridable
+#: because the corpus is a paid run's output, not a repository fixture: the test
+#: must work on any machine that has one, and skip on every machine that does
+#: not (CI included) rather than pretend the classes are unverified.
+CORPUS_ENV = "LOCAL_OPERATOR_REJECTION_CORPUS"
+DEFAULT_CORPUS = Path.home() / "worktrees" / "osworld" / "runs"
+CORPUS_GLOB = "batch-minimax-m3-*/task_*/evidence/ep-*"
+
+#: A runner bound, so a corpus that has rotated away to a handful of bundles
+#: skips instead of asserting a distribution it can no longer see.
+_MIN_CORPUS_ARTIFACTS = 20
+
+
+def _corpus_root() -> Path:
+    return Path(os.environ.get(CORPUS_ENV) or DEFAULT_CORPUS)
+
+
+def _sealed_rejection_artifacts() -> list[tuple[str, str]]:
+    """``(diagnostic, artifact_text)`` for every sealed ``decision-rejected``.
+
+    Read from the EVENT, not from the artifact directory listing: the artifact
+    a rejection points at is identified by digest in the event, and an orphan
+    file in ``artifacts/`` is not a rejection.
+    """
+
+    found: list[tuple[str, str]] = []
+    for episode in sorted(_corpus_root().glob(CORPUS_GLOB)):
+        events = episode / "events.jsonl"
+        if not events.exists():
+            continue
+        for line in events.read_text(encoding="utf-8", errors="replace").splitlines():
+            try:
+                record = json.loads(line)
+            except ValueError:
+                continue
+            if record.get("kind") != "error":
+                continue
+            payload = record.get("payload") or {}
+            if payload.get("diagnostic_code") != "decision-rejected":
+                continue
+            digest = (payload.get("detail_artifact") or {}).get("sha256")
+            artifact = episode / "artifacts" / str(digest)
+            if digest and artifact.exists():
+                found.append((artifact.read_text(encoding="utf-8", errors="replace"), str(episode)))
+    return found
+
+
+def _diagnostic_of(artifact: str) -> str:
+    """The rejection's diagnostic section: everything up to the reply marker.
+
+    Mirrors ``episode._rejection_detail``'s layout without importing the runner,
+    so this reads both the old artifacts (diagnostic then ``--- rejected
+    reply ---``) and the new ones (diagnostic, ``class:``, ``stream:``, reply).
+    """
+
+    head = artifact.split("\n\n--- rejected reply ---", 1)[0]
+    return "\n".join(
+        line
+        for line in head.splitlines()
+        if not line.startswith("class: ") and not line.startswith("stream: ")
+    )
+
+
+def _class_of(artifact: str) -> str:
+    """The class of a sealed rejection: recorded if it says so, derived if not.
+
+    Two generations of artifact, one reader. A bundle written since the class
+    key exists STATES its class (``class:``) and that is authoritative -- it is
+    what the run itself bucketed the refusal into. A bundle written before it
+    must be classified from its diagnostic text, which is the whole reason the
+    classifier reads text and not an exception object: the corpus that motivated
+    this work can only be measured that way.
+    """
+
+    for line in artifact.splitlines():
+        if line.startswith("class: "):
+            return line[len("class: ") :].strip()
+    return classify_rejection(_diagnostic_of(artifact))
+
+
+def test_the_hint_is_derived_from_the_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A protocol change moves the hint, exactly as it moves the prompt.
+
+    ``_action_schema_lines`` exists so the system prompt cannot advertise a
+    shape the validator refuses. The hint has the same job at the other end of
+    the episode -- it is the LAST thing the model reads before it retries -- so
+    it is derived from the same models and this asserts the two drift together.
+    Mutating ``KeyAction.keys`` from an array of names to a single string is the
+    protocol change that would otherwise leave the correction instructing the
+    model to send a shape the parser rejects.
+    """
+
+    current = observation()
+    before = rejection_hint(
+        "keys-not-array", reason="", observation=current, surface=LEGACY_ACTION_SURFACE
+    )
+    schema_before = _action_schema_lines(LEGACY_ACTION_SURFACE)
+
+    assert "an array of key names" in before
+    monkeypatch.setitem(KeyAction.model_fields, "keys", FieldInfo(annotation=str))
+
+    after = rejection_hint(
+        "keys-not-array", reason="", observation=current, surface=LEGACY_ACTION_SURFACE
+    )
+    schema_after = _action_schema_lines(LEGACY_ACTION_SURFACE)
+
+    assert "an array of key names" not in after
+    assert "a string" in after
+    assert after != before
+    # The mirror: the prompt's own rendering of the same field moved with it.
+    assert schema_after != schema_before
+    assert '"keys": [str, ...]' in "\n".join(schema_before)
+    assert '"keys": str' in "\n".join(schema_after)
+
+
+_PRESERVED_MESSAGES = [
+    # The envelope decoder's own diagnostic: it names the keys carried and
+    # omitted, and recovered 9/10 against 4/10 for the bare rule.
+    "model reply used the reserved envelope but carried 'action_batch', "
+    "'reply_version'; omitted 'public_observations'.",
+    # The batch-level rules, also the harness's own sentences.
+    "decision must carry a non-empty actions array",
+    "decision carries a second action batch for the same observation; send one batch",
+    # The adapter's negotiated restriction, phrased WITH the alternative it can
+    # carry -- a bare refusal would leave the model shortening text forever.
+    "decision does not match this observation: type supports only ASCII on this "
+    "adapter; use paste_text with an explicit chord",
+    # The silent-reply diagnostic, which names the channel and the shape.
+    "reply carried no tool call and no text: the model ended its turn as 'stop' "
+    "without emitting a decision on either channel. Reply with the action batch "
+    'itself, as a single JSON object with a non-empty "actions" array.',
+]
+
+
+@pytest.mark.parametrize("reason", _PRESERVED_MESSAGES, ids=[m[:24] for m in _PRESERVED_MESSAGES])
+def test_a_measured_message_is_preserved_rather_than_paraphrased(reason: str) -> None:
+    """The classes whose diagnostic was ALREADY measured keep it verbatim.
+
+    These are the harness's OWN sentences, written to be read by the model, and
+    each already does the job a hint exists to do -- naming the keys carried and
+    omitted, the rule broken, the limit and its alternative, or the shape the
+    reply must take. Re-deriving them here would replace measured text with
+    unmeasured text, so the hint returns them unchanged. Every one is asserted
+    to be Pydantic-free already, which is what makes preserving it safe; a class
+    whose diagnostic comes from a Pydantic rendering is never preserved.
+    """
+
+    key = classify_rejection(reason)
+
+    assert key != REJECTION_CLASS_UNKNOWN, reason
+    assert "input_value=" not in reason and "errors.pydantic.dev" not in reason
+    assert (
+        rejection_hint(key, reason=reason, observation=observation(), surface=LEGACY_ACTION_SURFACE)
+        == reason
+    )
+
+
+def test_an_unrecognised_message_is_still_recordable_and_still_answered() -> None:
+    """A refusal this build has never seen must not lose its evidence.
+
+    Every class key is a string, including the fallback, and the fallback hint
+    still states the accepted envelope: a taxonomy that raised on the unexpected
+    would turn a diagnosable refusal into an unsealed episode, which is strictly
+    worse than the prose this replaced.
+    """
+
+    reason = "the provider said something no template of ours produces"
+    assert classify_rejection(reason) == REJECTION_CLASS_UNKNOWN
+
+    hint = rejection_hint(
+        REJECTION_CLASS_UNKNOWN,
+        reason=reason,
+        observation=observation(),
+        surface=LEGACY_ACTION_SURFACE,
+    )
+
+    assert '"reply_version": "1.0"' in hint
+    assert '"action_batch"' in hint
+    assert "input_value=" not in hint
+
+
+@pytest.mark.skipif(
+    not _corpus_root().exists(),
+    reason=f"no sealed rejection corpus at {_corpus_root()} (set {CORPUS_ENV})",
+)
+def test_every_sealed_rejection_artifact_classifies(capsys: pytest.CaptureFixture[str]) -> None:
+    """The classes, over the artifacts a paid campaign actually produced.
+
+    Two claims, and the second is the one that matters for the instrument: not
+    one artifact falls through to the fallback key (so the taxonomy covers the
+    traffic), and the classes the corpus ranks are all present (so the keys are
+    not merely reachable in theory). The histogram is printed because it is the
+    measurement -- the reason the class key exists at all.
+    """
+
+    artifacts = _sealed_rejection_artifacts()
+    if len(artifacts) < _MIN_CORPUS_ARTIFACTS:
+        pytest.skip(f"corpus has rotated: {len(artifacts)} rejection artifacts left")
+
+    histogram: dict[str, int] = {}
+    for artifact, episode in artifacts:
+        derived = classify_rejection(_diagnostic_of(artifact))
+        key = _class_of(artifact)
+        histogram[key] = histogram.get(key, 0) + 1
+        assert derived != REJECTION_CLASS_UNKNOWN, episode
+        assert derived == key, episode
+
+    with capsys.disabled():
+        print(f"\nsealed rejection classes ({len(artifacts)} artifacts):")
+        for key, count in sorted(histogram.items(), key=lambda item: -item[1]):
+            print(f"  {count:4d}  {key}")
+
+    ranked = {
+        "malformed-json",
+        "unsupported-reply-version",
+        "envelope-shape",
+        "extra-action-key",
+        "unknown-key",
+        "out-of-frame-coordinate",
+    }
+    assert ranked.issubset(histogram), sorted(histogram)
+
+
+def test_a_sealed_artifact_reads_the_way_report_tools_will_read_it() -> None:
+    """Both generations of artifact, through the reader a script would use.
+
+    An artifact written before the class key existed is classified from its
+    diagnostic text; one written after it states its own class and the recorded
+    key wins. Both must work, or the reader gets a different answer depending on
+    when the corpus was paid for.
+    """
+
+    old = (
+        "Your previous reply was rejected: decision is not valid JSON: Expecting value: "
+        "line 1 column 1 (char 0)\n"
+        "Nothing was executed. Reply again for this same observation.\n"
+        "\n--- rejected reply ---\n"
+        "(model reply rejected; no public observations accepted)"
+    )
+    new = (
+        "Your previous reply was rejected: the reply was not one complete JSON object.\n"
+        "Nothing was executed. Reply again.\n"
+        "class: malformed-json\n"
+        "stream: content_deltas=1 reasoning_deltas=0 tool_call_deltas=0 stop=stop\n"
+        "\n--- rejected reply ---\n"
+        '{"actions": ['
+    )
+
+    assert _class_of(old) == "malformed-json"
+    assert _class_of(new) == "malformed-json"
+    # The diagnostic section excludes everything the artifact added around it,
+    # so a reader that WANTS the prose gets the prose and not the header.
+    for artifact in (old, new):
+        assert "--- rejected reply ---" not in _diagnostic_of(artifact)
+        assert not _diagnostic_of(artifact).startswith("class: ")
+    assert "stream:" not in _diagnostic_of(new)

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -241,10 +241,10 @@ def test_an_unused_channel_is_distinguishable_from_an_empty_one() -> None:
         # text) and is now reported as the silence it is, while on the channel
         # it means the model DID select the channel and sent empty arguments --
         # a malformed call, not an absent reply. Requiring one diagnostic to
-        # cover both would force the silent case back to "not valid JSON",
-        # which is the misdiagnosis that spends an episode's retry bound
-        # re-prompting a model to fix JSON it never wrote. The silent case is
-        # covered directly by ``test_a_silent_reply_is_a_correctable_rejection``
+        # cover both would force the silent case back to reporting a JSON
+        # complaint, which is the misdiagnosis that spends an episode's retry
+        # bound re-prompting a model to fix JSON it never wrote. The silent case
+        # is covered directly by ``test_a_silent_reply_is_a_correctable_rejection``
         # and the channel case by
         # ``test_an_empty_channel_call_is_rejected_like_an_empty_prose_body``.
     ],
@@ -672,4 +672,9 @@ async def test_an_empty_channel_call_is_rejected_like_an_empty_prose_body() -> N
 
     message = str(info.value)
     assert "no tool call and no text" not in message
-    assert "not valid JSON" in message
+    # The reply is reported as what it is: a reply that did not come through as
+    # one JSON object, bucketed as that class. The wording moved when the
+    # model-facing text became a shape hint instead of the decoder's prose; the
+    # distinction this test draws -- malformed, NOT silent -- is unchanged.
+    assert "not one complete JSON object" in message
+    assert info.value.class_key == "malformed-json"

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 import time
 from collections import Counter
@@ -39,6 +40,7 @@ from local_operator.harness.types import (
     NoticeEvent,
     StreamEndEvent,
     StreamEvent,
+    StreamReasoningDelta,
     StreamTextDelta,
     StreamToolCallDelta,
     StreamUsageEvent,
@@ -216,6 +218,46 @@ async def test_full_turn_text_tool_text():
     # System blocks and converted messages reached the provider.
     assert stream.requests[0].system_blocks == ["sys"]
     assert stream.requests[0].messages[0].text == "go"
+
+
+@pytest.mark.asyncio
+async def test_a_reasoning_delta_changes_nothing_a_consumer_can_see() -> None:
+    """The reasoning channel reaches no surface, and that claim is load-bearing.
+
+    ``stream_with_failover`` carves ``StreamReasoningDelta`` out of its "the
+    caller has seen output" gate on the strength of this property, and the
+    harness claims a consumer that ignores the event renders the old turn
+    unchanged. The loop is the one consumer that could regress silently, so the
+    same turn is run twice -- with and without a leading reasoning fragment --
+    and the two runs are compared: identical event types, identical assembled
+    text, and no emitted event (serialized in full) carrying the fragment.
+    """
+
+    def turn(with_reasoning: bool) -> list[StreamEvent]:
+        leading: list[StreamEvent] = (
+            [StreamReasoningDelta(delta="weighing the options")] if with_reasoning else []
+        )
+        return [*leading, StreamTextDelta(delta="Done"), StreamEndEvent(stop_reason="stop")]
+
+    async def run(with_reasoning: bool) -> list[Any]:
+        stream = ScriptedStream([turn(with_reasoning)])
+        context = LoopContext(system_blocks=["sys"], tools=[])
+        return [
+            event
+            async for event in AgentLoop().run(
+                [Message.user("go")], context, make_config(stream), None
+            )
+        ]
+
+    with_reasoning = await run(True)
+    without = await run(False)
+
+    assert [event.type for event in with_reasoning] == [event.type for event in without]
+    assert with_reasoning[-1].messages[0].text == "Done"
+    assert without[-1].messages[0].text == "Done"
+    assert not any(
+        "weighing" in json.dumps(event.model_dump(mode="json")) for event in with_reasoning
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -21,6 +21,7 @@ from local_operator.harness.types import (
     Message,
     ModelSpec,
     StreamEndEvent,
+    StreamReasoningDelta,
     StreamTextDelta,
     StreamToolCallDelta,
     StreamUsageEvent,
@@ -176,6 +177,52 @@ async def test_openai_compat_text_tool_usage() -> None:
     assert isinstance(end, StreamEndEvent)
     assert end.stop_reason == "toolUse"
     assert end.usage is not None and end.usage.output_tokens == 7
+
+
+async def test_openai_compat_surfaces_the_reasoning_channel() -> None:
+    """Reasoning is REPLAYED and was never REPORTED, which is a diagnosis hole.
+
+    The client accumulates ``reasoning_content``/``reasoning`` so it can replay
+    the model's own thinking in later requests, but it emitted no event for it,
+    so a caller watching the stream could not tell "the model thought for the
+    whole budget and said nothing" from "we threw away what it said". Both
+    spell an empty reply, and they call for opposite responses. Asserted beside
+    the text channel because the point is that the two are distinguishable: the
+    reasoning fragments surface as reasoning, and the visible text is still only
+    the visible text.
+    """
+
+    body = _sse(
+        [
+            {
+                "id": "chatcmpl-r1",
+                "choices": [{"delta": {"reasoning_content": "weighing "}, "index": 0}],
+            },
+            {"id": "chatcmpl-r1", "choices": [{"delta": {"reasoning": "options"}, "index": 0}]},
+            {
+                "id": "chatcmpl-r1",
+                "choices": [{"delta": {"content": "done"}, "index": 0, "finish_reason": "stop"}],
+            },
+        ]
+    )
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    client = OpenAICompatClient(
+        "https://api.test.example/v1", http_client=httpx.AsyncClient(transport=transport)
+    )
+    request = ChatRequest(model=_spec(), system_blocks=["be brief"], messages=[Message.user("hi")])
+
+    events = await _collect(client.stream(request, "sk-test"))
+
+    assert [event.delta for event in events if isinstance(event, StreamReasoningDelta)] == [
+        "weighing ",
+        "options",
+    ]
+    # The reasoning did NOT leak onto the visible channel: nothing renders it.
+    assert [event.delta for event in events if isinstance(event, StreamTextDelta)] == ["done"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -19,6 +19,7 @@ from local_operator.harness.types import (
     ChatRequest,
     ModelSpec,
     StreamEndEvent,
+    StreamReasoningDelta,
     StreamStartEvent,
     StreamTextDelta,
     StreamUsageEvent,
@@ -546,6 +547,92 @@ async def test_stream_fallback_chain_walks_to_next_model() -> None:
     got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
     assert [s.model_id for s in specs_seen] == ["gpt-4o", "claude-x"]
     assert any(isinstance(e, StreamTextDelta) and e.delta == "fallback" for e in got)
+
+
+class _FailsAfter:
+    """Emits scripted events, then dies mid-stream (a pre-content death)."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = events
+
+    async def stream(
+        self, request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        for event in self._events:
+            yield event
+        raise ProviderError(500, "boom", retryable=True)
+
+
+@pytest.mark.parametrize(
+    ("leading", "walks_chain"),
+    [
+        ([], True),
+        ([StreamStartEvent(response_id="r1")], True),
+        ([StreamReasoningDelta(delta="weighing the options")], True),
+        (
+            [StreamStartEvent(response_id="r1"), StreamReasoningDelta(delta="weighing")],
+            True,
+        ),
+        # The control: a VISIBLE delta is output the caller can see, so the
+        # attempt must not be replayed. Without this row, a carve-out that
+        # swallowed every event would pass every row above.
+        ([StreamTextDelta(delta="half an answer")], False),
+    ],
+    ids=["nothing", "start", "reasoning", "start-and-reasoning", "visible-text"],
+)
+async def test_a_pre_content_failure_after_a_reasoning_delta_still_walks_the_chain(
+    leading: list[Any], walks_chain: bool
+) -> None:
+    """What gates a retry is output the caller has SEEN, and reasoning is not.
+
+    ``forwarded_any`` means exactly that: the caller has seen output that cannot
+    be un-shown, so replaying the attempt would stream it twice. A
+    ``StreamStartEvent`` was already carved out for announcing nothing; a
+    ``StreamReasoningDelta`` announces nothing either -- no consumer renders it
+    (no loop branch, no frontend handler, no transcript entry) -- so counting it
+    would gate the retry on the one channel that cannot be seen. The consequence
+    would be confined to reasoning models, which is every model this harness
+    runs on a hard task: a 5xx arriving after the model started thinking would
+    stop credential rotation and the whole fallback chain, and a pre-content
+    transport death would be misreported as a mid-stream loss.
+
+    The last row is the boundary that must not move: a visible delta still
+    blocks the retry, so this cannot degrade into "retry everything".
+    """
+
+    specs_seen: list[ModelSpec] = []
+
+    async def client_for(spec: ModelSpec) -> Any:
+        specs_seen.append(spec)
+        if spec.model_id == "gpt-4o":
+            return _FailsAfter(leading)
+        return ScriptedClient(
+            [StreamTextDelta(delta="fallback"), StreamEndEvent(stop_reason="stop")]
+        )
+
+    settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}}
+    auth = FakeAuth({"openai": ["k1"], "anthropic": ["k2"]})
+
+    if not walks_chain:
+        with pytest.raises(ProviderError):
+            async for _ in stream_with_failover(_request(), auth, settings, client_for):
+                pass
+        assert [spec.model_id for spec in specs_seen] == ["gpt-4o"]
+        return
+
+    got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+
+    assert specs_seen[-1].model_id == "claude-x"
+    assert any(isinstance(e, StreamTextDelta) and e.delta == "fallback" for e in got)
+    # The reasoning this attempt produced is still FORWARDED -- carving it out
+    # of the retry gate must not swallow it. Asserted as a set rather than a
+    # count: a pre-content failure is retried on the same target before the
+    # chain is walked, and each of those attempts legitimately re-emits the
+    # channel. How many attempts the ladder burns is the ladder's business.
+    forwarded = {e.delta for e in got if isinstance(e, StreamReasoningDelta)}
+    assert forwarded == {
+        event.delta for event in leading if isinstance(event, StreamReasoningDelta)
+    }
 
 
 async def test_failover_stamps_serving_spec_on_usage() -> None:


### PR DESCRIPTION
## Summary of Changes

A refused reply is the one place the harness knows exactly what the model did wrong, and it was throwing that away twice over. This PR makes both halves readable.

**1. The rejected reply is published as evidence again (the dead instrument).** `_rejection_detail` documents its own purpose — "without the reply, diagnosing a rejection class costs a whole re-run of a paid episode" — but the rejected path replaced the reply with `(model reply rejected; no public observations accepted)` whenever the reply came near the reserved envelope. In the MiniMax campaign that is **273 of the 280 rejection artifacts** counted on 2026-09-12 (261 placeholder + 12 empty replies; 7 carried the reply). Every class histogram read off that corpus was therefore a histogram of the placeholder, and one reading was wrong for exactly this reason.

The reply is now published on a **separate boundary from the corrective history**:

- **Evidence** gets the raw reply, escape-aware redaction-scanned and bounded. The scan covers the plaintext, percent, JSON `\uXXXX`-escape and base64 renderings, plus the decoded JSON value when it parses, and **fails closed and whole** — any hit replaces the entire reply with a marker rather than masking a span (a partial rendering is how a canary stops matching the alarm that exists to catch it).
- **History** is unchanged: an envelope-shaped reply's unvalidated notes are still replaced by the placeholder before replay. That is F1's boundary and it still holds — the F1 runner repro passes unchanged in this PR.

**2. The model is told what the harness knows (the field-level hint).** The model-facing message used to be the validator's own prose — `keys — Input should be a valid tuple [type=tuple_type, input_value={'item': ['ctrl','alt','t']}] … https://errors.pydantic.dev/…` — when the harness knows `keys` must be an array of key names. It is now a class-keyed hint that always states the accepted shape with a concrete example, or the accepted literal/bound:

| class | what the model is told |
|---|---|
| `malformed-json` | not one complete JSON object (cut off / fenced / native syntax) + a concrete accepted envelope |
| `unsupported-reply-version` | `the only accepted value is "1.0"` |
| `envelope-shape` | **preserved verbatim** — the decoder's key-naming message (9/10 recovery vs 4/10) |
| `extra-action-key` | names the field, the kinds that DO take it, and the kind's exact fields |
| `unknown-key` | names the accepted key (`'Return'` → `"enter"`) + the array example |
| `keys-not-array` | `["ctrl","alt","t"]` written directly, not wrapped (`{"item": [...]}`) |
| `out-of-frame-coordinate` | `"x" 0..1279 and "y" 0..719`, from the frame's own model-visible geometry |
| `unknown-frame-id` | the only accepted frame ids on the observation |
| `unknown-action-kind` | `"right_click"` → `did you mean "click"?` + the accepted kinds |
| `observation-binding`, `field-invalid`, `batch-shape`, `adapter-capability`, `empty-reply` | the id the batch must carry / the field's own constraint / the rule + shape |

Hints are **derived from the enforced schema** — `KeyAction`'s own annotation and `FieldInfo` constraints, the envelope schema, the observation's frame geometry, the surface's key vocabulary — never hand-written, and a drift test mutates the protocol model to prove both the hint and `_action_schema_lines` move together. Classes whose diagnostic was **already measured** keep it verbatim rather than being paraphrased.

**3. The rejection artifact carries a class key and the stream shape.** `class: <key>` makes a batch of bundles countable without re-deriving classes from prose (and is authoritative when present), and `stream: content_deltas=… reasoning_deltas=… tool_call_deltas=… stop=…` answers the question the reply cannot: a refusal whose reply is empty may have been **empty** or **discarded**. That needed the reasoning channel to exist on the wire (see the providers commit): `OpenAICompatClient` collected `reasoning_content`/`reasoning` for replay and emitted no event for it.

## Related Issue(s)

- Related: none filed. Architect finding from the driver job on the MiniMax rejection corpus.

## Impact

- **No tolerance change.** `evaluation/protocol.py` is untouched: no normalisation of the `{"item": [...]}` wrapper (1 artifact of the ranked classes, and any tolerance would have to be a bijection onto the same action model with the same executed effect), no coordinate clamping or rescaling (the pointer would move to a pixel the model never chose).
- **No retry increase.** `max_decision_retries` is unchanged and no attempt is added for a decision-less reply — naming the defect beats more tries (9/10 vs 4/10) and retries are billed cycles.
- **No model- or provider-specific rules**, and no model-facing message may contain `input_value=` or a Pydantic docs URL (asserted per class, including the class whose defect arrives through a Pydantic model validator).
- **Artifact compatibility:** a rejection artifact's first line is unchanged; old artifacts are classified from their diagnostic text, new ones state their own class. Any bundle reader keeps working.
- **Blast radius of the shared piece.** `StreamReasoningDelta` is added to the harness stream union (providers commit). Every consumer narrows with `isinstance` (`harness/loop.py`, `session/session.py`, `session/runtime`, `server/utils/operator.py`, `providers/failover.py` buffering/`_stamp_serving_spec`) and ignores an event it does not know, so **nothing user-visible changes**: no transcript rendering, no TUI/mobile/server rendering, and analytics deliberately does not count it as a first token. An interactive session sees exactly the stream it saw before. Deliberately not extended to the Responses/Anthropic clients, which normalise reasoning differently (recorded under "Not addressed").
- `episode.py` applies the evidence bound; the constant lives beside the reply rendering so the runner core still does not import the provider-backed client. `DecisionRejected` gained `class_key`/`evidence_reply`/`stream_shape` as optional keywords, so any other implementation of the client protocol keeps working.

## Testing Details

### Gates (whole tree, exactly the CI commands)

| gate | command | result |
|---|---|---|
| flake8 | `.venv/bin/python -m flake8 .` | PASS |
| black | `uvx --from black==26.1.0 black --check .` | PASS |
| isort | `uvx isort==5.13.2 --check .` | PASS |
| pyright | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | PASS — 0 errors, 0 warnings, 0 informations |
| unit (affected subtrees) | `.venv/bin/python -m pytest tests/unit/evaluation tests/unit/providers tests/unit/harness -q` | PASS — **3069 passed, 1 skipped** in 3:26 |
| unit (whole tree, CI) | GitHub Actions `test (3.12, 0..3)` shards | PASS — 4/4 green on head `bea0151a` |
| e2e (CI) | GitHub Actions `tui-e2e (macos-latest)` and `(ubuntu-latest)` | PASS — both green, including the macOS resume-liveness guard |
| rest of CI | `lint`, `type-check`, `build`, `pip-audit`, `context-budget`, `filesystem-boundaries-windows` | PASS — all green |

Note on the local whole-tree run: this host was at load average 250-450 from other sessions' benchmark work while this PR was tested, and the local `tests/unit` invocation had not settled inside the working window; the whole-tree gate is therefore evidenced by the four CI test shards plus `tui-e2e` above, which run the same suite (`pytest --cov`) the local command runs. The affected subtrees were re-run locally after the last edit and are green as tabulated.

### The offline replay, over the sealed corpus (no new spend)

The corpus test walks a real campaign's bundles, reads each `decision-rejected` event's artifact, and classifies it. Run against `~/worktrees/osworld/runs/batch-minimax-m3-*` (~287 artifacts, a batch still running):

```
sealed rejection classes (287 artifacts):
   113  malformed-json
    35  out-of-frame-coordinate
    30  envelope-shape
    28  unsupported-reply-version
    27  extra-action-key
    20  unknown-key
    12  empty-reply
     9  field-invalid
     4  observation-binding
     3  unknown-action-kind
     2  batch-shape
     2  second-batch
     1  keys-not-array
     1  adapter-capability
```

**Not one artifact falls through to the `unknown` fallback**, and the classes the architect's corpus ranks are all present. The test skips when the corpus is absent (CI), so the coverage that must hold everywhere is generated instead: every class is produced through the real parsers and asserted per row.

### What the model actually sees now (real `ProviderModelClient`, scripted stream)

```
class : keys-not-array
hint  : Your previous reply was rejected: "keys" takes an array of key names written
        directly, e.g. ["ctrl", "alt", "t"] -- not an object wrapping the names. Do not
        add a container of your own.
evid  : '{"actions": [{"kind": "key", ... "keys": {"item": ["ctrl", "alt", "t"]}}]}'
history: <the reply itself -- no reserved key, so legacy replay>
```

```
class : unsupported-reply-version
hint  : ... replied with a "reply_version" this harness does not serve. The only
        accepted value is "1.0"
evid  : '{"reply_version": "9.9", ...}'          <- published, was the placeholder
history: '(model reply rejected; no public observations accepted)'   <- unchanged
```

```
class : out-of-frame-coordinate
hint  : ... action coordinate 17752,900 is outside model-visible frame 1280x720.
        the accepted bounds are "x" 0..1279 and "y" 0..719 for frame "screen" (1280x720)
```

```
class : empty-reply
shape : content_deltas=0 reasoning_deltas=2 tool_call_deltas=0 stop='stop'
```

### Tests added

(i) `test_a_refused_reply_is_told_what_to_send_instead` — 13-row table (one per class), each asserting the class key, the shape/literal/bound the model is told, and `input_value=` / `errors.pydantic.dev` / `[type=` **absent** from the model-facing message.
(ii) `test_the_hint_is_derived_from_the_schema` — mutating `KeyAction.keys` from an array to a string moves the hint **and** `_action_schema_lines`, mirroring the prompt's drift pin.
(iii) `test_a_rejected_envelope_is_published_but_not_replayed` (client) and `test_a_rejected_envelope_reaches_the_bundle_with_its_class` (real `EpisodeRunner`, real bundle) — the artifact carries the reply and the class; the next request carries the placeholder and not the reply.
(iv) `test_a_reply_carrying_a_canary_is_withheld_whole_from_evidence` — plain / JSON-unicode-escape / percent / base64 shapes, each withheld whole; plus the existing F1 runner repro, unchanged and green.
(v) `test_recording_a_rejection_does_not_change_the_decision_sequence` — the same scripted defective-then-corrected pair run with the recorder on and off: identical decision sequence and byte-identical requests (modulo per-construction message UUIDs).
(vi) `test_every_sealed_rejection_artifact_classifies` (above) and `test_a_sealed_artifact_reads_the_way_report_tools_will_read_it` (both artifact generations).
(vii) `test_the_published_rejected_reply_is_bounded` — a 3× bound reply is cut with the truncation marker and stays inside the bound.

Plus: `test_a_rejection_records_the_shape_of_the_stream_that_produced_it` (an empty reply with `reasoning_deltas=2` is not a silence), `test_an_unusual_stop_marker_is_recorded_rather_than_rejected` (a vendor marker or an over-long one cannot turn a refusal into a crash), `test_the_example_the_hint_hands_the_model_actually_parses` (the generated example is fed back through the real decoder), `test_the_key_example_in_the_hint_is_an_accepted_chord`, and a provider test asserting the reasoning fragments surface as reasoning while the visible text stays the visible text.

Three existing tests were updated because the message they pinned is what this PR replaces: `test_an_empty_channel_call_is_rejected_like_an_empty_prose_body` (asserts `not valid JSON` prose → asserts the new malformed-JSON hint and its class), and two `_stream` callers that unpacked the old positional tuple (now `_StreamOutcome`).

## Not addressed here (recorded, with reasons)

- **Reasoning surfacing on the Responses and Anthropic clients.** Both keep reasoning internal by design (`response.reasoning*` is skipped as opaque; Anthropic's thinking blocks are not collected as deltas). Offline replay only needs the OpenAI-compatible channel the MiniMax campaign ran on; extending it is a separate change with its own semantics question (encrypted vs plaintext reasoning).
- **Analytics TTFT for reasoning-only turns.** A reasoning-only turn still reports no first token, because `_record_stream` counts text/tool deltas only. That is the pre-existing semantics and changing it would move every latency series in the ledger.
- **The refused-key quoting rule in the new hint** reuses `is_quotable_key` (renamed from private) rather than re-deriving it.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.
