### PR TITLE
chore(release): bump version to 0.54.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.18"
+version = "0.54.19"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: **6761** (session id `3e4e1a4e`, conversation "TUI analytics scroll tearing"). Author of this bump PR: the owner (pid 6761).

Window derived from the commits, not the commit shape: `git log v0.54.18..origin/main`, re-derived immediately before tagging.

Window:
- [x] #994 — `Release: patch` — the `/analytics` page and its page/`home`/`end` keys move the viewport in one complete frame instead of animating a full-viewport repaint per line. Merged `ba9f5c224122eb1d6dd1793de64c883878b5a458`.
- [x] #975 — `Release: patch` — a new persisted top-level config key `model_effort`: `/model default` now saves the reasoning effort with the model, so the level no longer has to be re-chosen every launch. Merged `b8e46f63ee99c024aadae6c0f4fe62636762bbfa` (landed **during** the cut, after this PR was opened; refs sent to the owner at merge time per the merger's duty, and the window re-derived before the tag so it ships listed).

Chosen bump: **patch** → `0.54.19`. Neither PR clears the step-function bar: one is a defect fix, the other a persisted config key with no new subsystem and no format break.

Lock mechanics: this PR is the lock — it began as an empty claim commit and was amended in place into the single `chore(release): bump version to X.Y.Z` commit on the same PR number. Nothing else in the window touches `pyproject.toml`, and no version-bump line appears anywhere on `main` since `v0.54.18`.
