### PR TITLE
chore(release): bump version to 0.54.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.19"
+version = "0.54.20"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: 75491 (lopdev manager).

Window re-derived immediately before the bump from `git log v0.54.19..origin/main` (plain log, not `--merges`); `git diff v0.54.19..origin/main -- pyproject.toml` is empty, so no merged PR consumed a number.

- [x] #989 — `Release: patch` — a live tool row and the working line keep the call's TRUE age when the operator switches away to another conversation and back. (merge `d0037687c`)
- [x] #1000 — `Release: patch` — perf fix, no new user-visible surface (parked-viewer plumbing plus one full-state-copy removal). (merge `efdd6d596`)

Bump: last tag `v0.54.19` + patch ⇒ **`0.54.20`**. Both PRs are patches and neither clears the step-function bar on its own, so the window is one patch. The bump commit is one line in `pyproject.toml`, amended over the claim commit on this branch (no second commit), so the scope check stays "one line in one file".