### PR TITLE
fix(evaluation): record why an adapter observation failed

### DIFF
--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/observation.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/observation.py
@@ -82,6 +82,49 @@ class ObservationError(ValueError):
     """A frame could not be produced that the verifier will accept."""
 
 
+#: The fixed text every frameless observation fails with.
+#:
+#: Load-bearing as an EXACT string, not as a log line: it is what the harness
+#: journals (``observation-phase-retry``), what the docs name, and what every
+#: test that predates a provider-supplied cause matches on. A provider's cause
+#: therefore never rewrites it -- see ``ObservationCauseError``.
+NO_FRAME_MESSAGE = "environment returned no screenshot frame"
+
+#: Optional key in the raw observation dict: the PROVIDER's own bounded account
+#: of why it could not capture a frame.
+#:
+#: It rides the raw dict, and stops there, for two reasons. It must not reach
+#: ``Observation.metadata``: that mapping feeds ``observation_content_id``, and
+#: a content-addressed observation id has to be a function of what the model
+#: saw rather than of the guest's health (``docs/benchmarks/osworld_2/
+#: README.md``). And it is not a second exception type the harness would have to
+#: learn: the builder turns it into the CAUSE of the error it already raises.
+SCREENSHOT_CAUSE_KEY = "screenshot_unavailable_cause"
+
+
+class ObservationCauseError(RuntimeError):
+    """The provider's bounded account of a failed capture, as an exception CAUSE.
+
+    Chained as ``raise ObservationError(NO_FRAME_MESSAGE) from
+    ObservationCauseError(cause)`` rather than folded into the message, because
+    the two travel by different routes and only one of them is bounded:
+
+    * the MESSAGE is the fixed string above, and it is the ``message`` field of
+      the ``RpcErrorDetail`` the worker builds. Renaming it would break the
+      harness's own evidence vocabulary and every reader grepping a bundle.
+    * the CAUSE is variable text, so it rides the cause chain into
+      ``RpcErrorDetail.causes`` -- a field the worker bounds AND canary-checks
+      per entry (``worker._error_detail``), which is exactly the discipline a
+      variable string needs before it crosses the boundary.
+
+    The provider is the honest source of this fact (it is the code that spoke
+    to the guest), and it states it in a TEXT rather than a structured shape
+    because the harness has no field for benchmark-specific capacity facts and
+    must not grow one: ``docs/benchmarks/osworld_2/README.md`` explains why
+    environment capacity must not become part of an observation's identity.
+    """
+
+
 def _png_dimensions(data: bytes) -> tuple[int, int]:
     """Read IHDR width/height from a PNG without decoding pixels.
 
@@ -161,14 +204,21 @@ class ObservationBuilder:
 
         ``raw`` is OSWorld's shape: ``{"screenshot": bytes|None,
         "accessibility_tree": str|None, "terminal": str|None,
-        "instruction": str}``. A frameless observation is useless to a
+        "instruction": str}``, plus the optional provider cause under
+        ``SCREENSHOT_CAUSE_KEY``. A frameless observation is useless to a
         computer-use model, so a missing screenshot raises rather than
         producing an observation with no frames.
         """
 
         png = raw.get("screenshot")
         if png is None:
-            raise ObservationError("environment returned no screenshot frame")
+            cause = raw.get(SCREENSHOT_CAUSE_KEY)
+            if cause:
+                # A provider that knows WHY the frame is missing says so as the
+                # error's cause, leaving the message -- and so the whole
+                # downstream diagnostic -- byte-identical to the pre-cause case.
+                raise ObservationError(NO_FRAME_MESSAGE) from ObservationCauseError(str(cause))
+            raise ObservationError(NO_FRAME_MESSAGE)
         width, height = _png_dimensions(png)
         if (width, height) != (NATIVE_SCREEN.width, NATIVE_SCREEN.height):
             raise ObservationError(

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -68,8 +68,10 @@ from lop_osworld_v2_adapter.cleanup import (
     EVIDENCE_TERMINATE_DENIED,
     EVIDENCE_TERMINATE_UNCONFIRMED,
 )
+from lop_osworld_v2_adapter.observation import SCREENSHOT_CAUSE_KEY
 from lop_osworld_v2_adapter.providers.base import (
     GUEST_COMMAND_TIMEOUT_S,
+    bounded_observation_cause,
     guest_deadline_for,
 )
 from lop_osworld_v2_adapter.provisioning import ProvisioningPlan
@@ -339,6 +341,119 @@ class _JudgeErrorCapture(logging.Handler):
             self.messages.append(record.getMessage())
         except Exception:  # pragma: no cover - a broken format must not mask the error
             self.messages.append(record.msg if isinstance(record.msg, str) else "judge error")
+
+
+# The upstream frame path, pinned: ``desktop_env/controllers/python.py``
+# (OSWorld-V2 @ d578d2d, ``get_screenshot`` at 455-481). The handler is attached
+# to the one logger those records are written on, and each record is
+# additionally checked for the MODULE it came from. Neither half is enough on
+# its own: attachment alone would accept any record routed to that logger from
+# elsewhere, and a bare ``python.py`` basename is not unique in a package this
+# size. Together they name one function, which is what makes matching safe here
+# (an upstream rename disarms the capture, and it then degrades to no cause
+# rather than to a wrong one).
+_SCREENSHOT_LOGGER = "desktopenv.pycontroller"
+_SCREENSHOT_SOURCE_FILE = "python.py"
+
+# Upstream's per-attempt failure lines, matched as PREFIXES. A record is
+# reduced to a closed KIND plus, when the pinned format carries one, an integer
+# status code -- nothing else in the record is read, and upstream's own words
+# are never copied (see ``_ScreenshotFailureCapture``).
+_SCREENSHOT_RECORD_KINDS = (
+    ("Failed to get screenshot. Status code: ", "status"),
+    ("Invalid screenshot payload", "payload"),
+    ("An error occurred while trying to get the screenshot", "transport"),
+    ("Failed to get screenshot.", "exhausted"),
+)
+
+#: How many upstream failure records a bounded cause may name. The COUNT is
+#: always the true total; only the per-record detail is capped, so the cap can
+#: never understate how long the guest was failing.
+MAX_CAUSE_RECORDS = 8
+
+
+class _ScreenshotFailureCapture(logging.Handler):
+    """Records upstream's FAILED screenshot attempts during one ``observe``.
+
+    ``get_screenshot`` swallows its own failure: it retries ``retry_times``
+    times with ``retry_interval`` sleeps, logs each attempt at ERROR and
+    returns ``None``. By the time the adapter sees that ``None`` the reason is
+    gone, and "environment returned no screenshot frame" is all the bundle can
+    say -- which is how two canary episodes (285 and 248 model cycles, $1.08
+    and $2.24) died with nothing left to read.
+
+    WHAT IS RECORDED, AND WHAT IS DELIBERATELY NOT. Each record contributes a
+    closed KIND and, when the pinned format has one, an integer status code;
+    its message and ``args`` are never copied. That is the point: upstream's
+    text can carry a URL, a credential or a guest path, and a provider that
+    clipped it to a wire bound would sever any secret straddling the cut -- the
+    leak the harness closes by scanning BEFORE bounding (``worker._redacted``),
+    an ordering this side cannot reproduce. Structured facts contain no
+    third-party bytes, so bounding them is safe by construction. Upstream's own
+    words are surfaced by the HARNESS instead, as the worker's stderr tail.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.ERROR)
+        #: (kind, status_or_None, monotonic_seconds) per failed attempt.
+        self.records: list[tuple[str, int | None, float]] = []
+        self.started = time.monotonic()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if os.path.basename(record.pathname) != _SCREENSHOT_SOURCE_FILE:
+            return
+        try:
+            message = record.getMessage()
+        except Exception:  # pragma: no cover - a broken format must not mask the error
+            return
+        for prefix, kind in _SCREENSHOT_RECORD_KINDS:
+            if not message.startswith(prefix):
+                continue
+            status: int | None = None
+            if kind == "status":
+                tail = message[len(prefix) :].strip()
+                # A malformed code is not a reason to drop the record: the KIND
+                # is still known, only the OPTIONAL number is lost.
+                status = int(tail) if tail.isdigit() else None
+            self.records.append((kind, status, time.monotonic()))
+            return
+
+    def cause(self, *, elapsed_ms: int) -> str | None:
+        """One bounded, value-free line, or None when upstream said nothing.
+
+        ``elapsed_ms`` is the whole ``_get_obs`` call and ``first_ms`` the time
+        from its start to upstream's first failure record. Those readings are
+        the fact the harness could not otherwise obtain, and they separate the
+        two mechanisms it had to guess between: a refused or instantly-erroring
+        request leaves upstream's own 5 s retry sleep standing (a gap near
+        5000 ms), while a request that burned its 10 s client timeout adds that
+        much again (a gap near 15000 ms).
+        """
+
+        if not self.records:
+            return None
+        records = self.records[:MAX_CAUSE_RECORDS]
+        parts = [
+            f"upstream_failures={len(self.records)}",
+            "kinds=" + ",".join(kind for kind, _, _ in records),
+        ]
+        codes = [str(status) for _, status, _ in records if status is not None]
+        if codes:
+            parts.append("codes=" + ",".join(codes))
+        parts.append(f"first_ms={_since_ms(self.started, records[0][2])}")
+        gaps = [
+            _since_ms(records[index - 1][2], records[index][2]) for index in range(1, len(records))
+        ]
+        if gaps:
+            parts.append("gaps_ms=" + ",".join(str(gap) for gap in gaps))
+        parts.append(f"elapsed_ms={max(0, elapsed_ms)}")
+        return bounded_observation_cause("screenshot unavailable: " + " ".join(parts))
+
+
+def _since_ms(earlier: float, later: float) -> int:
+    """A non-negative millisecond delta between two monotonic readings."""
+
+    return max(0, int((later - earlier) * 1000))
 
 
 class AwsProvider:
@@ -812,8 +927,27 @@ class AwsProvider:
 
     async def observe(self) -> dict[str, Any]:
         env = self._require_env()
-        raw = await asyncio.to_thread(env._get_obs)
-        return dict(raw)
+        # Attached only for the duration of upstream's own retry loop, exactly as
+        # ``evaluate`` captures judge errors. The records are the ONLY trace of
+        # why a capture failed (``get_screenshot`` logs and returns None), and
+        # this call is the last place they exist.
+        capture = _ScreenshotFailureCapture()
+        screenshot_logger = logging.getLogger(_SCREENSHOT_LOGGER)
+        screenshot_logger.addHandler(capture)
+        started = time.monotonic()
+        try:
+            raw = await asyncio.to_thread(env._get_obs)
+        finally:
+            screenshot_logger.removeHandler(capture)
+        observation = dict(raw)
+        if observation.get("screenshot") is None:
+            # A frameless read with no captured record adds NOTHING: an absent
+            # cause must stay absent rather than be invented, and the builder
+            # then fails with the same fixed text it always did.
+            cause = capture.cause(elapsed_ms=_since_ms(started, time.monotonic()))
+            if cause is not None:
+                observation[SCREENSHOT_CAUSE_KEY] = cause
+        return observation
 
     async def execute(self, statements: list[str], *, settle: bool = True) -> None:
         env = self._require_env()

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
@@ -158,6 +158,34 @@ GUEST_TYPE_MS_PER_CHAR = 8.0
 GUEST_TYPE_DEADLINE_FRACTION = 0.6
 
 
+#: The largest observation cause a provider may attach to a raw observation.
+#:
+#: A BACKSTOP, NOT THE DISCIPLINE. Bounding third-party text is only safe here
+#: because the cause is restricted, by construction, to a closed set of facts
+#: (a record kind, an integer status code, a millisecond latency): there is no
+#: upstream byte in it for a cut to sever, so the harness's canary scan cannot
+#: be defeated the way it can when free text is clipped before it is scanned
+#: (see ``worker._redacted``, whose scan-before-bound ordering this side cannot
+#: reproduce). Upstream's own words are surfaced by the HARNESS instead, as the
+#: worker's stderr tail, where the scan sees the whole retained buffer.
+MAX_OBSERVATION_CAUSE = 512
+
+
+def bounded_observation_cause(text: str) -> str:
+    """Shape one provider-authored cause for the raw-observation channel.
+
+    Control characters collapse to spaces: the cause crosses an LF-delimited
+    JSONL wire and is rendered into a text/plain artifact, so a raw CR would
+    make an otherwise-valid frame unparseable, and a tab or NUL would be a
+    binary blob in a text artifact. The result is then bounded.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("an observation cause must be a string")
+    collapsed = "".join(character if character.isprintable() else " " for character in text)
+    return collapsed.strip()[:MAX_OBSERVATION_CAUSE]
+
+
 @runtime_checkable
 class EnvironmentProvider(Protocol):
     """One environment backend. Implemented by FakeProvider and AwsProvider."""
@@ -175,7 +203,15 @@ class EnvironmentProvider(Protocol):
         ...
 
     async def observe(self) -> dict[str, Any]:
-        """Return OSWorld's raw observation dict (screenshot/a11y/terminal/instruction)."""
+        """Return OSWorld's raw observation dict (screenshot/a11y/terminal/instruction).
+
+        The ONE addition to that shape is optional and belongs to this adapter's
+        own namespace: ``observation.SCREENSHOT_CAUSE_KEY``, the provider's
+        bounded, value-free account of a failed capture. It is present only when
+        the screenshot is absent AND the provider knows something about why. An
+        absent key means "nothing to add", never "nothing failed": the builder
+        then raises exactly the text it always did.
+        """
         ...
 
     async def execute(self, statements: list[str], *, settle: bool = True) -> None:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
@@ -29,7 +29,12 @@ from lop_osworld_v2_adapter.cleanup import (
     EVIDENCE_SCHEDULE_ABSENT,
     EVIDENCE_SCHEDULE_DELETED,
 )
-from lop_osworld_v2_adapter.observation import NATIVE_SCREEN, write_png_rgb
+from lop_osworld_v2_adapter.observation import (
+    NATIVE_SCREEN,
+    SCREENSHOT_CAUSE_KEY,
+    write_png_rgb,
+)
+from lop_osworld_v2_adapter.providers.base import bounded_observation_cause
 from lop_osworld_v2_adapter.provisioning import ProvisioningPlan
 from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 
@@ -44,6 +49,7 @@ class FakeProvider:
         fail_evaluate: bool = False,
         blind_observations: int = 0,
         blind_after_observe_calls: int = 0,
+        blind_cause: str | None = None,
         has_user_simulator: bool = False,
         simulator_answer: str = "simulated user answer",
     ) -> None:
@@ -60,6 +66,13 @@ class FakeProvider:
         # a test that blinded the very first read would exercise a different
         # (and easier) failure than the one that cost five paid episodes.
         self._blind_after_observe_calls = blind_after_observe_calls
+        # WHY the blinded read has no frame, as the provider's bounded account.
+        # The real provider derives this from upstream's own failed-attempt
+        # logging (``providers.aws``); the fake takes it from the test so a
+        # bundle assertion can prove the cause reaches the sealed error detail.
+        # ``None`` is the provider that knows nothing: it reproduces upstream's
+        # silent ``None`` exactly, so the absent-cause path is unchanged.
+        self._blind_cause = blind_cause
         self._has_user_simulator = has_user_simulator
         self._simulator_answer = simulator_answer
         # The in-memory registry stands in for EC2: ref -> state. Teardown
@@ -112,12 +125,15 @@ class FakeProvider:
         self.observe_calls += 1
         if self._blind_observations > 0 and self.observe_calls > self._blind_after_observe_calls:
             self._blind_observations -= 1
-            return {
+            blind: dict[str, Any] = {
                 "screenshot": None,
                 "accessibility_tree": None,
                 "terminal": None,
                 "instruction": "fake instruction",
             }
+            if self._blind_cause is not None:
+                blind[SCREENSHOT_CAUSE_KEY] = bounded_observation_cause(self._blind_cause)
+            return blind
         return {
             "screenshot": self._frame(),
             "accessibility_tree": None,

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -74,6 +74,12 @@ if os.name != "posix":  # pragma: no cover - import itself is the explicit diagn
     raise RuntimeError("evaluation adapter supervision requires POSIX process groups")
 
 MAX_DIAGNOSTIC_TAIL = 64 * 1024
+# Backstops for reading that tail on a FAILURE path. ``QUIET`` is the idle
+# window that ends the wait; ``TIMEOUT`` bounds the cost when a worker is
+# logging continuously. Both are deliberately short: this runs while sealing a
+# failed episode, which must still terminate promptly.
+STDERR_SETTLE_QUIET_S = 0.25
+STDERR_SETTLE_TIMEOUT_S = 2.0
 TERM_GRACE_SECONDS = 5.0
 OWNER_FD_ENV = "LO_ADAPTER_OWNER_FD"
 LAUNCH_IDENTITY_ENV = "LO_ADAPTER_LAUNCH_IDENTITY"
@@ -126,14 +132,27 @@ def _mutation_committed(error: BaseException) -> bool:
 
 
 class _Tail:
+    """A bounded tail of one drained stream, with an idle signal.
+
+    ``bytes()`` is a snapshot taken from the CALLER's thread while the drainer
+    that fills this buffer runs in another one. On a failure path reached
+    milliseconds after the process wrote -- and a scripted episode is over in
+    milliseconds -- that snapshot can miss the very lines that explain the
+    failure. ``settled()`` waits on the drainer's own APPEND NOTIFICATION
+    instead of on a clock: every append restarts the idle window, so the wait
+    ends only after a genuinely quiet interval, and it ends on the first quiet
+    interval rather than after a fixed budget.
+    """
+
     def __init__(self, limit: int = MAX_DIAGNOSTIC_TAIL) -> None:
         self._limit = limit
         self._chunks: deque[bytes] = deque()
         self._size = 0
         self._lock = threading.Lock()
+        self._appended = threading.Condition(self._lock)
 
     def append(self, chunk: bytes) -> None:
-        with self._lock:
+        with self._appended:
             self._chunks.append(chunk)
             self._size += len(chunk)
             while self._size > self._limit and self._chunks:
@@ -145,9 +164,36 @@ class _Tail:
                 else:
                     self._chunks[0] = first[excess:]
                     self._size -= excess
+            self._appended.notify_all()
 
     def bytes(self) -> bytes:
         with self._lock:
+            return b"".join(self._chunks)
+
+    def settled(
+        self,
+        *,
+        quiet: float = STDERR_SETTLE_QUIET_S,
+        timeout: float = STDERR_SETTLE_TIMEOUT_S,
+    ) -> bytes:
+        """The tail, once no append has arrived for ``quiet`` seconds.
+
+        ``timeout`` is the backstop for a worker that logs continuously: the
+        window is reset by every append, so without it a busy stream would hold
+        the caller indefinitely. It is a backstop, not the assertion -- an
+        idle-by-default tail returns as soon as the quiet window passes.
+        """
+
+        deadline = time.monotonic() + timeout
+        with self._appended:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                if not self._appended.wait(min(quiet, remaining)):
+                    # No append within a full idle window: the producer has
+                    # stopped, so what is here is what there is.
+                    break
             return b"".join(self._chunks)
 
 
@@ -440,8 +486,25 @@ class AdapterSupervisor:
 
 
 def _drain(stream: Any, tail: _Tail) -> None:
+    """Feed one drained stream into a tail, INCREMENTALLY.
+
+    ``read1`` rather than ``read``: a buffered reader over a pipe treats a
+    positive size as a FILL request and blocks until that many bytes arrive or
+    the stream ends, so ``stream.read(65536)`` on a live worker publishes
+    nothing at all until 64 KiB of chatter accumulates or the process dies.
+    That is the opposite of what this tail is for -- the failure path reads it
+    WHILE the worker is still running (an exhausted-retries artifact is written
+    between two of the worker's own RPC answers) and needs the bytes that are
+    there now. ``read1`` returns as soon as one raw read yields anything, so the
+    tail is bounded-but-live rather than complete-only-at-EOF.
+
+    Measured, not assumed: with a writer that wrote 6 bytes and stayed alive, a
+    reader thread blocked in ``read(65536)`` was still blocked after a second,
+    while ``read1(65536)`` returned the same bytes in ~30 ms.
+    """
+
     try:
-        while chunk := stream.read(65536):
+        while chunk := stream.read1(65536):
             tail.append(chunk)
     except OSError:
         pass

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -1202,13 +1202,22 @@ class EpisodeRunner:
         true because it describes this event, not the episode's fate: an
         exhausted final attempt propagates and is recorded separately by the
         fatal-error path.
+
+        The worker's stderr tail rides here as well as on the fatal path, and
+        deliberately: this artifact is written BEFORE the backoff, so it is the
+        first thing a reader sees and the only one that survives if the session
+        dies while waiting. On the two canary episodes it would have carried
+        upstream's own "Failed to get screenshot. Status code: %d" lines at
+        the moment the outage started instead of after it had already cost the
+        run.
         """
 
-        detail = self._publish(
+        text = (
             f"observation-phase failure, attempt {attempt} of {attempts}: "
-            f"{_diagnostic(error, self._redactions)}".encode("utf-8"),
-            media_type="text/plain",
+            f"{_diagnostic(error, self._redactions)}"
+            + _adapter_stderr_section(self._adapter_stderr(), self._redactions)
         )
+        detail = self._publish(text.encode("utf-8"), media_type="text/plain")
         self._append(
             "error",
             ErrorPayload(
@@ -1444,6 +1453,35 @@ class EpisodeRunner:
         # guard requires the terminal kind to agree with the stop reason.
         return await self._close_out(score, failure_kind=failure_kind, cancelled=False)
 
+    def _adapter_stderr(self) -> bytes:
+        """The adapter worker's retained stderr tail, for a failure artifact.
+
+        The supervisor already drains the worker's stderr into a bounded tail on
+        every launch (``MAX_DIAGNOSTIC_TAIL``) and nothing read it, so upstream's
+        own explanation for a failed capture reached the parent and was thrown
+        away. Reading it needs no adapter change and no new protocol field: the
+        bytes are already here.
+
+        Empty for a session that never launched, and for a launcher whose handle
+        has no tail (the in-process test seams), so an artifact written without
+        one is byte-identical to what it was before this existed.
+
+        ``settled()`` rather than ``bytes()``: the drainer that fills the tail
+        runs in another thread, and a failure path can be reached milliseconds
+        after the worker wrote -- a scripted episode entirely so -- where a bare
+        snapshot misses the lines that explain the failure. The wait is bounded
+        (``STDERR_SETTLE_QUIET_S``/``STDERR_SETTLE_TIMEOUT_S``) because it runs
+        while sealing a failed episode. A launch seam whose own tail object
+        offers only ``bytes()`` still works: a failure path must never raise,
+        so the narrower surface degrades to the snapshot.
+        """
+
+        tail = getattr(self._supervisor, "stderr_tail", None)
+        if tail is None:
+            return b""
+        settled = getattr(tail, "settled", None)
+        return settled() if settled is not None else tail.bytes()
+
     async def _finalize_failure(self, error: BaseException) -> EpisodeOutcome:
         """Finalize unscored after a mid-episode failure.
 
@@ -1485,6 +1523,11 @@ class EpisodeRunner:
         # chars, and ``publish_artifact`` independently scans every byte
         # against the episode's RedactionSet.
         #
+        # The worker's stderr tail is appended too (``_adapter_stderr``): it is
+        # the adapter's own account, upstream's words included, and it is the
+        # one source that could explain the two canary crashes whose only
+        # recorded fact was a fixed string.
+        #
         # That parent scan is NOT a backstop for a secret the harness itself
         # truncated, and must not be read as one. ``assert_clear`` is a
         # SUBSTRING check, so a value already cut by ``_diagnostic``'s 500-char
@@ -1492,11 +1535,16 @@ class EpisodeRunner:
         # and the scan returns clean on the surviving prefix. The defence that
         # actually closes that case is ordering: the worker scans the UNBOUNDED
         # string before truncating (``worker._redacted``), so a straddled
-        # secret is withheld whole before it ever reaches this side.
+        # secret is withheld whole before it ever reaches this side -- and the
+        # tail section applies the same order for the same reason.
         detail: Any = None
         try:
             detail = self._publish(
-                _failure_detail(error, self._redactions).encode("utf-8"),
+                _failure_detail(
+                    error,
+                    self._redactions,
+                    adapter_stderr=self._adapter_stderr(),
+                ).encode("utf-8"),
                 media_type="text/plain",
             )
         except (_EvidenceFailure, OSError):
@@ -2169,7 +2217,12 @@ def _incomplete_receipt(plan: CleanupPlan, action_id: str) -> CleanupReceipt:
     )
 
 
-def _failure_detail(error: BaseException, redactions: RedactionSet | None = None) -> str:
+def _failure_detail(
+    error: BaseException,
+    redactions: RedactionSet | None = None,
+    *,
+    adapter_stderr: bytes = b"",
+) -> str:
     """The fatal-error artifact: the diagnostic, plus the adapter's own cause.
 
     ``_diagnostic`` is also the ``outcome.diagnostic`` field and is bounded at
@@ -2180,6 +2233,12 @@ def _failure_detail(error: BaseException, redactions: RedactionSet | None = None
     So the artifact carries both: the same first line a reader sees in the
     outcome, then the full structured detail when the failure crossed the
     adapter boundary carrying one.
+
+    ``adapter_stderr`` is the worker's own stderr tail (see
+    ``EpisodeRunner._adapter_stderr``). It is appended as a THIRD section and
+    only when it has content, so a launcher that has no tail -- every
+    in-process test seam, and any adapter process whose stderr stayed empty --
+    produces byte-identical text to what this function produced before.
 
     The adapter-supplied fields below were bounded and canary-checked on the
     WORKER side before they crossed (``worker._error_detail``). The SUMMARY
@@ -2192,9 +2251,12 @@ def _failure_detail(error: BaseException, redactions: RedactionSet | None = None
     """
 
     summary = _diagnostic(error, redactions)
+    section = _adapter_stderr_section(adapter_stderr, redactions)
     detail = getattr(error, "detail", None)
     if detail is None or not hasattr(detail, "render"):
-        return summary
+        # No structured boundary detail: the summary is the whole artifact, and
+        # it stays byte-identical to what it was before a tail existed.
+        return summary + section
     lines = [
         summary,
         "",
@@ -2209,7 +2271,56 @@ def _failure_detail(error: BaseException, redactions: RedactionSet | None = None
         lines.append(f"cause[{index}]: {cause.exception_type}: {cause.message}")
     for frame in detail.frames:
         lines.append(f"  at {frame.file}:{frame.line} in {frame.function}")
-    return "\n".join(lines)
+    # ``section`` carries its own leading blank line, so the artifact ends on
+    # the tail when there is one and is unchanged when there is not.
+    return "\n".join(lines) + section
+
+
+#: How much of the adapter worker's retained stderr a failure artifact carries.
+#:
+#: The supervisor already keeps a bounded 64 KiB tail (``MAX_DIAGNOSTIC_TAIL``),
+#: so this is a second, tighter bound on what a bundle should embed: the LAST
+#: lines are the ones that name the failure, and an artifact that is mostly
+#: library chatter costs a reader more than it tells them.
+MAX_STDERR_TAIL_CHARS = 4096
+
+
+def _adapter_stderr_section(adapter_stderr: bytes, redactions: RedactionSet | None) -> str:
+    """Render the worker's stderr tail for a failure artifact, or nothing.
+
+    WHY THE HARNESS AND NOT THE ADAPTER. The supervisor drains the worker's
+    stderr into a bounded tail on every launch and NOTHING read it. Upstream's
+    own explanation for a failed capture -- "Failed to get screenshot. Status
+    code: %d", the exception that was raised, a library traceback -- therefore
+    arrived in the parent and was discarded, and a bundle could name only a
+    fixed string for a failure that cost two canary episodes $1.08 and $2.24.
+    Recovering it needs no adapter contract change, and putting it here rather
+    than on the adapter wire keeps it out of a size-bounded protocol field.
+
+    ORDER IS THE SECURITY PROPERTY, exactly as in ``_diagnostic`` and
+    ``worker._redacted``: the FULL decoded tail is scanned BEFORE the bound is
+    applied. ``assert_clear`` is a substring check, so bounding first would
+    sever a canary straddling the cut and the surviving prefix would be
+    published clean -- and ``publish_artifact``, applying the same substring
+    semantics to the bytes it receives, would agree. A tail that trips the scan
+    is withheld WHOLE rather than masked, because a partial still narrows the
+    secret for whoever holds the bundle.
+
+    The tail is third-party text and cannot be structured, so unlike the
+    adapter's bounded cause it is exactly the case that scan exists for.
+    """
+
+    if not adapter_stderr:
+        return ""
+    text = adapter_stderr.decode("utf-8", errors="replace")
+    if not text.strip():
+        return ""
+    if redactions is not None:
+        try:
+            redactions.assert_clear(text)
+        except ValueError:
+            return "\n\n--- adapter stderr tail ---\n" + WITHHELD
+    return "\n\n--- adapter stderr tail ---\n" + text[-MAX_STDERR_TAIL_CHARS:]
 
 
 def _rejection_detail(rejected: Any) -> str:

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import os
+import pwd
+import re
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +30,7 @@ import boto3
 import pytest
 from botocore.stub import ANY, Stubber
 from lop_osworld_v2_adapter import cleanup, provisioning, scoring, taskfile
+from lop_osworld_v2_adapter.observation import SCREENSHOT_CAUSE_KEY
 from lop_osworld_v2_adapter.providers import aws as aws_mod
 from lop_osworld_v2_adapter.providers.aws import (
     AllocationError,
@@ -39,6 +43,7 @@ from lop_osworld_v2_adapter.providers.aws import (
 )
 from lop_osworld_v2_adapter.providers.base import (
     GUEST_COMMAND_TIMEOUT_S,
+    MAX_OBSERVATION_CAUSE,
     guest_deadline_for,
 )
 
@@ -1225,6 +1230,169 @@ async def test_evaluate_returns_raw_when_the_judge_is_quiet() -> None:
             assert not any(
                 isinstance(h, aws_mod._JudgeErrorCapture) for h in logging.getLogger(name).handlers
             )
+
+
+# ---------------------------------------------------------------------------
+# observe: upstream's SWALLOWED capture failure becomes a bounded cause
+# ---------------------------------------------------------------------------
+
+# The upstream file that fetches frames, pinned. ``get_screenshot`` logs its
+# per-attempt failures here and then returns None, which is why the adapter sees
+# a frameless observation with no reason attached unless it captures them.
+_CONTROLLER = "/site-packages/desktop_env/controllers/python.py"
+
+# Upstream's own failure lines, verbatim from the pinned checkout.
+_STATUS_502 = "Failed to get screenshot. Status code: 502"
+_STATUS_504 = "Failed to get screenshot. Status code: 504"
+_INVALID_PAYLOAD = "Invalid screenshot payload (attempt 1/3)."
+_TRANSPORT = "An error occurred while trying to get the screenshot: HTTPConnectionPool(host='x')"
+_EXHAUSTED = "Failed to get screenshot."
+
+
+class _BlindEnv(_FakeEnv):
+    """Upstream's shape for a guest that cannot answer ``/screenshot``.
+
+    ``_get_obs`` logs the failed attempts and then returns a dict whose
+    screenshot is None -- exactly what the pinned ``get_screenshot``/
+    ``_get_obs`` pair does after its retries are exhausted. Each record names
+    the logger AND the file it is attributed to, so a test can show that a
+    record which does not come from that one function is not read as a capture
+    attempt.
+    """
+
+    def __init__(self, records: list[tuple[str, str, str]]) -> None:
+        super().__init__()
+        self.records = records
+
+    def _get_obs(self) -> dict[str, Any]:
+        for logger_name, pathname, message in self.records:
+            _log_from(logger_name, pathname, message)
+        return {"screenshot": None, "instruction": "do it"}
+
+
+async def _observe_blind(
+    records: list[tuple[str, str, str]],
+) -> dict[str, Any]:
+    with _Stubs() as stubs:
+        provider = AwsProvider(CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients)
+        provider._env = _BlindEnv(records)
+        observed = await provider.observe()
+        # The handler is attached for the duration of the call only.
+        assert not any(
+            isinstance(h, aws_mod._ScreenshotFailureCapture)
+            for h in logging.getLogger(aws_mod._SCREENSHOT_LOGGER).handlers
+        )
+        return observed
+
+
+@pytest.mark.asyncio
+async def test_observe_reports_upstreams_failed_attempts_as_a_bounded_cause() -> None:
+    """The fact the harness could not obtain: why the frame was missing.
+
+    "environment returned no screenshot frame" is all a bundle could say after
+    two paid episodes died, because upstream logs the reason and returns None.
+    The cause must name the attempt count and status codes, and the latencies
+    that separate a refusal from a client timeout.
+    """
+
+    observed = await _observe_blind(
+        [
+            (aws_mod._SCREENSHOT_LOGGER, _CONTROLLER, _STATUS_502),
+            (aws_mod._SCREENSHOT_LOGGER, _CONTROLLER, _STATUS_502),
+            (aws_mod._SCREENSHOT_LOGGER, _CONTROLLER, _STATUS_504),
+            (aws_mod._SCREENSHOT_LOGGER, _CONTROLLER, _EXHAUSTED),
+        ]
+    )
+    assert observed["screenshot"] is None
+    cause = observed[SCREENSHOT_CAUSE_KEY]
+    assert cause.startswith("screenshot unavailable: ")
+    assert "upstream_failures=4" in cause
+    assert "kinds=status,status,status,exhausted" in cause
+    assert "codes=502,502,504" in cause
+    # The latencies are the discriminator the harness had to guess between.
+    assert re.search(r"first_ms=\d+", cause)
+    assert re.search(r"gaps_ms=\d+,\d+,\d+", cause)
+    assert re.search(r"elapsed_ms=\d+", cause)
+    assert len(cause) <= MAX_OBSERVATION_CAUSE
+
+
+@pytest.mark.asyncio
+async def test_observe_never_echoes_upstreams_message_text() -> None:
+    """Only a closed KIND and an integer status cross; the text never does.
+
+    Upstream's message can carry a URL, a guest path or a credential, and this
+    side cannot scan a canary before bounding -- the harness can
+    (``worker._redacted``), and it scans the worker's stderr tail, which is
+    where upstream's own words are surfaced instead.
+    """
+
+    observed = await _observe_blind(
+        [
+            (aws_mod._SCREENSHOT_LOGGER, _CONTROLLER, _INVALID_PAYLOAD),
+            (aws_mod._SCREENSHOT_LOGGER, _CONTROLLER, _TRANSPORT),
+            (aws_mod._SCREENSHOT_LOGGER, _CONTROLLER, _EXHAUSTED),
+        ]
+    )
+    cause = observed[SCREENSHOT_CAUSE_KEY]
+    assert "kinds=payload,transport,exhausted" in cause
+    assert "codes=" not in cause
+    for leaked in ("HTTPConnectionPool", "host='x'", "ConnectionError", "Invalid screenshot"):
+        assert leaked not in cause
+
+
+@pytest.mark.asyncio
+async def test_observe_adds_no_cause_when_upstream_said_nothing() -> None:
+    """An absent cause stays absent: the builder's text is never embellished."""
+
+    observed = await _observe_blind([])
+    assert observed["screenshot"] is None
+    assert SCREENSHOT_CAUSE_KEY not in observed
+
+
+@pytest.mark.asyncio
+async def test_observe_ignores_records_from_other_modules_and_loggers() -> None:
+    """Only the pinned file, on the pinned logger, is read as a capture attempt."""
+
+    observed = await _observe_blind(
+        [
+            # The right logger, but a record from another upstream module.
+            (aws_mod._SCREENSHOT_LOGGER, _DESKTOP_ENV, _STATUS_502),
+            # The right module, but another logger.
+            ("desktopenv.other", _CONTROLLER, _STATUS_502),
+            ("desktopenv.env", _CONTROLLER, _STATUS_502),
+        ]
+    )
+    assert SCREENSHOT_CAUSE_KEY not in observed
+
+
+@pytest.mark.asyncio
+async def test_the_cause_count_is_uncapped_while_its_detail_is_bounded() -> None:
+    """A long outage is counted honestly without inflating the artifact."""
+
+    observed = await _observe_blind([(aws_mod._SCREENSHOT_LOGGER, _CONTROLLER, _STATUS_502)] * 40)
+    cause = observed[SCREENSHOT_CAUSE_KEY]
+    assert "upstream_failures=40" in cause
+    assert cause.count("status") == aws_mod.MAX_CAUSE_RECORDS
+    assert len(cause) <= MAX_OBSERVATION_CAUSE
+
+
+def test_the_screenshot_capture_target_matches_the_pinned_upstream() -> None:
+    """The capture filters on a module basename off a pinned logger name; a
+    rename upstream would silently disarm it, so pin both against the
+    checkout. Skipped where that checkout is absent (CI)."""
+
+    inputs_root = Path(
+        os.environ.get(
+            "OSWORLD_INPUTS_ROOT", Path(pwd.getpwuid(os.getuid()).pw_dir) / "worktrees" / "osworld"
+        )
+    )
+    controller = inputs_root / "prepared" / "desktop_env" / "controllers" / "python.py"
+    if not controller.exists():  # pragma: no cover - inputs root absent on CI
+        pytest.skip("pinned OSWorld checkout not present")
+    source = controller.read_text()
+    assert f'getLogger("{aws_mod._SCREENSHOT_LOGGER}")' in source
+    for prefix, _kind in aws_mod._SCREENSHOT_RECORD_KINDS:
+        assert prefix in source, prefix
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
+++ b/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
@@ -24,6 +24,7 @@ asserted only in ``test_spawn.py``, and none of them are asserted here.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, cast
 
@@ -41,8 +42,9 @@ from local_operator.evaluation.adapters.api import (
     ResetStartParams,
     ScopedInfraValue,
 )
-from local_operator.evaluation.adapters.rpc import RpcRemoteError
+from local_operator.evaluation.adapters.rpc import MAX_DETAIL_MESSAGE, RpcRemoteError
 from local_operator.evaluation.adapters.worker import _error_detail
+from local_operator.evaluation.evidence.models import ErrorPayload
 from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.runner.episode import EpisodeRunner
 from tests.unit.evaluation.adapters.osworld import fixtures
@@ -51,6 +53,7 @@ from tests.unit.evaluation.runner.conftest import (
     ScriptedModel,
     build_config,
     build_spec,
+    payloads,
 )
 
 RELEASE_DIGEST = "d" * 64
@@ -446,3 +449,113 @@ async def test_simulator_is_called_once_and_host_finish_is_refused(
     refused = await adapter.ask_user_exchange(begin.model_copy(update={"ask_id": "no-simulator"}))
     assert not refused.accepted and refused.answer is None
     provider.respond.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# A blind read's account reaches the SEALED bundle's error detail
+# ---------------------------------------------------------------------------
+
+# What the AWS provider derives from upstream's failed-attempt logging: a
+# closed set of facts, never upstream's own words (``providers.aws``).
+_BLIND_CAUSE = (
+    "screenshot unavailable: upstream_failures=3 kinds=status,status,status "
+    "codes=502,502,502 first_ms=14 gaps_ms=5004,5002 elapsed_ms=15009"
+)
+
+
+async def _run_blind_episode(
+    tmp_path: Path, episode_id: str, *, blind_cause: str | None
+) -> tuple[Any, Path, str]:
+    """Drive one episode into an exhausted-observation failure and read its detail.
+
+    ``blind_after_observe_calls=1`` keeps reset_start's frame honest, so the run
+    fails where the paid canary runs did: mid-episode, on the read-back after a
+    committed batch, with every earlier step already paid for.
+    """
+
+    provider = FakeProvider(
+        scripted_score=1.0,
+        # More blind reads than the runner has attempts, so recovery is
+        # exhausted and the ORIGINAL failure is the one recorded.
+        blind_observations=5,
+        blind_after_observe_calls=1,
+        blind_cause=blind_cause,
+    )
+    adapter = _adapter(tmp_path, provider)
+    selector = _selector(tmp_path, adapter._workspace_root, adapter)
+    runner = EpisodeRunner(
+        _spec_with_task(episode_id),
+        build_config(tmp_path, observation_retry_delay=0.0),
+        selector=selector,
+        model=ScriptedModel(["step", "step", "finish"]),
+        launch=lambda _selector: _AdapterSupervisorShim(adapter, selector),
+    )
+    outcome = await runner.run()
+    assert outcome.status == "failed", outcome.diagnostic
+    assert outcome.diagnostic is not None and "no screenshot frame" in outcome.diagnostic
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    fatal = [error for error in payloads(root, ErrorPayload) if not error.retryable]
+    assert len(fatal) == 1
+    detail = fatal[0].detail_artifact
+    assert detail is not None
+    return outcome, root, (root / "artifacts" / detail.sha256).read_bytes().decode()
+
+
+@pytest.mark.asyncio
+async def test_a_blind_reads_cause_reaches_the_sealed_error_detail(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The whole point of the change: a crash bundle can now say WHY.
+
+    The two canary episodes recorded only the fixed string, so nothing in the
+    bundle could prove or refute the mechanism. With a cause, the sealed detail
+    carries the provider's bounded facts -- attempt count, status codes, and the
+    gaps that separate a refused request from one that burned its timeout.
+    """
+
+    _, root, text = await _run_blind_episode(tmp_path, episode_id, blind_cause=_BLIND_CAUSE)
+
+    # The message the harness journals is unchanged...
+    assert "environment returned no screenshot frame" in text
+    # ...and the provider's own account rides beside it, attributed.
+    assert "ObservationCauseError" in text
+    assert _BLIND_CAUSE in text
+    # The degraded reads are still journalled, so the bundle shows the faltering
+    # environment rather than a suspiciously quiet failure.
+    retries = [
+        json.loads(line) for line in (root / "events.jsonl").read_text().splitlines() if line
+    ]
+    assert any(
+        event["kind"] == "error"
+        and event["payload"]["diagnostic_code"] == "observation-phase-retry"
+        for event in retries
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_blind_read_without_a_cause_keeps_the_pre_cause_detail(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """No cause means NO cause: the text must not be embellished or invented."""
+
+    _, _, text = await _run_blind_episode(tmp_path, episode_id, blind_cause=None)
+
+    assert "environment returned no screenshot frame" in text
+    assert "ObservationCauseError" not in text
+    # Exactly the one cause the crossing always produced -- the ObservationError
+    # itself -- with nothing appended to it.
+    assert text.count("cause[") == 1
+    assert text.count("caused by ") == 1
+
+
+@pytest.mark.asyncio
+async def test_the_surfaced_cause_is_bounded_by_the_wire(tmp_path: Path, episode_id: str) -> None:
+    """A pathological cause cannot inflate a bundle past the field bound."""
+
+    _, _, text = await _run_blind_episode(tmp_path, episode_id, blind_cause="x" * 4000)
+
+    cause_line = next(line for line in text.splitlines() if line.startswith("cause[2]: "))
+    assert len(cause_line) <= len("cause[2]: ObservationCauseError: ") + MAX_DETAIL_MESSAGE

--- a/tests/unit/evaluation/adapters/osworld/test_observation.py
+++ b/tests/unit/evaluation/adapters/osworld/test_observation.py
@@ -16,7 +16,10 @@ from pathlib import Path
 import pytest
 from lop_osworld_v2_adapter.observation import (
     NATIVE_SCREEN,
+    NO_FRAME_MESSAGE,
+    SCREENSHOT_CAUSE_KEY,
     ObservationBuilder,
+    ObservationCauseError,
     ObservationError,
     write_png_rgb,
 )
@@ -95,8 +98,52 @@ def test_a_missing_screenshot_raises(tmp_path: Path) -> None:
     builder = ObservationBuilder(tmp_path)
     raw = _raw()
     raw["screenshot"] = None
-    with pytest.raises(ObservationError):
+    with pytest.raises(ObservationError) as raised:
         builder.build(raw, task_id="t", episode_id="e", sequence=0)
+    # Degrades to exactly the pre-cause text, and invents nothing: with no
+    # provider cause there is no exception cause either.
+    assert str(raised.value) == NO_FRAME_MESSAGE
+    assert raised.value.__cause__ is None
+
+
+def test_a_provider_cause_rides_as_the_error_cause_not_the_message(tmp_path: Path) -> None:
+    """The provider's account must not rewrite the harness's own vocabulary.
+
+    ``NO_FRAME_MESSAGE`` is journalled as ``observation-phase-retry`` and is what
+    a bundle reader greps for, so a provider cause travels as the error's
+    ``__cause__`` -- which the worker bounds and canary-checks as
+    ``RpcErrorDetail.causes`` -- and never as the message.
+    """
+
+    builder = ObservationBuilder(tmp_path)
+    raw = _raw()
+    raw["screenshot"] = None
+    raw[SCREENSHOT_CAUSE_KEY] = (
+        "screenshot unavailable: upstream_failures=3 kinds=status,status,status"
+    )
+    with pytest.raises(ObservationError) as raised:
+        builder.build(raw, task_id="t", episode_id="e", sequence=0)
+    assert str(raised.value) == NO_FRAME_MESSAGE
+    assert isinstance(raised.value.__cause__, ObservationCauseError)
+    assert "upstream_failures=3" in str(raised.value.__cause__)
+
+
+def test_a_stray_cause_does_not_change_observation_identity(tmp_path: Path) -> None:
+    """Capacity facts stay out of ``observation_content_id``.
+
+    The cause rides the RAW dict and is dropped at the builder, so an
+    observation built beside a provider cause is content-identical to the same
+    frame built without one -- which is the invariant
+    ``docs/benchmarks/osworld_2/README.md`` states for environment facts.
+    """
+
+    builder = ObservationBuilder(tmp_path)
+    plain = builder.build(_raw(shade=5), task_id="t", episode_id="e", sequence=0)
+    with_cause = _raw(shade=5)
+    with_cause[SCREENSHOT_CAUSE_KEY] = "screenshot unavailable: elapsed_ms=15012"
+    caused = builder.build(with_cause, task_id="t", episode_id="e", sequence=0)
+    assert caused.observation_id == plain.observation_id
+    assert SCREENSHOT_CAUSE_KEY not in (caused.metadata or {})
 
 
 def test_a_resized_guest_frame_raises(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -7,6 +7,7 @@ import signal
 import stat
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -401,6 +402,29 @@ def test_diagnostic_tail_is_bounded() -> None:
     tail = _Tail()
     tail.append(b"x" * (MAX_DIAGNOSTIC_TAIL + 10))
     assert tail.bytes() == b"x" * MAX_DIAGNOSTIC_TAIL
+
+
+def test_the_tail_settle_includes_a_late_append() -> None:
+    """``settled`` waits for the DRAINER's append, not for a fixed budget.
+
+    A failure path can be reached milliseconds after the worker wrote its last
+    line -- a scripted episode is over in milliseconds -- while the thread that
+    drains the stream has not been scheduled yet. A bare snapshot then misses
+    the only lines that explain the failure, which is what this replaces: the
+    append notification restarts the idle window, so a late append is included
+    and a quiet buffer returns after exactly one window.
+    """
+
+    tail = _Tail()
+    writer = threading.Timer(0.02, tail.append, args=(b"late line\n",))
+    writer.start()
+    try:
+        assert tail.settled(quiet=1.0, timeout=5.0) == b"late line\n"
+    finally:
+        writer.join()
+
+    # An idle tail returns what it has rather than inventing anything.
+    assert _Tail().settled(quiet=0.01, timeout=0.5) == b""
 
 
 def test_persist_and_load_rescue_is_atomic_mode_0600(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -585,3 +585,47 @@ def test_error_phase_is_declared_by_the_adapter_and_only_for_execute() -> None:
         )
         assert wrong_method is not None
         assert wrong_method.phase == "unknown", method
+
+
+def test_an_adapter_supplied_observation_cause_is_canary_checked() -> None:
+    """The newly surfaced variable text is bounded AND canary-checked.
+
+    ``RpcErrorDetail.causes`` is where an adapter's account of a failed
+    observation now travels (``ObservationCauseError``), so the worker's
+    redaction discipline has to cover it per entry -- including the ENCODED
+    forms a library, a URL or a log line could carry, which is why the check is
+    ``RedactionSet.assert_clear`` rather than a search for the literal. The
+    alternative reading -- "the adapter bounded it, so it is safe" -- is exactly
+    backwards: bounding is what SEVERS a canary so the substring check stops
+    matching, which is why the worker scans the unbounded value before it cuts
+    (``_redacted``), and why the scan must see the whole cause string.
+    """
+
+    from urllib.parse import quote
+
+    from local_operator.evaluation.adapters.api import ObservationPhaseError
+    from local_operator.evaluation.adapters.rpc import WITHHELD
+    from local_operator.evaluation.adapters.worker import _error_detail
+    from local_operator.evaluation.receipts import RedactionSet
+
+    secret = "AKIA-CAUSE-CANARY-0123456789"
+    for carried in (secret, quote(secret, safe=""), secret.encode("utf-8").hex()):
+        reason = ValueError("environment returned no screenshot frame")
+        reason.__cause__ = RuntimeError(f"screenshot unavailable: {carried}")
+        error = ObservationPhaseError("environment returned no screenshot frame")
+        error.__cause__ = reason
+
+        detail = _error_detail(
+            error, "execute", "exec-0", RedactionSet.from_resolved_values((secret,))
+        )
+
+        assert detail is not None and detail.phase == "observation"
+        # The fixed message survives, so the failure is still bucketable...
+        assert detail.message == "environment returned no screenshot frame"
+        assert detail.causes[0].message == "environment returned no screenshot frame"
+        # ...while the variable half is withheld WHOLE, in every encoding.
+        assert detail.causes[1].message == WITHHELD
+        rendered = detail.render()
+        assert secret not in rendered
+        assert quote(secret, safe="") not in rendered
+        assert secret.encode("utf-8").hex() not in rendered

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -241,6 +241,11 @@ class FakeAdapter:
         self.fail_after = fail_after or {}
         self.calls: list[str] = []
         self.terminated = False
+        # The supervisor surface the failure path inspects for the worker's
+        # drained stderr (``EpisodeRunner._adapter_stderr``). ``None`` models a
+        # launch seam with no tail at all; a test that wants one attaches a
+        # stub exposing ``settled()``/``bytes()``.
+        self.stderr_tail: Any = None
         self.sequence = 0
         self.current = observation(episode_id, 0)
         self._counts: dict[str, int] = {}

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 
 from local_operator.evaluation.adapters.api import Requirement, ScopedInfraValue
+from local_operator.evaluation.adapters.rpc import WITHHELD
 from local_operator.evaluation.adapters.supervisor import SupervisionError
 from local_operator.evaluation.evidence.models import (
     ActionBatchPayload,
@@ -33,6 +34,7 @@ from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.receipts import RedactionSet
 from local_operator.evaluation.runner.episode import (
     DISCLOSED_INFRA_METADATA_KEYS,
+    MAX_STDERR_TAIL_CHARS,
     EpisodeRunner,
 )
 from tests.unit.evaluation.runner.conftest import (
@@ -66,6 +68,7 @@ def _runner(
     model: ScriptedModel,
     responder: Any = None,
     max_steps: int = 4,
+    redactions: RedactionSet | None = None,
 ) -> EpisodeRunner:
     return EpisodeRunner(
         build_spec(episode_id),
@@ -75,6 +78,7 @@ def _runner(
         responder=responder,
         launch=lambda _: adapter,
         rescue=_rescue_ok,
+        redactions=redactions,
     )
 
 
@@ -1803,3 +1807,204 @@ async def test_host_refusal_does_not_publish_supplied_answer(
     assert outcome.bundle_root is not None
     assert "user_simulator_exchange" not in _kinds(outcome.bundle_root)
     assert "execute" not in adapter.calls and "score" not in adapter.calls
+
+
+# ---------------------------------------------------------------------------
+# The adapter worker's stderr tail on the failure path
+# ---------------------------------------------------------------------------
+
+
+class _StubTail:
+    """Stands in for ``AdapterSupervisor.stderr_tail``.
+
+    The real one is a bounded, thread-fed buffer with an idle signal; this is
+    the same surface -- ``settled()`` for the failure path and ``bytes()`` for
+    a snapshot -- so a test can hand the runner a tail without spawning a
+    worker. ``with_settle=False`` models a launch seam whose tail object offers
+    no settle at all, which the failure path must tolerate rather than raise
+    on. The spawned path is covered in ``test_episode_subprocess``.
+    """
+
+    def __init__(self, data: bytes, *, with_settle: bool = True) -> None:
+        self._data = data
+        if with_settle:
+            self.settled = lambda: self._data
+
+    def bytes(self) -> bytes:
+        return self._data
+
+
+_TAIL_HEADER = "--- adapter stderr tail ---"
+
+
+def _fatal_detail_text(root: Path) -> str:
+    fatal = [error for error in payloads(root, ErrorPayload) if not error.retryable]
+    assert len(fatal) == 1
+    detail = fatal[0].detail_artifact
+    assert detail is not None
+    return (root / "artifacts" / detail.sha256).read_bytes().decode()
+
+
+async def _fatal_run(
+    tmp_path: Path,
+    episode_id: str,
+    adapter: FakeAdapter,
+    *,
+    redactions: RedactionSet | None = None,
+) -> Any:
+    outcome = await _runner(
+        tmp_path,
+        episode_id,
+        adapter=adapter,
+        model=ScriptedModel(["step", "step", "finish"]),
+        redactions=redactions,
+    ).run()
+    assert outcome.status == "failed", outcome.diagnostic
+    assert outcome.bundle_root is not None
+    assert verify_bundle(outcome.bundle_root).valid
+    return outcome
+
+
+def _fatal_adapter(tmp_path: Path, episode_id: str) -> FakeAdapter:
+    return FakeAdapter(
+        tmp_path,
+        episode_id,
+        failures={"execute": SupervisionError("worker died mid-observe")},
+        fail_after={"execute": 1},
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_worker_stderr_tail_rides_the_fatal_detail(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """Upstream's own explanation must reach the bundle, not be discarded.
+
+    The supervisor drained the worker's stderr into a bounded tail and nothing
+    read it, so the two canary episodes whose only recorded fact was
+    "environment returned no screenshot frame" left no way to tell a full disk
+    from a dead server.
+    """
+
+    adapter = _fatal_adapter(tmp_path, episode_id)
+    adapter.stderr_tail = _StubTail(
+        b"desktopenv.pycontroller: Failed to get screenshot. Status code: 502\n"
+    )
+    outcome = await _fatal_run(tmp_path, episode_id, adapter)
+
+    text = _fatal_detail_text(outcome.bundle_root)
+    # The summary is unchanged and still first: the tail is ADDITIONAL evidence.
+    assert text.startswith("SupervisionError: worker died mid-observe")
+    assert _TAIL_HEADER in text
+    assert "Failed to get screenshot. Status code: 502" in text
+
+
+@pytest.mark.asyncio
+async def test_no_stderr_tail_leaves_the_detail_byte_identical(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """An absent tail adds nothing at all, down to the byte."""
+
+    untailed = _fatal_adapter(tmp_path, episode_id)
+    outcome = await _fatal_run(tmp_path, episode_id, untailed)
+    # The pre-change assertion from `test_fatal_error_records_a_bounded_diagnostic_detail`,
+    # restated for the tail-free case: a launch handle with no tail, and an
+    # empty one, must not even add a header.
+    assert _fatal_detail_text(outcome.bundle_root) == "SupervisionError: worker died mid-observe"
+
+    # A second run needs its own roots and its own episode id: the evidence
+    # terminal is immutable and the lifecycle lineage is per episode id.
+    second = tmp_path / "empty-tail"
+    second.mkdir()
+    empty = _fatal_adapter(second, f"{episode_id}-empty")
+    empty.stderr_tail = _StubTail(b"")
+    outcome = await _fatal_run(second, f"{episode_id}-empty", empty)
+    assert _fatal_detail_text(outcome.bundle_root) == "SupervisionError: worker died mid-observe"
+
+
+@pytest.mark.asyncio
+async def test_a_tail_that_can_only_be_snapshotted_still_surfaces(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A launch seam's own tail object may offer no settle; it must not raise.
+
+    The failure path is the last place that may turn a handled failure into a
+    crash, so the narrower surface degrades to a snapshot rather than failing.
+    """
+
+    adapter = _fatal_adapter(tmp_path, episode_id)
+    adapter.stderr_tail = _StubTail(b"snapshot-only tail\n", with_settle=False)
+    outcome = await _fatal_run(tmp_path, episode_id, adapter)
+    assert "snapshot-only tail" in _fatal_detail_text(outcome.bundle_root)
+
+
+@pytest.mark.parametrize("encoded", [False, True])
+@pytest.mark.asyncio
+async def test_a_secret_in_the_stderr_tail_withholds_the_tail_whole(
+    tmp_path: Path, episode_id: str, encoded: bool
+) -> None:
+    """The newly surfaced text is canary-checked, and the check is escape-aware.
+
+    ``RedactionSet`` derives base64, percent-encoded and hex canaries from every
+    resolved secret, so a plain substring check on the literal would miss the
+    encoded form a library or a URL might carry. The tail is withheld WHOLE
+    rather than masked, and only the tail: the diagnostic line is still
+    published, so the failure stays bucketed.
+    """
+
+    from urllib.parse import quote
+
+    secret = "AKIA-STDERR-CANARY-0123456789"
+    carried = quote(secret, safe="") if encoded else secret
+    adapter = _fatal_adapter(tmp_path, episode_id)
+    adapter.stderr_tail = _StubTail(f"upstream said {carried} while fetching\n".encode())
+    outcome = await _fatal_run(
+        tmp_path, episode_id, adapter, redactions=RedactionSet.from_resolved_values((secret,))
+    )
+
+    text = _fatal_detail_text(outcome.bundle_root)
+    assert secret not in text
+    assert "upstream said" not in text
+    assert _TAIL_HEADER in text and WITHHELD in text
+    assert text.startswith("SupervisionError: worker died mid-observe")
+
+
+@pytest.mark.asyncio
+async def test_the_tail_is_scanned_before_it_is_bounded(tmp_path: Path, episode_id: str) -> None:
+    """A secret outside the retained window is still found, because the scan
+    sees the whole buffer before the bound is applied.
+
+    Bounding first is the ordering that leaks: a canary straddling the cut no
+    longer matches, and ``publish_artifact`` applies the same substring
+    semantics to whatever bytes it receives, so it would publish the surviving
+    fragment as clean.
+    """
+
+    secret = "AKIA-OUTSIDE-WINDOW-CANARY-0123456789"
+    adapter = _fatal_adapter(tmp_path, episode_id)
+    padding = b"x" * 20_000
+    adapter.stderr_tail = _StubTail(secret.encode() + padding)
+    outcome = await _fatal_run(
+        tmp_path, episode_id, adapter, redactions=RedactionSet.from_resolved_values((secret,))
+    )
+
+    text = _fatal_detail_text(outcome.bundle_root)
+    assert secret not in text
+    assert WITHHELD in text
+
+
+@pytest.mark.asyncio
+async def test_the_tail_section_is_bounded_and_keeps_its_end(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A chatty worker cannot inflate a bundle, and the END is what is kept."""
+
+    adapter = _fatal_adapter(tmp_path, episode_id)
+    adapter.stderr_tail = _StubTail(b"a" * 10_000 + b"TAIL-END-MARKER\n")
+    outcome = await _fatal_run(tmp_path, episode_id, adapter)
+
+    text = _fatal_detail_text(outcome.bundle_root)
+    section = text.split(_TAIL_HEADER, 1)[1]
+    assert section.endswith("TAIL-END-MARKER\n")
+    assert len(section) <= MAX_STDERR_TAIL_CHARS + 64
+    assert section.count("a") < 10_000

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -183,6 +183,24 @@ def _consume_observation_failure():
     return True
 
 
+# Text this run writes to the WORKER's stderr, armed the same adapter-owned way
+# as the cutpoint. The parent drains the worker's stderr into a bounded tail
+# (``AdapterSupervisor.stderr_tail``); asserting that drain exists proves
+# nothing, so the test that uses this reads the text back out of the SEALED
+# bundle. Written at reset_start rather than at the failure so the parent's
+# drainer thread has several RPC round trips to pick it up before the worker
+# dies -- a tail read is a snapshot, not a join.
+def _stderr_marker():
+    import os
+
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tiny_stderr_marker")
+    try:
+        with open(path) as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
 # Whether reset_start should import a task module from the WORKSPACE (the
 # worker's cwd), the way upstream OSWorld's ``instantiate_task`` does. Armed
 # through a file beside the module like the cutpoint. This is the import that
@@ -331,6 +349,11 @@ class TinyAdapter:
     async def reset_start(self, params):
         self._maybe_die("reset_start")
         _maybe_import_workspace_task()
+        marker = _stderr_marker()
+        if marker:
+            import sys
+
+            print(marker, file=sys.stderr, flush=True)
         self.task_id = params.task_id
         self.episode_id = params.episode_id
         self.artifact_root = params.artifact_root
@@ -587,6 +610,21 @@ def _arm_workspace_import(site: Path, enabled: bool) -> None:
         marker.unlink(missing_ok=True)
 
 
+def _arm_stderr_marker(site: Path, marker: str | None) -> None:
+    """Tell the installed adapter to write ``marker`` to the worker's stderr.
+
+    The supervisor builds the worker's environment from a closed allowlist, so
+    this cannot ride in as an env var; the adapter reads it from a file beside
+    its own module, exactly like the cutpoint.
+    """
+
+    path = site / "tiny_stderr_marker"
+    if marker is None:
+        path.unlink(missing_ok=True)
+    else:
+        path.write_text(marker)
+
+
 def _arm_frames(site: Path, mode: str | None) -> None:
     """Tell the installed adapter how to publish observation frames.
 
@@ -750,6 +788,67 @@ async def test_exhausted_observation_retries_still_fail_and_seal_the_bundle(
     # The step never completed, so no step event was written for it.
     assert report.counters is not None
     assert report.counters.environment_step_count == 0
+
+
+@pytest.mark.asyncio
+async def test_the_failure_path_reads_the_workers_stderr_tail(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+) -> None:
+    """The worker's stderr must be READ on the failure path, out of the bundle.
+
+    The supervisor drains the worker's stderr into a bounded 64 KiB tail on
+    every launch and nothing consumed it, so upstream's own explanation for a
+    failed capture -- "Failed to get screenshot. Status code: %d", the raised
+    exception, a traceback -- arrived in the parent and was discarded. Two
+    canary episodes then died with a bundle that could name only a fixed
+    string. This drives a REAL worker, makes it write to stderr, exhausts the
+    observation retries, and reads the marker back out of the SEALED bundle.
+    """
+
+    _arm_cutpoint(adapter_site, None)
+    _arm_frames(adapter_site, "honest")
+    # One more failure than the runner has attempts, so the episode fails.
+    _arm_observation_failures(adapter_site, 5)
+    marker = "desktopenv.pycontroller: Failed to get screenshot. Status code: 502"
+    _arm_stderr_marker(adapter_site, marker + "\n")
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        _subprocess_config(tmp_path, observation_retry_delay=0.0),
+        selector=real_selector,
+        model=ScriptedModel(["step", "step", "finish"]),
+        launch=AdapterSupervisor.launch,
+        rescue=_accepting_rescue,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed", outcome.diagnostic
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+
+    events = [json.loads(line) for line in (root / "events.jsonl").read_text().splitlines() if line]
+    errors = [event for event in events if event["kind"] == "error"]
+    retries = [
+        event
+        for event in errors
+        if event["payload"]["diagnostic_code"] == "observation-phase-retry"
+    ]
+    fatal = [event for event in errors if not event["payload"]["retryable"]]
+    assert len(retries) == 3 and len(fatal) == 1
+    # Both call sites: the retry record (written BEFORE the backoff, so it is
+    # the one a session that dies while waiting still leaves behind) and the
+    # fatal record.
+    for event in retries + fatal:
+        detail = event["payload"]["detail_artifact"]
+        assert detail is not None, event["payload"]["diagnostic_code"]
+        text = (root / "artifacts" / detail["sha256"]).read_bytes().decode()
+        assert "--- adapter stderr tail ---" in text, event["payload"]["diagnostic_code"]
+        assert marker in text, event["payload"]["diagnostic_code"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR Description

## Summary of Changes

Two OSWorld 2.0 episodes from the same canary batch ran long (264 / 225 / 312
steps), then died unscored with

```
error {"category":"environment","diagnostic_code":"observation-phase-retry"}
error {"category":"adapter","diagnostic_code":"rpcremoteerror"} -> failure_kind: crash
```

$1.08 and $2.24 burned, both graded 0 — 48% of that canary's total spend. The
sealed bundles recorded `environment returned no screenshot frame` and nothing
else: the guest stayed responsive (an `exec` committed on the same host:port the
second before), every `/screenshot` request failed in tens of milliseconds
rather than on its 10 s timeout, and upstream's own 3x5 s retries returned
nothing. **The best-supported mechanism — the guest root filesystem filling
again, from a run that started with 2.11 GiB free — could be neither proven nor
refuted from the harness's own evidence.** That incapacity is the defect.

The harness had the answer twice and discarded it both times:

1. upstream (`desktop_env/controllers/python.py::get_screenshot`) logs each
   failed attempt at ERROR and then returns `None`, so the only trace of the
   reason dies inside the worker;
2. the supervisor drains the worker's stderr into a bounded 64 KiB tail on
   every launch — and **nothing ever read it**.

### 1. The adapter records its own upstream failure

`AwsProvider.observe()` now attaches a `_ScreenshotFailureCapture` handler to
the pinned upstream logger (`desktopenv.pycontroller`), filtered by source file
(`python.py`), for the duration of upstream's retry loop — the same shape
`evaluate()` already uses to capture judge errors. Each captured record
contributes a **closed kind** (`status`/`payload`/`transport`/`exhausted`) plus,
where the pinned format carries one, an **integer status code**; the record's
message and args are never copied. The call's `first_ms`, the `gaps_ms` between
records and the total `elapsed_ms` are measured.

The cause is attached to the raw observation under
`observation.SCREENSHOT_CAUSE_KEY` and dropped at the builder, which raises
**the same fixed message as before** with the cause chained behind it:

```python
raise ObservationError(NO_FRAME_MESSAGE) from ObservationCauseError(cause)
```

So it travels the existing `RpcErrorDetail.causes` path — a field the worker
bounds AND canary-checks per entry — and `NO_FRAME_MESSAGE` stays byte-identical
for every reader that greps a bundle for it.

Why the cause is *structured* rather than upstream's own words: this side cannot
reproduce the harness's scan-before-bound ordering, and a provider that clipped
free text to a wire bound would sever any secret straddling the cut — the exact
leak `worker._redacted` closes (a 40-character key across the 512-character cut
emitted 25 characters of itself). Kinds, codes and latencies contain no
third-party bytes, so bounding them is safe by construction. Upstream's own
words are surfaced by the harness instead, in (2).

### 2. The harness surfaces the stderr tail it already collects

`EpisodeRunner` now reads the supervisor's tail and appends it to both failure
artifacts — the `observation-phase-retry` record (written *before* the backoff,
so it also survives a session that dies while waiting) and the fatal record:

```
--- adapter stderr tail ---
desktopenv.pycontroller: Failed to get screenshot. Status code: 502
```

Bounded to the last 4096 characters of the retained 64 KiB, and the **full**
tail is scanned against the episode's `RedactionSet` *before* it is bounded; a
tail that trips the scan is withheld whole rather than masked. The scan is
escape-aware (`assert_clear` covers base64/URL-safe base64, percent-encoding and
hex), because a library or a URL does not carry a secret in its literal form.

### 3. A defect found on the way, which the fix depends on

`supervisor._drain` used `stream.read(65536)`. On a pipe, a buffered reader
treats a positive size as a **fill** request and blocks until that many bytes
arrive or the stream ends — so the "drained tail" published nothing at all until
64 KiB of chatter accumulated or the process died. A tail that is empty exactly
while the worker is still running is useless for a failure artifact written
between two of that worker's own RPC answers.

Measured, not assumed — a writer that wrote 6 bytes and stayed alive:

```
reader blocked in  read(65536): still blocked after 1s
reader using       read1(65536): returned the same bytes in ~30 ms
```

`read1` makes the drain incremental, and `_Tail.settled()` (bounded: 0.25 s idle
window, 2 s backstop) waits on the drainer's own append notifications, so a
failure path observes the drain instead of snapshotting under it. A launch seam
whose tail object offers only `bytes()` still works — a failure path must never
raise, so it degrades to the snapshot.

## What a future crash bundle now says that this one could not

For the same failure, the bundle's fatal detail would read:

```
environment returned no screenshot frame; method=execute; phase=observation;
caused by ObservationError: environment returned no screenshot frame;
caused by ObservationCauseError: screenshot unavailable: upstream_failures=3
kinds=status,status,status codes=502,502,502 first_ms=14 gaps_ms=5004,5002
elapsed_ms=15009
... at desktop_env/controllers/python.py:473 in get_screenshot

--- adapter stderr tail ---
desktopenv.pycontroller: Failed to get screenshot. Status code: 502
```

That is: **how many** attempts upstream made, **what the guest answered**
(status code, or a transport/payload failure), and **whether each request was
refused immediately or burned its client timeout** — `gaps_ms` near 5000 means
the request failed instantly and only upstream's 5 s sleep remained, near 15000
means the client timeout elapsed. Against `guest-preparation.json`'s
`free_bytes_before` in the same episode's cache root, that is the evidence
needed to confirm or kill the full-disk mechanism from the bundle alone, without
a paid rerun.

## Constraints respected

- **No lifecycle authority moved.** The adapter reports; the host decides. No
  phase, score, terminal or abandonment path changed, and
  `evidence/verify.py`'s unscored-crash guard is untouched — a crash still seals
  unscored.
- **No retry tuning.** `observation_retry_attempts`/`observation_retry_delay`
  are unchanged: 60 s of patience cannot un-fill a disk.
- **No out-of-band probing.** Nothing calls `/screenshot` outside the adapter's
  own observation path.
- **No capacity on the `Observation`.** The cause rides the raw dict and is
  dropped at the builder; `test_a_stray_cause_does_not_change_observation_identity`
  pins that `observation_content_id` is unchanged beside a cause.
- **Bounded and fail-closed.** The cause is ≤ `MAX_OBSERVATION_CAUSE` and, on
  the wire, ≤ `MAX_DETAIL_MESSAGE`; the tail is bounded at 4096 characters after
  the scan; a canary trip withholds, never masks.

## Impact

Benchmark-only. `local_operator.evaluation.adapters.supervisor` and
`...runner.episode` are imported by `scripts/run_episode.py` and the evaluation
tests, and by nothing in the TUI, CLI, server or mobile paths (checked by grep
across `local_operator/` and `scripts/`). Existing bundle text is unchanged
unless a tail or a cause exists: `test_fatal_error_records_a_bounded_diagnostic_detail`
still asserts the exact pre-change string, and
`test_no_stderr_tail_leaves_the_detail_byte_identical` pins both the absent-tail
and empty-tail cases.

## Testing Details

20 new tests (21 cases) across six files:

- `osworld/test_aws_provider.py` — the capture reports counts, kinds, codes and
  latencies; upstream's message text is **never** echoed (`HTTPConnectionPool`,
  `host='x'` asserted absent); a frameless read with no captured record adds no
  cause (never a fabrication); records from another module or another logger are
  ignored; 40 attempts are counted honestly while the detail stays capped; and
  the capture's logger/file/prefixes are **pinned against the pinned OSWorld
  checkout** (the same guard style the judge capture already has).
- `osworld/test_fake_end_to_end.py` — a blind read's cause reaches the **sealed
  bundle's** error detail, with the retry record still journalled; an absent
  cause keeps exactly the one pre-change cause; a 4000-character cause is cut at
  the wire bound.
- `osworld/test_observation.py` — the cause rides `__cause__` (not the message)
  and an absent cause leaves `__cause__` `None`; a stray cause does not move
  `observation_id`.
- `adapters/test_worker.py` — an adapter-supplied cause is withheld in plain,
  percent-encoded and hex forms (`WITHHELD`), with the fixed message surviving.
- `adapters/test_supervisor.py` — `_Tail.settled` includes a late append and
  returns an idle tail's bytes.
- `runner/test_episode.py` — the tail reaches the fatal artifact; absent/empty
  tails leave the detail byte-identical; a snapshot-only tail still surfaces; a
  secret anywhere in the tail (plain and percent-encoded) withholds the tail
  whole while the diagnostic line survives; a secret **outside** the retained
  window still trips (scan-before-bound); the section keeps its END and stays
  bounded.
- `runner/test_episode_subprocess.py` — the required `it is actually read` test:
  a **real** spawned worker, a real supervisor and its real drain, a real
  episode failing on exhausted observation retries, and the marker the worker
  wrote to stderr is read back out of the **sealed** bundle on both the retry
  and the fatal artifact.

Evidence, from the sealed in-process bundle (the real artifact bytes):

```
RpcRemoteError: adapter_error: adapter operation failed [ObservationPhaseError:
environment returned no screenshot frame; method=execute;
operation_id=exec-0-38ff85523325-obs3; phase=observation; caused by
ObservationError: environment returned no screenshot frame; caused by
ObservationCauseError: screenshot unavailable: upstream_failures=3
kinds=status,status,status codes=502,502,502 first_ms=14 gaps_ms=5004,5002
elapsed_ms=15009; at test_fake_end_to_end.py:107 in _call_raw <- adapter.py:770 in

--- adapter detail ---
exception_type: ObservationPhaseError
message: environment returned no screenshot frame
method: execute
operation_id: exec-0-38ff85523325-obs3
cause[1]: ObservationError: environment returned no screenshot frame
cause[2]: ObservationCauseError: screenshot unavailable: upstream_failures=3
kinds=status,status,status codes=502,502,502 first_ms=14 gaps_ms=5004,5002
elapsed_ms=15009
  at test_fake_end_to_end.py:107 in _call_raw
  at adapter.py:770 in execute
```

Gates on head `1dd2b750a`:

```
$ .venv/bin/python -m flake8 .                                   # clean
$ uvx --from black==26.1.0 black --check .                       # 1239 files unchanged
$ uvx isort==5.13.2 --check .                                    # clean (2 files skipped)
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .    # 0 errors, 0 warnings
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/evaluation -q
        # 1370 passed, 1 skipped in 272.42s
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
        tests/unit/session/test_no_session_deletion.py scripts -q -n0
        # 186 passed in 25.51s  (the only non-evaluation importers of the changed modules)
```

**What did NOT run, disclosed rather than implied away.** The whole-tree
`tests/unit` run was started and **cancelled at ~16 minutes**: this host was
carrying sibling suites at load average 171–304 while free disk fell to 174 MiB,
and continuing would have cost the other sessions on the machine. No failure had
been observed before cancellation, but it is not a green full-suite claim. Every
module that imports the changed code lives under `tests/unit/evaluation`, which
ran in full and is green; CI covers the whole tree.

## Related Issue(s)

No issue filed. The defect was found by the OSWorld campaign
(`~/worktrees/osworld/runs/...`) and specified in the architect round of the
canary-crash investigation (the same round that produced the observation-phase
recovery contract).

## Review rounds

Agent review, QA and design rounds to follow on this head; this section is
updated with their verdicts as they land. No design/UX round applies (no
user-visible surface).

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass (whole `tests/unit/evaluation` tree; see the disclosure above).
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have commented the WHY and the constraints in every non-obvious change.
- [x] Security considerations are addressed (bounded causes, scan-before-bound, fail-closed withholding, no new I/O path, nothing new on the wire schema).
- [x] No related issue to link (none exists).

## Not addressed

- `docs/benchmarks/osworld_2/README.md` still describes the observation-failure
  taxonomy without naming the two evidence surfaces this adds. Worth a paragraph
  once a real bundle carries them — deliberately left out of this PR to keep the
  review on the mechanism.
- The `ObservationCauseError` cause is benchmark-neutral text on the wire; a
  structured capacity/diagnostic shape on `RpcErrorDetail` would be a protocol
  change and is out of scope here (and the capacity half must stay off the
  `Observation`, per the README).
- `_drain`'s `read1` change also makes the *stdout* tail live; no consumer reads
  it yet, so nothing else changed behaviour.

Release: patch — an adapter failure now records its own cause and the harness
surfaces the worker stderr it already collected, so crash bundles become
diagnosable; no API, schema or behaviour change to a successful episode.
