### PR TITLE
feat(notifications): compose descriptive banners and gate them on real turn ends

### DIFF
--- a/docs/ATTENTION.md
+++ b/docs/ATTENTION.md
@@ -51,6 +51,27 @@ authenticated and source-fenced SSE connection starts with an authoritative
 snapshot; its first projection may have a lower counter after daemon restart.
 Retired sources cannot publish callbacks or close the current connection.
 
+The desktop app is a `claim_delivery` claimant like any other, with
+`backend="desktop"`. It reaches the primitive through `POST
+/v1/desktop/sessions/{id}/notified` (`{completion_token}` →`{claimed}`), which
+is cold: no bridge is acquired and no runtime is started, because a completion
+worth announcing usually has no owner alive. With the desktop window unfocused
+a session's `live_state` is `idle`, so a TUI observer and the desktop are both
+eligible for one completion and the watermark picks exactly one — a losing claim
+is the arbitration working, not a fault. The `backend` column is diagnostics
+only; no decision reads it, since a claim consulting anything beyond the
+monotonic sequence would stop being clock-free.
+
+**The claim never advances the read watermark.** `claim_delivery` writes
+`deliveries` alone, so `unseen` and the sidebar's mark survive a banner
+untouched and a conversation can be delivered-and-unread indefinitely. The
+desktop route therefore does not reuse `/seen` and must not be routed through
+any foreground-receipt guard: that guard demands a focused window, which is the
+exact opposite of when a notification fires. Claim-then-deliver also means the
+claimant must BE the deliverer — the app claims immediately before constructing
+the OS notification and after its focus gate, because a claim taken for a banner
+it then suppresses would mark the completion delivered to nobody, for good.
+
 ## What a frontend can acknowledge
 
 The selected result must actually be rendered, uncovered, and visible in a

--- a/docs/DESKTOP_API.md
+++ b/docs/DESKTOP_API.md
@@ -164,6 +164,7 @@ falling back to the parent of the config root when no cwd was retained.
 | POST `.../{id}/answers` | `{epoch,request_id,value,question_index}` OR `{epoch,request_id,approved}` | runtime receipt; stale runtime/request/question409 |
 | GET `.../{id}/events` | optional `epoch`, `after_seq` | authenticated SSE, `data: <DesktopSessionFrame>` |
 | POST `.../{id}/watch` | `{subscription_id,visible,can_notify}` | `{lease_seconds:45}`; disconnected/wrong-session ID404 |
+| POST `.../{id}/notified` | `{completion_token}` | `{claimed:bool}`; cold, never marks read |
 
 Create/message/command `request_id` is a canonical lowercase UUID string, reused
 for a retry of the **same** operation. Answer `request_id` is instead the pending
@@ -224,6 +225,74 @@ cursor**, independent of the inner canonical frontend `{epoch,sequence}`.
    delta, and `event` carries a typed canonical AgentEvent. Apply the snapshot
    after replay so an old cumulative record cannot repaint newer snapshot text.
    Preserve runtime sequence/epoch checks independently of semantic event dedupe.
+5. `notification` carries one bridge-composed banner:
+   `{contract,kind,title,status,body,body_is_snippet,body_is_failure,`
+   `title_is_session_name,dedupe_key,completion_token,session_name,`
+   `focus_policy}`. It is NOT an `AgentEvent` and must not be painted into the
+   transcript; a renderer that does not know the type ignores it and still
+   advances its receipt cursor.
+
+### The `notification` frame
+
+Emitted **if and only if** the bridge observes a newly published, unseen
+`completions` row whose kind is `complete` or `error`, on a bridge that has
+already taken a baseline attention reading. No engine event triggers one —
+in particular `turn_end` is ONE MODEL CALL and `agent_end` routinely arrives
+while `task` children still run, so neither is the turn-over signal. The
+authority is `Session._publish_attention_outcome`, which makes that decision
+inside the process owning the job manager; the bridge observes it rather than
+re-deriving it, which is why a frontend cannot disagree with the TUI.
+
+`ask`/`approval` never travel as `notification`: they already reach the app as
+`pending_gate` in the snapshot and update frames, and a second channel for the
+same card would duplicate it. `interrupted` is suppressed (the user pressed the
+key themselves).
+
+The frame is **live-only, never replayed**. An edge whose whole value is
+timeliness must not arrive hours after a reconnect, and a retained notification
+would push a real transcript event out of the 256-frame budget. Its `seq` still
+advances, which keeps `seq` monotonic across both publish paths; the gap
+arithmetic is unaffected because `gap` is computed against the oldest RETAINED
+frame. The durable signal for a missed completion is `attention` plus the
+sidebar's unseen mark, both of which survive a reconnect.
+
+`body` says what happened rather than that something happened. For `complete`
+it is the last assistant line (`body_is_snippet:true`); for `error` it is the
+session's own recorded failure text (`body_is_failure:true`), read from the
+`session_incident` record's unrendered `raw` so the banner names a cause the
+user can act on instead of only "Stopped with an error". Both degrade to the
+house sentence when unavailable, and BOTH are suppressed entirely when
+`display.notification_session_name` is off — one flag over every
+session-derived fact, decided in the backend. The two flags are never both
+true. An `interrupted` or `complete` body is never the failure text and an
+`error` body is never the last assistant line: a failing turn's last sentence
+routinely reads as a success.
+
+Parked gates do **not** travel as `notification`. They keep using
+`pending_gate` in the snapshot and `frontend.update` frames, which the app
+already receives; a second channel for one question is how one gate becomes
+two banners. `pending_gate` gained an **additive, optional** `session_name` so
+a gate banner can be triaged — "Waiting for approval" with several sessions
+open names none of them. It is `""` when
+`display.notification_session_name` is off, and absent/empty on an older
+backend, so it is additive in both skew directions and an unchanged renderer
+keeps drawing the anonymous card it draws today.
+
+`payload.contract` (`1` today) is advertised as `features.notification_contract`
+in `/v1/capabilities`. Additive fields do not bump it. A renderer seeing the
+capability owns every completion banner and must stop toasting on `agent_end`,
+or one turn produces two banners; a renderer not seeing it is talking to a
+backend that composes nothing.
+
+`POST .../{id}/notified` claims the right to raise ONE banner for a completion,
+through `AttentionStore.claim_delivery(..., backend="desktop")`. Exactly one
+surface wins per `completion_token`, so a TUI observer and the desktop watching
+the same idle session produce one toast between them. Claim-then-deliver means
+the claimant must BE the deliverer: call it immediately before constructing the
+OS notification and never before the focus gate, because a claim taken for a
+banner that is then suppressed is delivered to nobody, permanently. It is cold
+(no bridge acquire, no runtime spawn) and it **never** advances the read
+watermark: `unseen` and the sidebar mark survive it untouched.
 
 A cold reconnect, HTTP restart, detached interval, expired replay cursor or future
 cursor requires a gap snapshot. One live shared bridge retains at most256frames
@@ -240,8 +309,15 @@ heartbeat automatically grants presence. Expiry clears runtime presence, and ASG
 disconnect cleanup is shielded from the cancelled request scope so lease revoke
 and detach actually reach the runtime. A stream alone means neither visible nor
 notification-capable. Electron must set can_notify=false until native delivery
-really exists; its gate/turn notification dedupe/click behavior is not implemented
-by these backend routes.
+really exists.
+
+Notification CONTENT and cross-surface arbitration are now backend concerns: the
+`notification` frame above carries composed `{title,status,body}` and
+`/notified` arbitrates who may raise the banner. What remains outside these
+routes is the renderer's own business — its local TTL dedupe map (keyed on the
+backend-minted `dedupe_key`), its focus gate, and notification-click behaviour.
+The backend still never DELIVERS an OS toast for a leased desktop surface; it
+composes for a frontend that does.
 
 ### Verification
 
@@ -249,7 +325,14 @@ by these backend routes.
 Session/ServingSessionHandle/RuntimeServer/AttachClient with only the provider
 stream scripted: same-session terminal controls, consumed team prompt, durable
 single admission, actual runtime ask/approval futures, invalid/stale answers,
-ordered replay, session isolation, disconnect/watch cleanup and reopen.
+ordered replay, session isolation, disconnect/watch cleanup and reopen. Two of
+its cases assert the `notification` contract on the ordered frame log, which is
+the only shape in which a COUNT is checkable: a real multi-step turn (a tool
+call, then an answer) emits several `turn_end` frames, one `agent_end` and
+exactly one `notification`; and a turn that ends with a registered `task` child
+still running emits none at all until the child settles and its re-entry turn
+completes. `tests/unit/server/test_desktop_notifications.py` covers the frame's
+gating, the replay exemption, the gap arithmetic and the `/notified` claim.
 `tests/e2e/test_desktop_spawn.py` additionally executes the real detached process
 launcher using the built-in test provider, then recreates the HTTP lifespan and
 checks stable identity/title, persisted receipts, authoritative history and epoch

--- a/docs/design/descriptive-notifications.md
+++ b/docs/design/descriptive-notifications.md
@@ -1,0 +1,1439 @@
+# Design: descriptive desktop notifications (`notification` frame + shared composer)
+
+Status: proposal for implementation. Author: architect (anthropic/claude-opus-5).
+Base: `origin/main` @ `1c2933509` (backend), `2217ea59a` (local-operator-ui).
+All `file:line` references are against those trees.
+
+Scope: two repositories, two coders. The backend coder owns §3, §4, §5, §6, §7,
+§10.1 and §11.1. The UI coder owns §8, §10.2 and §11.2. Nothing in here requires
+either of them to choose a semantic.
+
+---
+
+## 0. The problem, as found
+
+Two defects, one of them a correctness bug and one of them a content gap.
+
+**Defect A — the false "turn ended".** `desktop-notifier.ts:101-106` raises a
+toast on `frame.type === "event"` when the event type is `agent_end` **or**
+`turn_end`. Those are not the same fact and neither is "the turn is over":
+
+- `turn_end` is **one model call finishing** — `TurnBoundaryEnd` in
+  `local_operator/tui/events.py:191-192` says so, and `TurnEndEvent`
+  (`local_operator/harness/types.py:1275-1278`) carries `message` +
+  `tool_results` for a single loop step. An agentic turn is many of these. Every
+  one of them currently produces "Turn complete / The agent finished its turn."
+  This is the user's report, exactly.
+- `agent_end` is the parent's logical turn end, but it routinely arrives while
+  `task` children are still running. The `task` tool returns at registration, so
+  the model stops talking long before the delegated work lands
+  (`local_operator/tui/notify.py:65-77`, and `Notifier.notify_turn_complete` at
+  `notify.py:1047-1068` refuses while `running_children > 0`).
+
+So the desktop app notifies on a per-step event the TUI has never treated as
+notifiable, and on a parent end the TUI deliberately suppresses. Both produce a
+toast asserting something false.
+
+**Defect B — the content is canned.** `desktop-notifier.ts:134` hardcodes
+`"Turn complete"` / `"The agent finished its turn."`. The session name is on the
+wire already (`conversation_title`, `frontend_state.py:1548`) and unused; the
+status is not expressed at all; the last assistant line is reachable
+(`session_preview`, `resume.py:1926`) and not sent.
+
+**What is already right and must not be broken.** The gate path
+(`desktop-notifier.ts:116-127`) is correct: it toasts title/detail from
+`pending_gate`, keys dedupe on `session:epoch:request_id`, and deliberately
+ignores focus because the user may be reading another conversation in the same
+window. The watch lease (`desktop_sessions.py:357-400`) and the
+claim-then-deliver arbiter (`attention.py:585-655`) are both sound. This design
+adds one frame type and one composer; it changes no existing frame.
+
+### 0.1 Corrections to the framing
+
+The brief asked to be corrected rather than designed on top of. Five items.
+
+1. **"notifications generally originate in the backend" is only half true
+   today, and the half that is true is the wrong half for this feature.** The
+   backend emits OS toasts from two places — the TUI's own `Notifier`
+   (`notify.py:1084`) and the *detached runtime's* gate fallback
+   (`serving.py:2260-2352`) — but both are **delivery**, and both are explicitly
+   suppressed when a desktop lease claims `can_notify`
+   (`serving.py:2293-2298`). There is no backend path that composes notification
+   *content* for the desktop. That is the gap this design fills, and it fills it
+   with composition, not with a second delivery transport. `local-operator serve`
+   must stay silent as a *deliverer* (`notify.py:53-59`); composing a payload the
+   UI delivers does not violate that rule, and §3 keeps them separate on purpose.
+
+2. **`_outstanding_delegated_jobs` counts `running` + `task` only, not "queued
+   and backgrounded work too".** The code is `tui/app.py:23405-23422`: `status ==
+   "running" and type == "task"`. Queued children are included **because a queued
+   child's `JobState.status` is still `"running"`** and the queued-ness lives in a
+   separate `queued` flag (`harness/jobs.py:345`, and `frontend_state.py:2653`
+   reconstructs the split). Backgrounded `bash` jobs are deliberately **excluded**
+   (`app.py:23377-23391`) — the comment at `app.py:34464-34466` claiming
+   otherwise is stale. This matters for §5: the bridge must reproduce
+   `type == "task" and status == "running"`, and must **not** subtract queued
+   children.
+
+3. **The brief asks "what about a turn that ended while a child was killed?"
+   The bridge never has to answer it.** See §5: the authoritative signal is not a
+   job count read at `agent_end` time but the durable attention publication,
+   whose own delegated check (`session.py:5962`) runs inside the session process
+   at the same instant, and whose re-entry path (`_on_job_completed`,
+   `session.py:7604`) opens a *fresh turn* for each settled child. A cancelled
+   child never settles into a turn, so the eligibility decision is simply
+   deferred to whatever turn does complete. There is no killed-child edge case to
+   encode because the bridge does not make that decision at all.
+
+4. **`session_preview` returns at most `PREVIEW_MAX_CHARS = 200`
+   (`resume.py:378`), not the notification budget.** The banner budget is
+   `BACKGROUND_SNIPPET_MAX_CHARS = 120` (`notify.py:335`) and is passed as
+   `max_chars` so the word-boundary ellipsis is computed against the real budget
+   (`app.py` background body, which passes `max_chars=`). Do not trim after the
+   call.
+
+5. **`desktop_sessions.py:614` calls `session_preview` in the session *catalog*
+   (`DesktopSessions.list`), not in the bridge.** The bridge itself never reads a
+   preview today. So §4's claim "a preview is reachable from the bridge" is true
+   only in the sense that the function is importable; the plumbing is new work.
+
+---
+
+## 1. Decision summary
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Where content is composed | **Backend, shared composer** in `local_operator/notifications/compose.py`, consumed by the desktop bridge and (§9) the TUI foreground path. |
+| 2 | Wire contract | **New frame type `notification`**, additive, replay-exempt, versioned by `notification_contract` in `/v1/capabilities`. |
+| 3 | What may notify | Exactly four kinds: `complete`, `ask`, `approval`, `error`, plus `interrupted` **suppressed by default** (§6.5). Emission is driven by the **attention publication**, not by `agent_end`. |
+| 4 | Content | `title` = session name (privacy-gated), `status` = `CONTEXTS[kind]`, `body` = snippet for `complete` only, else `BODIES[kind]`. One privacy flag gates **both** name and snippet. |
+| 5 | Arbitration | **Both**, at different layers: `can_notify` decides *whether the backend suppresses its own fallback* (unchanged); `claim_delivery` decides *which surface owns this completion*. The desktop **claims in main, and releases on suppression** (§7.3). |
+| 6 | TUI parity | Yes — `Notifier.send` gains an optional `body` via the same composer. |
+| 7 | Rollout | **Backend first.** The UI change is safe to ship after, never before. |
+
+---
+
+## 2. Option 1 — where content is composed
+
+### The alternatives
+
+**(A) Backend shared composer.** The backend emits a fully-composed
+`{title, status, body}` and the UI renders it verbatim.
+
+**(B) UI-side composition from richer facts.** The backend sends structured
+facts (`kind`, `conversation_title`, `last_assistant_text`) and
+`desktop-notifier.ts` assembles the strings.
+
+### Trade-offs
+
+(B) is cheaper on the wire and lets the UI localise later. It is also how the
+gate path works today — `pending_gate` carries `title`/`detail` and the UI picks
+the fallback `"Approval needed"` (`desktop-notifier.ts:126`).
+
+But (B) puts four decisions in a signed Electron binary the user may be running
+against any backend version:
+
+1. **The privacy gate.** `session_names_in_notifications()`
+   (`notify.py:398-416`) reads `display.notification_session_name` from the
+   backend's config. Its docstring is explicit that it governs *both*
+   notification legs so the settings copy ("a session's name appears on
+   banners, including the lock screen") is true of every banner. A UI that
+   composes locally either re-reads that config over HTTP on every toast, or
+   ships a banner the user opted out of. An old UI against a new backend would
+   leak the name *forever*, because the opt-out is a backend setting the old
+   binary has never heard of. This alone decides it.
+
+2. **The snippet-iff-complete rule.** `app.py:18830-18880` documents at length
+   why an `error`/`interrupted` session must not carry its last assistant line:
+   `session_preview` filters to `role == "assistant"`, so on a failed turn it
+   returns the last thing the model said *before* the failure — typically a
+   success sentence under a `Needs attention` subtitle, "the two content lines
+   of the frame asserting opposite things" (review round 1 M1, design round 1
+   D1). The attention anchor already refuses this (`session.py:5985`). A rule
+   this subtle, re-implemented in TypeScript, will drift.
+
+3. **Sanitisation.** `sanitize_text` (`notify.py:419-431`) strips
+   `[\x00-\x1f\x7f-\x9f]` because the text is model-generated and reaches argv
+   and an AppleScript literal. The Electron `Notification` constructor is a
+   softer target than `osascript`, but the composer output is *also* consumed by
+   the TUI (§9) and by the cmux/`notify-send` legs, so the scrub has to happen
+   once, at the source, or two consumers disagree about whether the text is
+   shape-safe.
+
+4. **Wording parity.** The whole point of the operator's report is that "every
+   surface agrees". `CONTEXTS`/`BODIES` (`notify.py:140-206`) are the house
+   vocabulary, carrying design-round decisions (D3: `interrupted` is its own
+   category, not a synonym for `error`). Parity is free with (A) and is an
+   ongoing manual sync with (B).
+
+### Recommendation: (A), backend composer
+
+New module `local_operator/notifications/compose.py`. **Not** inside `tui/`:
+`notify.py`'s module docstring makes "this module is imported only from `tui/`"
+a load-bearing rule about *delivery*, and the bridge importing `tui.notify`
+directly would erode it. (Verified: `notify.py` pulls in no Textual —
+`import local_operator.tui.notify` loads no `textual` module — and
+`serving.py:2300` already imports it from outside `tui/`. So the import is
+*safe*; it is the **rule** that is worth preserving, which is why the new module
+re-exports rather than relocating.)
+
+`compose.py` imports the vocabulary from `tui/notify.py` and adds no delivery.
+The existing constants stay where they are; moving them would churn ten import
+sites for no gain.
+
+**Cost of choosing wrong.** If (A) turns out wrong, we have one Python module
+with a pure function and one frame field set — the UI would keep the structured
+fields (§4 carries `kind` and `session_name` *beside* the composed strings for
+exactly this reason) and start composing from them. That is a one-file UI change.
+If (B) turned out wrong, the fix requires shipping a new signed Electron build to
+every user, because the wrong strings live in the binary. The asymmetry favours
+(A) independently of the arguments above.
+
+---
+
+## 3. Module and function contract (backend)
+
+### 3.1 New module: `local_operator/notifications/__init__.py`, `compose.py`
+
+```python
+# local_operator/notifications/compose.py
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+#: The kinds a composed notification may carry. Deliberately the CONTEXTS key
+#: set (tui/notify.py:140) plus the two gate kinds, so the vocabulary cannot
+#: drift from the TUI's.
+NotificationKind = Literal["complete", "error", "interrupted", "ask", "approval"]
+
+#: Wire contract version for the `notification` frame's payload shape.
+#: Bumped only on a BREAKING change to field names/types; additive fields do
+#: not bump it (see docs/design/descriptive-notifications.md §4.3).
+NOTIFICATION_CONTRACT_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ComposedNotification:
+    """One notification's rendered text plus the facts it was rendered from.
+
+    Both halves travel. The strings are what every surface shows, so wording
+    parity is free; the facts are what lets a future consumer re-render
+    (localisation, a different budget) without the backend having to guess
+    which surface is asking.
+    """
+
+    kind: NotificationKind
+    #: Banner title: the session's name, or APP_NAME when the privacy flag is
+    #: off, or BACKGROUND_FALLBACK_TITLE when the session has no stored title.
+    title: str
+    #: Short state category from CONTEXTS: "Complete", "Input required",
+    #: "Needs attention", "Interrupted". Rendered as the subtitle where a
+    #: surface has one and folded into the body where it does not.
+    status: str
+    #: The content line. A last-assistant-line snippet for `complete` when the
+    #: privacy flag allows and one exists; the BODIES sentence otherwise.
+    body: str
+    #: True when `body` is model-written text rather than a house constant.
+    #: The UI uses it for nothing today; it exists so a surface that must not
+    #: show conversation content (a shared screen mode) can degrade without
+    #: re-deriving the privacy rule.
+    body_is_snippet: bool
+    #: Whether `title` is the conversation's real name. False when the privacy
+    #: flag is off or the session is untitled.
+    title_is_session_name: bool
+
+
+def compose(
+    kind: NotificationKind,
+    *,
+    session_dir: Path | None,
+    session_name: str = "",
+    gate_title: str = "",
+    gate_detail: str = "",
+) -> ComposedNotification:
+    """Render one notification. Pure apart from two best-effort disk reads.
+
+    `session_dir` is read for the stored title and, for `complete`, the last
+    assistant line. `session_name` is the caller's already-resolved name (the
+    TUI has it in hand; the bridge reads `conversation_title` off the frontend
+    snapshot) and WINS over the stored title when non-empty, because a rename
+    reaches the live state before it reaches the sidecar.
+
+    `gate_title`/`gate_detail` are used only for `ask`/`approval`; they carry
+    the tool name and the action being authorised, in the shape
+    `serving.py::_announce_pending` already builds. Ignored for other kinds.
+
+    Never raises: a notification is chrome. Every read is guarded and degrades
+    to the house vocabulary.
+    """
+```
+
+### 3.2 Exact composition rules (this is the whole of §4 of the brief)
+
+Let `names_ok = session_names_in_notifications()`, read **per call** (the
+`/settings` page writes it live; `notify.py:1096-1100` documents why caching it
+at construction leaks the name for the rest of the session).
+
+**`title`**
+
+| Condition | Value | `title_is_session_name` |
+|---|---|---|
+| `not names_ok` | `APP_NAME` (`"Local Operator"`) | `False` |
+| `names_ok` and a name resolves | `sanitize_text(name, limit=MAX_TITLE_CHARS)` where `name = session_name or stored_session_title(session_dir)` | `True` |
+| `names_ok`, no name | `BACKGROUND_FALLBACK_TITLE` (`"A session finished"`) for `complete`/`error`/`interrupted`; `APP_NAME` for `ask`/`approval` | `False` |
+
+The split on the nameless case is deliberate: "A session finished" is a true
+sentence for a completion and a false one for a parked question. For the gate
+kinds the brand is the honest fallback, which is what `serving.py:2318-2324`
+already does (`name = APP_NAME` then conditionally the conversation name).
+
+`MAX_TITLE_CHARS` is 80 (`notify.py:377`). macOS clips a title at ~43 characters
+(`notify.py:230-240`), which is why the status never rides in the title.
+
+**`status`** — `CONTEXTS[kind]` verbatim (`notify.py:140-146`):
+
+| kind | status |
+|---|---|
+| `complete` | `Complete` |
+| `ask` | `Input required` |
+| `approval` | `Input required` |
+| `error` | `Needs attention` |
+| `interrupted` | `Interrupted` |
+
+**`body`**
+
+| kind | Condition | Value | `body_is_snippet` |
+|---|---|---|---|
+| `complete` | `names_ok` and `session_preview(session_dir, max_chars=BACKGROUND_SNIPPET_MAX_CHARS)` is non-empty | `sanitize_text(preview, limit=BACKGROUND_SNIPPET_MAX_CHARS)` | `True` |
+| `complete` | otherwise | `BODIES["complete"]` = `"Task complete"` | `False` |
+| `error` | always | `BODIES["error"]` = `"Stopped with an error"` | `False` |
+| `interrupted` | always | `BODIES["interrupted"]` = `"Stopped before finishing"` | `False` |
+| `ask` / `approval` | `gate_detail` non-empty | `gate_detail`, prefixed with `gate_title` **only when it does not already start with it** (see below) | `False` |
+| `ask` / `approval` | otherwise | `BODIES[kind]` | `False` |
+
+The gate body reuses `serving.py:2337-2347` exactly, including its bug fix: a
+tool's `describe_approval` already leads with its own action word
+(`_describe_path_approval` emits `"write: /path"`) and the title **is** the tool
+name, so a naive `f"{title}: {detail}"` renders `"write: write: /path"` — round
+4, Q3. The rule is:
+
+```python
+subject = (gate_detail or "").strip()
+if subject and gate_title and not subject.lower().startswith(gate_title.lower()):
+    subject = f"{gate_title}: {subject}".strip().rstrip(":").strip()
+body = subject or BODIES[kind]
+```
+
+Extract this into a `compose.py` helper and have `serving.py::_announce_pending`
+call it, so the two cannot drift. That is the only change to `serving.py`.
+
+**Budgets, restated as constants the coder must not re-pick**
+
+- title: `MAX_TITLE_CHARS = 80` (`notify.py:377`)
+- snippet: `BACKGROUND_SNIPPET_MAX_CHARS = 120` (`notify.py:335`), passed as
+  `max_chars` to `session_preview`, **not** applied afterwards — the
+  word-boundary ellipsis must be computed against the real budget.
+- The UI's `body.slice(0, 240)` (`desktop-notifier.ts:153`) stays as a
+  belt-and-braces cap and will never bind, since 120 < 240.
+
+**Why one flag gates both the name and the snippet.** `app.py:18886-18894` is
+explicit: the flag exists to keep model-written session text off a screen other
+people can see, and "a snippet is strictly more session-derived than the name —
+a name is a topic, a snippet is content". A user who opted out of the name has
+necessarily opted out of the snippet. No new setting; `display.notification_
+session_name` governs both. The settings copy stays true.
+
+---
+
+## 4. Option 2 — the wire contract
+
+### 4.1 The frame
+
+A **new frame type**, not an extension of `event` or `frontend.update`.
+
+```
+{
+  "session_id": "<12 lowercase hex>",
+  "epoch": "<bridge epoch hex>",
+  "seq": <int>,
+  "type": "notification",
+  "payload": {
+    "contract": 1,
+    "kind": "complete" | "error" | "interrupted" | "ask" | "approval",
+    "title": "<string, <=80 chars, sanitised>",
+    "status": "<string, one of CONTEXTS values>",
+    "body": "<string, <=120 chars for snippets, sanitised>",
+    "body_is_snippet": <bool>,
+    "title_is_session_name": <bool>,
+    "dedupe_key": "<string, see 4.2>",
+    "completion_token": "<uuid string>" | null,
+    "session_name": "<string>" | null,
+    "focus_policy": "when_unfocused" | "always"
+  }
+}
+```
+
+**Why a new type and not an extension of `event`.** Three reasons, in order of
+weight.
+
+1. **`event` is a typed canonical `AgentEvent`** — `_event()` at
+   `desktop_sessions.py:198-199` is `publish("event", event.model_dump())` and
+   `DESKTOP_API.md:224` pins it as "a typed canonical AgentEvent". A notification
+   is a bridge-composed decision, not an engine event. Putting it there would
+   mean inventing a fake `AgentEvent` subtype, which every existing consumer
+   (`use-canonical-session.ts:323`, `applyEvent`) would then try to paint into
+   the transcript.
+2. **An older UI must ignore it silently**, and the renderer's frame loop
+   already does exactly that for an unknown type: `use-canonical-session.ts:183-
+   334` is a chain of `if (frame.type === ...)` with **no `else` and no throw**,
+   and `frame.type === "open" || "seq" in frame` (line 201) advances the receipt
+   cursor for any frame carrying a `seq` — so an old renderer advances its cursor
+   correctly and paints nothing. `desktop-notifier.ts:87-107` is the same shape.
+   Verified by reading both, not assumed.
+3. **`frontend.update` is a field delta of canonical state.** A notification is
+   an *edge*, not a state — `notify.py:12-16` draws precisely this distinction
+   (the title is a persistent state, a notification is a one-shot edge). A
+   notification in `changes` would be re-delivered by every snapshot.
+
+### 4.2 `dedupe_key`
+
+The backend mints it; the UI treats it as an opaque string and keys its existing
+TTL map on it. Shape:
+
+- completions: `complete:{session_id}:{completion_token}`
+- gates: `gate:{session_id}:{bridge_epoch}:{request_id}`
+
+**Why the backend mints it.** The UI's current completion key is
+`turn:{session}:{frontendEpoch}:{seq}` (`desktop-notifier.ts:130`), keyed on the
+*bridge's* sequence. That is wrong across a reconnect: `acquire()` mints a new
+epoch and resets `sequence` to 0 (`desktop_sessions.py:108-109`), so the same
+completion re-delivered after a detached interval gets a different key and
+toasts twice. The `completion_token` is the durable, conversation-bound identity
+(`attention.py:487`, a validated UUID) and is stable across every epoch.
+
+The gate key keeps the bridge epoch because a `request_id` is only unique within
+a runtime generation, which is exactly what the current UI code already assumes.
+
+### 4.3 Versioning and both directions of skew
+
+`payload.contract` is an integer, `1` today. **Additive fields do not bump it.**
+It bumps only if a field is removed or changes type — and if that ever happens,
+the *old* field is kept beside the new one for one release.
+
+`/v1/capabilities` (`local_operator/server/routes/capabilities.py`) gains one
+entry under `features`:
+
+```python
+"features": {
+    ...
+    "notification_contract": 1,
+}
+```
+
+This follows the existing `<subsystem>: <version>` convention the file's own
+comment establishes (`capabilities.py:31-34`).
+
+**New backend, old UI.** The old UI does not know `"notification"`. Its
+`observe()` falls through every branch and returns; its renderer advances the
+receipt cursor and paints nothing. **But it still toasts on `agent_end`/
+`turn_end`**, because that code is in the shipped binary. So the user keeps the
+buggy behaviour they have today and gains nothing — no double toast, because the
+new frame is ignored. This is the "degrade to something sane" requirement: the
+old UI is no worse than before. It is not *fixed*, and it cannot be, because the
+bug lives in a signed binary.
+
+> **This is the reason the backend must NOT stop emitting `agent_end`.** A
+> tempting "fix" is to suppress `agent_end` on the desktop stream so old UIs
+> stop toasting. Do not: `agent_end` is a canonical event several renderer paths
+> depend on (`TERMINAL_EVENTS` at `use-canonical-session.ts:325`, and the
+> transcript reducer), and removing it to fix a notification would break
+> transcript settling on **every** UI version.
+
+**Old backend, new UI.** The new UI reads `features.notification_contract` from
+`/v1/capabilities` once at startup (the `useDesktopCapabilities` hook already
+fetches this — `backend-compatibility-banner.tsx:27-29`). Two branches, and the
+branch is a *hard* switch, not a heuristic:
+
+- **`notification_contract >= 1` present** → the UI **stops** toasting on
+  `agent_end`/`turn_end` entirely and toasts only on `notification` frames.
+- **absent** → the UI keeps its legacy path, but **narrowed to `agent_end`
+  only** with the canned copy. Dropping `turn_end` from the legacy path is safe
+  against any backend (it is a per-step event on every version) and fixes the
+  loudest half of the bug even on an old backend. Keeping `agent_end` there
+  preserves *some* completion signal against an old backend rather than going
+  silent.
+
+`notification_contract` unknown/unfetchable is treated as **absent** (legacy
+path). Failing toward the legacy path rather than toward silence is deliberate:
+a missing capability response is a transient HTTP failure far more often than it
+is an old backend, and going silent on a transient failure loses completions.
+
+### 4.4 Replay and the frame budget
+
+The bridge retains `REPLAY_COUNT = 256` frames / `REPLAY_BYTES = 8 MiB`
+(`desktop_sessions.py:49-50`), and `publish()` pushes every frame into
+`self.replay`. A notification frame is ~400 bytes, so the byte budget is not the
+concern — **the count is**. A notification frame occupying a replay slot pushes
+out a real transcript event.
+
+**Decision: `notification` frames are NOT retained for replay.**
+
+```python
+def publish(self, kind: str, payload: dict[str, Any], *, replay: bool = True) -> None:
+    ...
+    if replay:
+        self.replay.append((frame, size))
+        self.replay_bytes += size
+        while self.replay and (...):
+            ...
+    for sub in self.subscribers.values():
+        ...
+```
+
+and the notification path calls `self.publish("notification", payload, replay=False)`.
+
+**Why.** A notification is an edge whose whole value is timeliness. Replaying it
+on reconnect means toasting the user about a turn that finished while their
+laptop lid was shut, possibly hours later — which is precisely the "one-shot
+edge" contract `notify.py:12-16` describes. The durable signal is not lost: the
+`attention` frame and the sidebar's unseen mark both survive a reconnect and are
+the correct surface for "you missed something".
+
+**The `seq` numbering stays global**, i.e. a non-replayed frame still increments
+`self.sequence`. This is load-bearing: `events()` computes `gap` from
+`after_seq < first - 1` (`desktop_sessions.py:415`) where `first` is the oldest
+*retained* frame's seq. If a notification consumed a seq and was not retained,
+`first` naturally skips it and a client reconnecting at that cursor is **not**
+flagged as gapped — because `after_seq` equals the notification's seq, which is
+`>= first - 1` for the next retained frame. Verified against the arithmetic. The
+alternative (not incrementing) would make `seq` non-monotonic across the two
+paths and break the receipt cursor.
+
+**One consequence the UI coder must handle:** a notification frame carries a
+`seq` the renderer will record as its receipt cursor
+(`use-canonical-session.ts:201-203`, `"seq" in frame`). That is correct and
+desirable — it means a reconnect after a notification does not re-request frames
+it already saw. No change needed; stated so it is not "fixed".
+
+---
+
+## 5. Option 3 — the gating rules
+
+### 5.1 The source of truth, named
+
+**For "the turn is genuinely over": the attention publication, i.e. a new
+`completions` row in `attention.db`.**
+
+Not `agent_end`. The reasoning:
+
+- `Session._publish_attention_outcome` (`session.py:5949-5999`) runs in the
+  `finally` of `_run_turn_pipeline` (`session.py:6534`), after
+  `_flush_held_end()`. It is the one place in the codebase that already answers
+  "did this turn produce a notifiable outcome" — and it answers it with the
+  *same* delegated-children check the TUI uses: `delegated = any(job.type ==
+  "task" and job.status == "running" for job in self.jobs.list())`
+  (`session.py:5962`).
+- When `kind == "complete"` and (`not messages` or `delegated`), it writes an
+  `eligible: False` marker and **publishes nothing** (`session.py:5970-5980`).
+  So a delegating parent's premature `agent_end` produces no completion row at
+  all. The false-finish problem is already solved, one layer below every
+  frontend.
+- It runs **inside the session process**, which owns the job manager. The bridge
+  does not have to reconstruct the job count, cannot disagree with the TUI about
+  it, and does not need to answer the killed-child question (§0.1 item 3).
+- It is durable and cross-process, which is what makes §7's arbitration possible
+  at all.
+
+**This is the single most important decision in the design.** Every alternative
+("count jobs in the bridge from `frontend_state.jobs`", "read `last_turn_outcome`
+from the snapshot") reconstructs a decision that is already made correctly, in a
+process with less information, and can therefore disagree with the TUI. The
+bridge's job is to *observe* the publication, not to re-derive it.
+
+**How the bridge observes it.** `_poll_attention` (`desktop_sessions.py:237-293`)
+already runs a 1 s loop per bridge, gated on the cheap `store.revision()` change
+detector, and `refresh_attention` already computes the new state and publishes an
+`attention` frame when it differs (`desktop_sessions.py:228-234`). The
+notification hook goes **inside `refresh_attention`**, immediately after the
+`attention` publish, and fires when:
+
+```
+previous is non-empty                      # not the bridge's first read
+and state["completion_token"] is not None
+and state["completion_token"] != previous.get("completion_token")
+and state["unseen"] is True
+and state["kind"] in NOTIFIABLE_COMPLETION_KINDS
+```
+
+The `previous` guard is the existing baseline rule (`desktop_sessions.py:232-234`:
+"the initial snapshot owns the baseline") and is what keeps opening a session
+from toasting its last completion.
+
+**For "children still running": nothing in the bridge.** Answered upstream by
+`session.py:5962`, in the process that owns `self.jobs`. Stated explicitly
+because the brief asked which of `frontend_state.jobs` or the attention store is
+authoritative: **neither is consulted in the bridge**, because the question is
+already answered before the fact the bridge observes even exists. This is why
+the TUI and the bridge cannot disagree — they are reading two projections of one
+decision, not making the same decision twice.
+
+### 5.2 For the gate kinds: the existing `pending_gate`, unchanged
+
+`ask` and `approval` are **not** routed through the new frame. The existing path
+(`desktop-notifier.ts:89-99` reading `pending_gate` out of `snapshot` and
+`frontend.update`) already works, already ignores focus for the right reason,
+and already dedupes on `request_id`.
+
+**The new path must not duplicate it.** The rule, stated so a coder cannot get
+it wrong:
+
+> **The bridge emits `notification` frames with `kind` in `{complete, error}`
+> ONLY. It never emits `kind` `ask` or `approval`.**
+
+The `ask`/`approval` kinds exist in `compose()` because the *TUI* path (§9) and
+`serving.py::_announce_pending` use them. They are unreachable on the desktop
+wire. The `NotificationKind` literal keeps them so one vocabulary serves all
+surfaces; the bridge has its own narrower allowlist:
+
+```python
+#: The kinds the DESKTOP BRIDGE may put on the wire. Narrower than
+#: NotificationKind on purpose: `ask` and `approval` already reach the desktop
+#: as `pending_gate` in the snapshot/update frames, and a second channel for
+#: the same card is the duplicate this whole design exists to prevent.
+BRIDGE_NOTIFIABLE_KINDS = frozenset({"complete", "error"})
+```
+
+What this design *does* improve for gates is the **fallback title**: the UI
+currently renders `title || "Approval needed"` (`desktop-notifier.ts:126`),
+which is wrong for an `ask`. §8.3 fixes that UI-side, using
+`gate.kind` which is already on the wire (`PendingDesktopGate.kind`,
+`desktop-session-contract.ts:99`).
+
+### 5.3 The permitted transitions, exhaustively
+
+| Transition | Emits? | Exact condition | How it is proven |
+|---|---|---|---|
+| Real turn end | **YES**, `kind="complete"` | A new `completions` row with `kind="complete"` and `unseen=true` appears for this conversation | `session.py:5970-5999` refuses to publish when `delegated` or when the turn produced no durable assistant message. The bridge observes the row; it does not judge it. |
+| Turn ended with children still running | **NO** | — | No row is ever written (`session.py:5970-5976` writes `eligible: False` and returns). Nothing for the bridge to see. |
+| Turn ended, a child was killed | **NO** for that turn | — | Same: no row. Each settled child re-enters as a fresh turn (`session.py:7604`) whose own completion publishes normally. A cancelled child never re-enters, so the next real turn carries the notification. §0.1 item 3. |
+| Error | **YES**, `kind="error"` | A new `completions` row with `kind="error"` | `session.py:5971`: `kind = "error" if outcome.error else ...`. Published even with no assistant message, anchored to `provisional_anchor(token)`. |
+| Interrupted | **NO** by default | See §6.5 | Suppressed by `BRIDGE_NOTIFIABLE_KINDS`. |
+| `ask` awaiting input | **YES, via `pending_gate`** — no new frame | `frontend.snapshot.pending_gate` / `changes.pending_gate` non-null with `kind == "ask"` | Existing path, `desktop-notifier.ts:89-99`. |
+| Approval gate | **YES, via `pending_gate`** — no new frame | same, `kind == "approval"` | Existing path. |
+| Per-step `turn_end` | **NEVER** | — | It is one model call (`events.py:191`, `types.py:1275`). The defect. |
+| `agent_end` | **NEVER** as a notification trigger | — | Still forwarded as an `event` frame for the transcript (§4.3 warning). It is not the turn-over signal. |
+| `subagent_end` / child completion | **NEVER** | — | `notify.py:65-77`: a child finishing is an implementation detail of the parent's task; five children would fire five toasts for one task. |
+| `subagent_start` / `subagent_progress` | **NEVER** | — | Progress, not an edge the user owes anything for. |
+| `tool_execution_start/update/end`, `tool_call_compose` | **NEVER** | — | Steps. |
+| `message_start` / `message_update` / `message_end` / streaming deltas | **NEVER** | — | Fragments of one message. |
+| `history_delta` | **NEVER** | — | Durable rows painted on reconnect; every one is already settled. |
+| Session rename | **NEVER** | — | A `conversation_title` change in `frontend.update`. Not an edge; it changes the *title* of a future toast. |
+| `compaction_start` / `compaction_end` | **NEVER** | — | Internal context management. `session.py:6457-6468`: the pipeline deliberately holds the boundary events so compaction does not look like a turn ending and restarting. |
+| Todo updates | **NEVER** | — | `frontend.update` field delta. |
+| `retry_start` / `retry_end`, `model_change` | **NEVER** | — | Provider mechanics. |
+| `wake_delivered` / `peer_message_delivered` / `steering_delivered` | **NEVER** | — | Inbound, not an outcome. A wake that drives a turn produces a completion, which notifies. |
+| `notice` | **NEVER** | — | Infrastructure chatter (an MCP server that failed to connect). |
+| Bridge reconnect / gap / new epoch | **NEVER** | — | `previous is non-empty` guard, plus §4.4 replay exemption. |
+| Opening a session with an old unseen completion | **NEVER** | — | Same `previous` guard: the first `refresh_attention` of a bridge's life sets the baseline and publishes nothing (`desktop_sessions.py:232-234`). |
+
+### 5.4 The NEVER list, as one sentence for the coder
+
+> The bridge emits a notification frame **if and only if** `refresh_attention`
+> observes a *newly published, unseen* completion row whose kind is `complete`
+> or `error`, on a bridge that has already taken a baseline reading. No engine
+> event triggers a notification. Ever.
+
+---
+
+## 6. Backend implementation sketch
+
+### 6.1 `refresh_attention` gains the hook
+
+```python
+async def refresh_attention(self) -> dict[str, Any]:
+    state = await asyncio.to_thread(
+        AttentionStore(self.root / "attention.db").state, f"session/{self.session_id}"
+    )
+    remote = self.remote
+    state["supported"] = bool(...)
+    if state != self.attention:
+        previous = self.attention
+        self.attention = state
+        if previous:
+            self.publish("attention", state)
+            # THE NOTIFICATION EDGE. After the attention frame, because a
+            # reader that toasts should already have the receipt state that
+            # explains the toast. `previous` being non-empty is the same
+            # baseline rule the attention publish uses: a bridge's FIRST read
+            # is the session's history, not news.
+            self._maybe_publish_notification(previous, state)
+    return state
+```
+
+### 6.2 The emitter
+
+```python
+def _maybe_publish_notification(
+    self, previous: dict[str, Any], state: dict[str, Any]
+) -> None:
+    """Turn a newly published completion into one notification frame.
+
+    Guarded end to end: a notification is chrome and this runs inside the 1 s
+    attention poll, whose loop already treats a store error as costing one
+    tick rather than the feature (see `_poll_attention`).
+    """
+    token = state.get("completion_token")
+    if (
+        not token
+        or token == previous.get("completion_token")
+        or not state.get("unseen")
+        or state.get("kind") not in BRIDGE_NOTIFIABLE_KINDS
+    ):
+        return
+    try:
+        composed = await_in_thread_or_inline(...)  # see note
+        payload = {
+            "contract": NOTIFICATION_CONTRACT_VERSION,
+            "kind": composed.kind,
+            "title": composed.title,
+            "status": composed.status,
+            "body": composed.body,
+            "body_is_snippet": composed.body_is_snippet,
+            "title_is_session_name": composed.title_is_session_name,
+            "dedupe_key": f"complete:{self.session_id}:{token}",
+            "completion_token": token,
+            "session_name": composed.title if composed.title_is_session_name else None,
+            "focus_policy": "when_unfocused",
+        }
+        self.publish("notification", payload, replay=False)
+    except Exception:
+        logger.debug("notification compose failed for %s", self.session_id, exc_info=True)
+```
+
+**Two implementation notes the coder must not improvise.**
+
+1. **`compose()` does disk I/O** (`stored_session_title` reads up to 128 KiB
+   from both ends of the transcript, `resume.py:336`; `session_preview` reads
+   64 KB from the tail, `resume.py:373`). `refresh_attention` is on the event
+   loop. Wrap it: `composed = await asyncio.to_thread(compose, kind, session_dir=..., session_name=...)`.
+   Make `_maybe_publish_notification` `async` and `await` it from
+   `refresh_attention`. This is why the sketch above is deliberately
+   incomplete — write it as an `async def` that `await`s `asyncio.to_thread`.
+
+2. **`session_name` comes from the live snapshot, not the sidecar**, when a
+   runtime is attached: `self.remote.frontend_state.conversation_title`
+   (`frontend_state.py:1548`, populated from `session.conversation_name` at
+   `frontend_state.py:3195`). A rename reaches the live state before the
+   sidecar. Guard it — `self.remote` may be `None` for a cold bridge, in which
+   case `compose()` falls back to `stored_session_title`.
+
+### 6.3 `publish()` gains `replay`
+
+Signature change per §4.4. Default `True`, so no existing call site changes.
+
+### 6.4 `serving.py::_announce_pending` uses the composer
+
+Replace the inline body-building at `serving.py:2337-2347` with a call to the
+extracted helper. Behaviour-identical; this is what keeps the gate wording
+identical across the detached-runtime OS fallback and the TUI.
+
+### 6.5 `interrupted`: suppressed, and why
+
+`interrupted` composes correctly and is deliberately **not** in
+`BRIDGE_NOTIFIABLE_KINDS`.
+
+The TUI already refuses it: `app.py:34457-34459` — "aborted → none. The user
+pressed Ctrl+C or Esc, so they were at the keyboard a moment ago and already
+know; telling them their own stop worked is the definition of a notification
+nobody wants."
+
+The counter-argument is real: on the *desktop*, an interruption can come from
+another surface (a phone, a second TUI), so the desktop user may not have been
+the one who pressed the key. But we cannot tell those apart — `AgentEndEvent`
+carries `aborted: bool` with no actor — and the maintainer's store has 318
+complete / 0 error / 14 interrupted (`notify.py:133-136`), so the population is
+small and dominated by the user's own Ctrl+C.
+
+**Recommendation: ship suppressed.** It is one frozenset entry to change if the
+user asks for it, and shipping it on would add a toast for an action the user
+almost always just took themselves. The evidence that would settle it: an actor
+field on the abort path (who requested the interrupt), which does not exist
+today and is not worth building for this.
+
+---
+
+## 7. Option 5 — cross-surface arbitration
+
+Three surfaces can see one completion: a TUI in a terminal, the desktop app, and
+the mobile relay.
+
+### 7.1 What each mechanism actually does
+
+These are **two different questions** and conflating them is the trap.
+
+**`can_notify` (the watch lease) answers: may the backend's own OS-toast
+fallback stay quiet?** It is consumed at `serving.py:2293-2298` (gate routing)
+and `server.py:1829-1837` (`notification_surfaces`). A live desktop lease with
+`can_notify=true` suppresses the detached runtime's `detached_notify` for gates.
+It says nothing about which *frontend* owns a completion.
+
+**`claim_delivery` (the deliveries watermark) answers: which observer process
+owns this completion's toast?** `attention.py:585-655`. `BEGIN IMMEDIATE`
+serialises N observers; exactly one wins per `completion_token`. It is the
+arbiter, and it is clock-free by construction (`attention.py:43-49`: the
+`delivered_at` column is diagnostics only, because "a wall clock must never
+enter the claim, or two observers whose clocks disagree would both deliver").
+
+### 7.2 Who claims what
+
+**Decision: the desktop claims in the Electron main process, via a new
+`sessions.notified` op — not in the bridge.**
+
+This is the subtle part and the brief is right to flag it.
+
+The naive design claims in `_maybe_publish_notification` before putting the
+frame on the wire. That is wrong, for the reason `claim_delivery`'s own
+docstring gives (`attention.py:601-607`): **claim-then-deliver means the claimant
+must actually be the deliverer.** The bridge is not. Between the bridge's claim
+and an OS toast lie: the SSE socket, the Electron main process, the
+`Notification.isSupported()` check, and the focus gate. A bridge-side claim that
+the UI then suppresses (focused window) would mark the completion delivered while
+nobody was told — and no other surface could ever tell them, because
+`claim_delivery` returns `False` for good.
+
+So:
+
+1. The bridge publishes the `notification` frame **without claiming**. A frame
+   is an offer, not a delivery.
+2. `desktop-notifier.ts` receives it, checks `Notification.isSupported()`, its
+   local TTL dedupe, and the focus gate.
+3. **Only if it is actually going to call `new Notification(...)`** does it
+   claim, through a new desktop op, and only shows the toast if the claim wins.
+
+New op in `local_operator/server/routes/desktop_sessions.py`:
+
+```
+POST /v1/desktop/sessions/{session_id}/notified
+body: { "completion_token": <uuid> }
+200 -> { "claimed": true | false }
+404 -> unknown session
+```
+
+Backed by a `DesktopSessions.claim_notification(session_id, token)` that mirrors
+`acknowledge_attention` (`desktop_sessions.py:467-485`) exactly — **cold path,
+no bridge acquire, no runtime spawn**, same `SESSION_ID.fullmatch` +
+`is_user_session` validation — and calls:
+
+```python
+AttentionStore(self.root / "attention.db").claim_delivery(
+    f"session/{session_id}", token, "desktop"
+)
+```
+
+`backend="desktop"` (the `backend` column is diagnostics only —
+`attention.py:47-49` — but naming it correctly is what makes a store dump
+readable).
+
+**Why not reuse `sessions.seen`.** Because notifying is not reading.
+`attention.py:9-15` is unambiguous: two watermarks, deliberately separate;
+`claim_delivery` "NEVER ACKNOWLEDGES", and `docs/SESSION_SIDEBAR.md` pins that
+routing a notification never marks anything read. Reusing `seen` would clear the
+sidebar's unseen mark for a session the user never opened. The new op must
+therefore **not** go through `guardForegroundReceipts`
+(`desktop-ipc.ts:29-59`) — that guard exists for `sessions.seen` and demands a
+focused window, which is the exact opposite of when a notification fires.
+
+### 7.3 The focused-window case (the subtle one the brief names)
+
+**Answer: the claim is never taken in that case, because the focus gate runs
+BEFORE the claim.** Order is load-bearing:
+
+```
+observe(notification frame)
+  → isSupported()?              no  → return, no claim
+  → local TTL dedupe fresh?     no  → return, no claim
+  → focus_policy === "when_unfocused" && anyFocused()?  yes → return, NO CLAIM
+  → POST /notified              claimed=false → return (another surface won)
+  → new Notification(...)       claimed=true  → show
+```
+
+So there is nothing to release: a suppressed toast never claimed. The completion
+stays unclaimed and **another surface can still notify it** — a TUI observer on
+the same machine running `_notify_background_completions` will pick it up on its
+next 1 s poll and toast it. That is the right outcome: the desktop window being
+focused on session A says nothing about whether session B's completion deserves
+a banner elsewhere.
+
+`release_delivery` is therefore **not needed on the desktop path**, and must not
+be wired in. It exists for the case where a backend claims and then *fails to
+deliver* (`attention.py:657-671`), which the ordering above makes unreachable —
+the claim is the last thing before `notification.show()`, and
+`Notification.show()` on a supported platform does not fail synchronously.
+
+> One residual risk, accepted and named: Electron's `Notification.show()` can be
+> silently dropped by the OS (Focus Assist / Do Not Disturb / a denied
+> permission that `isSupported()` still reports true for). The claim is then
+> taken for a banner nobody saw. This is the identical accepted trade
+> `attention.py:609-621` already documents for the TUI path ("bounded in
+> CONSEQUENCE, unbounded in TIME"), and the durable signal survives: `unseen`
+> stays true and the sidebar keeps its mark. Do not add a lease to fix it; a
+> lease needs a clock, and a clock in this predicate is what lets two observers
+> both deliver.
+
+### 7.4 The TUI's side is already correct and needs no change
+
+`_notify_background_completions` (`app.py:19130-19140`) skips a row when
+`entry.row.live_state not in _BACKGROUND_NOTIFY_ANNOUNCEABLE_STATES`
+(`{"", "idle"}`, `app.py:666`) — i.e. it stays quiet when another TUI holds the
+session attached, busy, or wedged.
+
+**A desktop bridge does not make a session `attached`.** `live_state` comes from
+the record's `detached` flag (`catalog.py:374-386`), which is
+`not bool(self._visible_attach_surfaces())` (`server.py:1788`), and a desktop
+surface counts as visible there only while its lease says `desktop_visible`
+(`server.py:1818-1826`) — which the renderer sets to `visible && focused`
+(`desktop-notifier.ts:77`). So:
+
+- Desktop window **focused on this session** → `live_state == "attached"` → the
+  TUI observer skips it → only the desktop can notify → and the desktop's focus
+  gate suppresses it. Correct: the user is looking at it.
+- Desktop window **not focused** → `live_state` is `"idle"` → both the TUI
+  observer and the desktop are eligible → `claim_delivery` picks exactly one.
+  Correct: one toast.
+
+The mobile relay is not a competitor: it is a `daemon` client
+(`server.py:1846-1856`), never counted as watching, and it emits no OS toasts —
+`grep` for `detached_notify|claim_delivery` under `local_operator/mobile/`
+returns nothing. It participates in the *read* watermark (`POST
+/api/sessions/{id}/seen`), not the delivery one.
+
+### 7.5 What about the same session open in two Electron windows?
+
+`desktop-notifier.ts` holds one `delivered` map across every window
+(`desktop-notifier.ts:39`) and `anyFocused()` scans all of them
+(`desktop-notifier.ts:109-114`). Unchanged. The stream relay is per-window, so
+two windows on one session produce two `notification` frames with the *same*
+`dedupe_key` — and the shared map collapses them to one before any claim is
+attempted. Good: the HTTP claim is not even reached twice.
+
+---
+
+## 8. UI contract
+
+### 8.1 `src/shared/desktop-session-contract.ts`
+
+```ts
+/**
+ * One composed notification, as the backend rendered it.
+ *
+ * The strings are authoritative: the backend owns wording parity across the
+ * TUI, the detached-runtime fallback and this app, and it is the only place
+ * that can read the `display.notification_session_name` privacy flag. The
+ * structured fields travel beside them so a future surface can re-render
+ * without this app re-deriving a rule it cannot see.
+ */
+export type DesktopNotification = {
+	/** Payload shape version. 1 today; additive fields do not bump it. */
+	contract: number;
+	kind: "complete" | "error" | "interrupted" | "ask" | "approval";
+	title: string;
+	/** Short state category ("Complete", "Needs attention"). */
+	status: string;
+	body: string;
+	/** True when `body` is model-written text rather than a house constant. */
+	body_is_snippet: boolean;
+	/** False when the privacy flag is off or the session has no stored name. */
+	title_is_session_name: boolean;
+	/** Opaque; key the dedupe map on this and nothing else. */
+	dedupe_key: string;
+	/** Durable completion identity; the argument to `sessions.notified`. */
+	completion_token: string | null;
+	session_name: string | null;
+	/** `when_unfocused` for completions; `always` for a gate. */
+	focus_policy: "when_unfocused" | "always";
+};
+```
+
+and one arm added to the union:
+
+```ts
+	| Receipt<"notification", DesktopNotification>
+```
+
+### 8.2 `src/main/desktop-notifier.ts`
+
+```ts
+observe(sessionId: string, frame: DesktopSessionFrame): void {
+	if (!this.canNotify) return;
+	if (frame.type === "snapshot") { /* unchanged */ }
+	if (frame.type === "frontend.update") { /* unchanged */ }
+	if (frame.type === "notification") {
+		void this.composed(sessionId, frame.payload);
+		return;
+	}
+	if (frame.type === "event") {
+		// LEGACY PATH ONLY. A backend advertising `notification_contract` owns
+		// every completion toast, so this must stay silent against it or the
+		// user gets two banners for one turn. `turn_end` is dropped
+		// unconditionally: it is ONE MODEL CALL on every backend version
+		// (local_operator/tui/events.py TurnBoundaryEnd), never a finished turn.
+		if (this.notificationContract > 0) return;
+		if (String(frame.payload.type ?? "") === "agent_end") {
+			this.turn(sessionId, frame.seq);
+		}
+	}
+}
+
+private async composed(sessionId: string, n: DesktopNotification): Promise<void> {
+	if (!this.claim(n.dedupe_key)) return;
+	if (n.focus_policy === "when_unfocused" && this.anyFocused()) return;
+	if (n.completion_token) {
+		// Claim LAST, immediately before delivery: an unclaimed completion
+		// stays available to another surface (a TUI on this machine), while a
+		// claim taken for a toast we then suppressed would be delivered to
+		// nobody, for good. See docs/design/descriptive-notifications.md 7.3.
+		const won = await this.claimDelivery(sessionId, n.completion_token);
+		if (!won) return;
+	}
+	this.show(sessionId, n.title, n.status, n.body);
+}
+```
+
+`claimDelivery` posts `{op: "sessions.notified", sessionId, completionToken}`
+through the **ungated** `request` (not the `guardForegroundReceipts` wrapper —
+see §7.2). A rejected/failed request returns `false` and the toast is skipped:
+failing closed is right, because the failure mode of failing open is a duplicate
+banner on every surface.
+
+`notificationContract` is a number on the notifier, default `0`, set from
+`/v1/capabilities` — `setNotificationContract(n: number)` called once at
+backend-connect. `0` means legacy.
+
+### 8.3 `show()` gains the status line, and the gate fallback is fixed
+
+```ts
+private show(sessionId: string, title: string, status: string, body: string): void {
+	const notification = new Notification({
+		title,
+		// macOS has no subtitle on this API, so the state category leads the
+		// body. It is the word the user reads in under a second, and it must
+		// not be the line the OS clips first.
+		body: `${status ? `${status} — ` : ""}${body}`.slice(0, 240),
+		silent: false,
+	});
+	...
+}
+```
+
+> **The `status — body` concatenation is a guess about a rendered frame and must
+> be validated visually before merge (§11.2).** Electron's `NotificationConstructorOptions`
+> has `subtitle`, but it is documented macOS-only; if it renders correctly on the
+> maintainer's machine, prefer `subtitle: status` with a bare `body`, which is
+> what every backend leg already does (`cmux_command` takes title/subtitle/body,
+> `notify.py:624-646`). The coder decides from the screenshot, not from the docs.
+> Either way the *strings* come from the backend unchanged.
+
+The gate path's fallback title (`desktop-notifier.ts:126`) changes from
+`title || "Approval needed"` to a kind-aware one, since `gate.kind` is already on
+the wire:
+
+```ts
+this.show(sessionId, title || (kind === "ask" ? "Question" : "Approval needed"), "", detail);
+```
+
+### 8.4 What the UI must NOT do
+
+- Must not compose or re-word `title`/`status`/`body`.
+- Must not toast on `turn_end`, on any backend version.
+- Must not toast on `agent_end` when `notification_contract >= 1`.
+- Must not call `sessions.seen` from the notification path.
+- Must not claim before the focus gate.
+
+---
+
+## 9. Option 6 — TUI parity
+
+**Yes, `Notifier.send` gains the body, via the same composer.**
+
+Today `Notifier.send` (`notify.py:1084-1122`) sends `title = label or APP_NAME`,
+`subtitle = CONTEXTS[kind]`, `body = BODIES[kind]` — no snippet. Meanwhile the
+*background observer* path in the same app already sends the snippet
+(`app.py:18752+`). So a user gets a richer banner for a session they were **not**
+in than for the one they were. That asymmetry is backwards, and closing it is the
+"every surface agrees" half of the operator's request.
+
+Signature change, additive and back-compatible:
+
+```python
+def send(self, kind: NotifyKind, *, body: str = "") -> bool:
+    """Deliver one notification of `kind`; return whether anything was sent.
+
+    `body` overrides the house sentence from BODIES when supplied. It is
+    already composed and sanitised by `notifications.compose` — this method
+    does not re-derive the privacy gate, because the composer read it at the
+    same instant it read the text, and a second read here could disagree with
+    the text it is gating.
+    """
+```
+
+and `OperatorApp._notify` (`app.py:18490-18520`) resolves it:
+
+```python
+def _notify(self, kind: str, *, running_children: int | None = None) -> bool:
+    ...
+    notifier.set_label(self._notify_label())
+    composed = compose(kind, session_dir=self._session_dir(), session_name=self._notify_label())
+    if kind == "complete":
+        return notifier.notify_turn_complete(running_children=running_children or 0,
+                                             body=composed.body)
+    ...
+```
+
+`notify_turn_complete`, `notify_waiting` and `notify_error` each take
+`body: str = ""` and forward it. Every existing call site keeps working.
+
+**One constraint the coder must respect:** `compose()` does disk I/O and
+`_notify` runs on the Textual event loop. The reads are bounded (64 KB tail,
+128 KB for the title) and the method is already wrapped in a `try/except` that
+swallows everything, but a synchronous read on the UI thread at turn end is a
+frame hitch. Use the app's existing worker pattern (`run_worker(thread=True)`)
+or accept the hitch after measuring it. **Measure before deciding** — if
+`session_preview` over the maintainer's largest transcript is under ~5 ms,
+inline is fine and simpler.
+
+> **MEASURED, and resolved to inline.** Over a synthetic 42 MB transcript
+> (20,000 assistant messages of 2 KB each — larger than any real session on the
+> maintainer's machine), `compose()` runs in **0.19 ms median, 0.31 ms worst of
+> 20 runs**. That is two orders of magnitude under the 5 ms bar and under a
+> frame at any refresh rate, because both reads are bounded windows rather than
+> whole-file scans, so the cost is independent of transcript size. `_notify`
+> therefore calls the composer directly; a `run_worker` hop would buy nothing
+> and would cost the turn-end toast a scheduling delay. The measurement is
+> recorded here rather than in a comment alone so a future reader can see what
+> was actually tested rather than re-deriving the decision.
+>
+> The bridge's call is still wrapped in `asyncio.to_thread` (§6.2 note 1) and
+> that is not inconsistent: it runs inside the 1 s attention poll shared by up
+> to `BRIDGE_COUNT` bridges, where a burst of simultaneous completions stacks
+> the cost on one event loop serving every session, rather than on one app's UI
+> thread at one turn's end.
+
+**What does not change:** the focus gate (`notify.py:1094-1095`), the cmux-first
+routing (`notify.py:1104-1107`), and the fact that the snippet reaches
+`cmux_command`/`notify-send` argv but **never** an OSC escape
+(`app.py:18898-18906` — `notification_writes` is only ever called with the fixed
+`BODIES` constant). If `send()` now passes a model-written body into
+`notification_writes`, that invariant breaks and the OSC injection surface opens.
+
+> **BLOCKER-CLASS CONSTRAINT, stated so it cannot be missed:** in
+> `Notifier.send`, the composed body may be passed to the **cmux leg** and the
+> **D-Bus leg**, but the **in-band OSC leg must keep using `BODIES[kind]`**.
+> `sanitize_text` strips ESC and BEL (`notify.py:373`) so it is defence in
+> depth either way, but the invariant that model text never reaches an OSC
+> string is worth keeping intact rather than relying on one regex. A test pins
+> this (§10.1, T-N4).
+
+---
+
+## 10. Test plan
+
+### 10.1 Backend
+
+**Extend `tests/unit/tui/test_notify.py`** (55 tests today) — or add
+`tests/unit/notifications/test_compose.py` for the pure composer, which is
+cleaner since the module is new:
+
+| ID | Assertion |
+|---|---|
+| T-C1 | `complete` with a stored title and assistant text → title is the name, status `Complete`, body is the snippet, `body_is_snippet is True`. |
+| T-C2 | `complete` with `display.notification_session_name` off → title is `APP_NAME`, body is `BODIES["complete"]`, both flags `False`. **The snippet is absent.** |
+| T-C3 | `error` with assistant text present → body is `"Stopped with an error"`, never the snippet. Pins review round 1 M1. |
+| T-C4 | `interrupted` likewise. |
+| T-C5 | A 400-char assistant line → body ≤ 120 chars **and** ends on a word boundary (proves `max_chars` was passed to `session_preview`, not applied after). |
+| T-C6 | A title/snippet containing `\x1b]0;pwned\x07` → both scrubbed. |
+| T-C7 | Untitled session, `complete` → `BACKGROUND_FALLBACK_TITLE`; untitled session, `ask` → `APP_NAME`. |
+| T-C8 | `approval` where `gate_detail` already starts with `gate_title` → no `"write: write:"` duplication. Pins round 4 Q3. |
+| T-C9 | Unreadable/missing `session_dir` → returns the house vocabulary, never raises. |
+
+**Extend `tests/unit/tui/test_notify_wiring.py`** (real app via `run_test`):
+
+| ID | Assertion |
+|---|---|
+| T-N1 | A completed turn's toast body is the last assistant line, not `"Task complete"`. |
+| T-N2 | With the privacy flag off, the same turn's toast carries neither the name nor the snippet. |
+| T-N3 | An errored turn's body is the house sentence even with assistant text present. |
+| T-N4 | **The OSC leg never carries model text**: with no cmux surface and an `osc9` terminal, the bytes written to the driver contain `BODIES[kind]` and not the snippet. Pins §9's invariant. |
+
+**Existing `test_background_completion_notify.py` (34 tests) must stay green
+untouched** — it already covers the claim/release path. Its continued passing is
+the evidence that §7 changed nothing about the TUI's arbitration.
+
+**New `tests/unit/server/test_desktop_notifications.py`** (mirroring
+`test_desktop_attention.py`'s cold-path style):
+
+| ID | Assertion |
+|---|---|
+| T-B1 | Publishing a `complete` completion for a bridged session emits exactly one frame with `type == "notification"`, after the `attention` frame. |
+| T-B2 | The **first** `refresh_attention` of a bridge's life (baseline) emits **no** notification, even with an unseen completion already in the store. |
+| T-B3 | The same completion observed twice (revision churn, no new token) emits one frame, not two. |
+| T-B4 | A `kind == "interrupted"` completion emits **no** frame. |
+| T-B5 | An `agent_end` event on the bridge emits an `event` frame and **no** `notification` frame. The anti-regression test for defect A. |
+| T-B6 | A `turn_end` event likewise. |
+| T-B7 | The notification frame is **not** in `bridge.replay` — reconnecting with `after_seq` before it replays the transcript events around it and not the notification. |
+| T-B8 | `seq` still advances monotonically across a notification, and a client reconnecting at the notification's `seq` is **not** flagged `gap`. |
+| T-B9 | `POST /notified` claims once: the second call for the same token returns `claimed: false`. |
+| T-B10 | `POST /notified` does **not** change `unseen` or the `receipts` watermark — read `state()` before and after. Pins the two-watermark separation. |
+| T-B11 | `POST /notified` never acquires a bridge or starts a runtime (monkeypatch `DesktopSessions.session` to raise, as `test_desktop_attention.py:39-44` does). |
+| T-B12 | `POST /notified` with a foreign/unknown token returns `claimed: false` without writing. |
+| T-B13 | An unreadable transcript during compose costs the notification, not the attention poll: the `attention` frame is still published. |
+
+**Extend `tests/unit/session/test_attention.py`** (26 tests): one test that
+`claim_delivery(..., backend="desktop")` and a TUI claim for the same token
+produce exactly one winner. The primitive is already covered; this pins that the
+desktop is just another claimant with no special path.
+
+**`tests/unit/server/test_openapi.py`** picks up the new route automatically —
+confirm the `/notified` shape is in the generated schema with `extra="forbid"`
+on its `Input` subclass.
+
+### 10.2 UI
+
+**New `scripts/desktop-notifier.test.mjs`, added to the `test:desktop` list.**
+Same in-memory esbuild bundling `desktop-contract.test.mjs:1-47` uses, with the
+electron fixture extended to supply a **fake `Notification`** that records
+constructor args instead of calling the OS:
+
+```js
+export class Notification {
+  static isSupported() { return true; }
+  constructor(options) { globalThis.__toasts.push(options); }
+  on() {}
+  show() { globalThis.__shown.push(this); }
+}
+```
+
+This is the "test-visible delivery sink" the brief asks for: it proves the
+*right payload* reached the OS boundary without anyone reading Notification
+Center.
+
+| ID | Assertion |
+|---|---|
+| T-U1 | A `notification` frame with `focus_policy: "when_unfocused"` and no focused window produces exactly one toast whose title/body are the backend's strings, verbatim. |
+| T-U2 | The same frame with a focused window produces **no** toast **and no `sessions.notified` request**. The §7.3 ordering test. |
+| T-U3 | Two frames with the same `dedupe_key` produce one toast and one claim. |
+| T-U4 | `sessions.notified` returning `{claimed: false}` produces no toast. |
+| T-U5 | A rejected/500 `sessions.notified` produces no toast (fail closed). |
+| T-U6 | With `notificationContract = 1`, an `agent_end` event frame produces **no** toast. The anti-double-toast test. |
+| T-U7 | With `notificationContract = 0`, `agent_end` produces the legacy toast and `turn_end` produces **none**. |
+| T-U8 | An unknown future frame type (`type: "something_new"`) is ignored without throwing — the forward-compat test. |
+| T-U9 | A `pending_gate` with `kind: "ask"` and an empty title falls back to `"Question"`, not `"Approval needed"`. |
+| T-U10 | The notification path never emits an op of `sessions.seen`. |
+
+**`pnpm check-types`, `pnpm lint`** cover the contract type addition.
+
+### 10.3 End-to-end proof for the QA round
+
+The real surface is an OS toast. Three layers of evidence, none of which is a
+human staring at Notification Center:
+
+1. **Bridge-side frame assertion (backend, real HTTP).** Extend
+   `tests/e2e/test_desktop_sessions.py`, which already drives real loopback HTTP
+   with the production `Session`/`RuntimeServer`/`AttachClient` and a scripted
+   provider stream (`DESKTOP_API.md:248-252`). Run a turn that calls a tool and
+   then answers, and assert on the **ordered frame log** from the SSE
+   subscription: exactly one `notification` frame, following N `turn_end`
+   frames, with a body equal to the model's last line. This is the proof that
+   the *right thing* was emitted, at the real transport, over a real turn.
+   Run it with `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest
+   tests/e2e -m e2e -n0 -q`.
+
+2. **Delegation case, same harness.** A turn that spawns a `task` child and
+   returns while the child runs must produce **zero** notification frames; the
+   frame appears only after the child settles and its re-entry turn completes.
+   This is the user's defect, proven end to end.
+
+3. **UI-side delivery sink (Electron main harness).** T-U1..T-U10 above with the
+   fake `Notification`. Plus one **manual-but-captured** step for the QA report:
+   run the real app against a real backend, trigger a completion with the window
+   unfocused, and capture the banner with a screenshot (`screencapture -x` on
+   macOS catches the banner). That single screenshot is what validates the
+   `status — body` vs `subtitle` decision in §8.3, which no unit test can.
+
+**The QA matrix must cover, per surface:** completion / error / interrupted /
+`ask` / `approval`; privacy flag on and off; window focused and unfocused; old
+backend + new UI; new backend + old UI (install the previous signed build and
+confirm no double toast and no crash on the unknown frame); two windows on one
+session; TUI and desktop both running with the same session idle (exactly one
+toast, and `lop sessions` still shows the row unseen afterwards — proving §7.2's
+watermark separation on a real store).
+
+---
+
+## 11. Rollout order and risks
+
+### 11.1 Order: backend first, always
+
+The backend PR is safe alone:
+
+- The `notification` frame is additive and ignored by every shipped UI
+  (§4.3, verified against `use-canonical-session.ts` and `desktop-notifier.ts`).
+- `POST /notified` is a new route nothing calls yet.
+- `features.notification_contract` is a new key in an existing map.
+- The TUI parity change (§9) is self-contained and independently valuable.
+
+The UI PR is **not** safe alone: without the backend it has no frames to render,
+and if it drops the `agent_end` legacy path on the strength of a capability the
+backend does not advertise, completions go silent. The capability check in §4.3
+makes the UI safe *whenever* it ships, but shipping it first delivers nothing.
+
+Recommended sequence:
+
+1. **Backend PR** — composer, frame, route, capability, TUI parity, tests.
+   Merge, release, `lop-update`.
+2. **UI PR** — contract type, notifier rewrite, capability gate, tests,
+   screenshot evidence. Merge and cut the Electron release.
+
+There is no window where the user gets two toasts for one turn: an old UI
+ignores the new frame, and a new UI stops the legacy path only when the backend
+says it owns notifications.
+
+### 11.2 Risks to watch during rollout
+
+1. **The `status — body` concatenation may read badly on the real OS.** §8.3.
+   Watch: the screenshot in the UI PR. Remedy: `subtitle: status` on macOS. This
+   is the one genuinely undecided rendering question and it is decided by looking
+   at a frame, not by a doc.
+
+2. **The 1 s attention poll adds a compose on the loop.** Only on the tick where
+   a token changes, so the steady state is unaffected
+   (`desktop_sessions.py:252-269` gates on `revision()`). But
+   `BRIDGE_COUNT = 64` bridges each with their own poll means a burst of
+   completions could stack `to_thread` calls. Watch: the e2e run's wall time,
+   and `logger` noise from the poll's failure-transition logging. Remedy: the
+   existing guard already costs one tick rather than the feature.
+
+3. **`claim_delivery` returning `False` looks like a bug and is not.** When both
+   a TUI and the desktop are eligible, one of them silently drops its toast. Watch:
+   user reports of "I only got the banner on one surface" — that is the feature.
+   The diagnostic is the `backend` column in `deliveries`, which will read
+   `desktop` or `detached`/`cmux`.
+
+4. **A `notification` frame consumes a `seq` without being replayable.** §4.4
+   argues the gap arithmetic is unaffected. Watch: T-B8, and any `gap` frames in
+   the e2e log after a notification. If this is wrong, the symptom is a spurious
+   full-snapshot refetch after every completion — visible as a transcript flash.
+
+5. **The composer reads the transcript while the session is writing it.**
+   `session_preview` already handles a half-written final line
+   (`resume.py:1974-1976`). Watch: empty bodies degrading to `"Task complete"`
+   more often than expected, which would mean the read is racing the flush. The
+   emitter fires off the *durable* attention publication, which happens after
+   message persistence (`session.py:5982-5988`), so the row should always be
+   there — but the ordering is worth one assertion in T-B1.
+
+6. **Two windows, two relays, one HTTP claim.** §7.5 argues the shared dedupe
+   map collapses them first. Watch: duplicate `POST /notified` in the backend
+   access log. Harmless if it happens (the second returns `claimed: false`), but
+   it would mean the map is not as shared as `desktop-notifier.ts:39` implies.
+
+### 11.3 Documentation to amend in the backend PR
+
+- **`docs/DESKTOP_API.md`** — a `notification` row in the frame list at
+  line ~211-234, a `/notified` row in the endpoint table at ~156-166, and an
+  amendment to the sentence at line 243 ("its gate/turn notification
+  dedupe/click behavior is not implemented by these backend routes"), which this
+  change makes partly false.
+- **`docs/ATTENTION.md`** — one paragraph under "Read APIs and transports"
+  naming the desktop as a `claim_delivery` claimant with `backend="desktop"`,
+  and restating that the claim never advances the read watermark. Its existing
+  closing line ("Desktop adoption ... must not equate a watch/notification lease
+  with a durable read") is already correct and this design honours it.
+- **`local_operator/tui/notify.py`'s module docstring** — the "Only a terminal"
+  gate (lines 53-59) needs one sentence: the server still never *delivers*, but
+  it now *composes* for a frontend that does.
+- **`docs/SESSION_SIDEBAR.md`** — no change; its rule that routing a
+  notification never marks anything read is preserved by §7.2 and pinned by
+  T-B10.
+
+---
+
+## 12. What this design deliberately does not do
+
+- **No new setting.** `display.notification_session_name` gates both the name
+  and the snippet (§3.2). A second flag would let a user opt out of names while
+  leaking conversation content, which is strictly worse than one clear promise.
+- **No notification for `interrupted` on the desktop** (§6.5). One frozenset
+  entry away if asked for.
+- **No backend-side OS delivery for completions.** The `can_notify` lease
+  already suppresses the runtime's fallback for gates; completions were never
+  delivered from the server and still are not.
+- **No replay of notifications** (§4.4). An edge that arrives hours late is
+  noise; the durable unseen mark is the right surface for a missed completion.
+- **No relocation of `CONTEXTS`/`BODIES`.** Ten import sites, zero benefit.
+- **No change to the `pending_gate` notification path** beyond the `ask` title
+  fallback. It works.
+
+---
+
+## 13. Amendments from the UI PR's design round (applied in the backend PR)
+
+Two findings from the UI half's design round landed on the backend, because the
+user-facing result spans both halves and neither could be fixed in the
+renderer without moving a decision the backend owns.
+
+### D4 (MAJOR) — an `error` banner must name the failure
+
+**As designed**, §3.2 gave every non-`complete` kind the house constant, so a
+failure read `Needs attention — Stopped with an error`. That names a state the
+user must act on while withholding the only fact that says WHICH action: top up
+a quota, fix a credential, or simply retry. They have to open the session to
+learn anything, on the surface whose entire purpose is to save them that trip.
+
+**Resolved by adding the text, not by deferring it.** The failure text IS
+durably reachable without inventing a path: `incidents.py` journals a
+`session_incident` custom message on every classified failure, persisted
+precisely so a resumed session can explain itself, and its `details.raw` holds
+the unrendered provider text. `resume.session_failure_summary()` reads it from
+the same bounded 64 KiB tail window `session_preview` already uses, so the cost
+is one more read of a warm region rather than a second scan strategy.
+
+Three constraints the implementation holds:
+
+- **`raw`, never `text`.** The rendered `text` is the model-facing block, several
+  lines long and tailed with "This is why the previous turn ended. Take it into
+  account before repeating the same request." — an instruction addressed to the
+  model, which on a lock screen reads as nonsense.
+- **Same scrub and budget as the snippet.** `sanitize_text(...,
+  BACKGROUND_SNIPPET_MAX_CHARS)`: a provider's error envelope is untrusted text
+  on the same argv and AppleScript wires, and is not length-bounded at source.
+- **Same privacy gate,** for a stronger reason than the snippet's — an error
+  envelope can quote a prompt fragment, a file path or an account identifier.
+
+`ComposedNotification` gained `body_is_failure`, defaulted and last, so a
+surface can tell the two kinds of untrusted text apart. The two flags are never
+both true. This does not weaken review round 1's M1: the snippet is still
+`complete`-only, and the reason the failure text is safe where the last
+assistant line was not is that it describes the FAILURE rather than the work,
+so it cannot read as a success beside a state that says it failed.
+
+### D3 (MAJOR) — a gate banner must be triageable
+
+**As designed**, completions gained a session identity and gates kept none, so
+the banner holding a run hostage could not be attributed: "Waiting for approval"
+with three sessions open names none of them.
+
+**Resolved without a second channel**, exactly as §5.2 requires. Gates keep
+travelling on `pending_gate`; `PendingGateState` gained an additive, optional,
+defaulted `session_name`, stamped at both publication sites
+(`ServingSessionHandle._publish_pending_gate` and `RuntimeServer.set_pending`,
+the latter delegating to the former's helper so the privacy rule cannot hold on
+one and not the other).
+
+Empty when `display.notification_session_name` is off, and the emptiness is
+decided in the BACKEND for the reason §1 gives for composing there at all: only
+the backend can read that setting, and a renderer re-deriving it is one that can
+get it wrong inside a signed binary the user updates on their own schedule.
+Additive in both skew directions — an old viewer ignores the key, a new viewer
+reading an old payload gets `""` and falls back to the anonymous card it already
+draws — which is what lets the backend ship before the UI renders it.

--- a/docs/design/descriptive-notifications.md
+++ b/docs/design/descriptive-notifications.md
@@ -401,7 +401,11 @@ weight.
 The backend mints it; the UI treats it as an opaque string and keys its existing
 TTL map on it. Shape:
 
-- completions: `complete:{session_id}:{completion_token}`
+- completions: `{kind}:{session_id}:{completion_token}` — the frame's own
+  `kind` (`complete` or `error`), so a store or dedupe-map dump reads
+  consistently beside the frame it keys. A token has exactly one kind, so the
+  prefix can never widen or narrow a collision; it is a label, not a
+  discriminator.
 - gates: `gate:{session_id}:{bridge_epoch}:{request_id}`
 
 **Why the backend mints it.** The UI's current completion key is
@@ -701,7 +705,7 @@ def _maybe_publish_notification(
             "body": composed.body,
             "body_is_snippet": composed.body_is_snippet,
             "title_is_session_name": composed.title_is_session_name,
-            "dedupe_key": f"complete:{self.session_id}:{token}",
+            "dedupe_key": f"{composed.kind}:{self.session_id}:{token}",
             "completion_token": token,
             "session_name": composed.title if composed.title_is_session_name else None,
             "focus_policy": "when_unfocused",

--- a/local_operator/notifications/__init__.py
+++ b/local_operator/notifications/__init__.py
@@ -1,0 +1,36 @@
+"""Notification CONTENT, composed once and rendered by every surface.
+
+Deliberately not under ``tui/``. ``tui/notify.py``'s module docstring makes
+"this module is imported only from ``tui/``" a load-bearing rule about
+*delivery*: a backend that delivered its own toasts would double every alert
+and would raise it on whichever machine the server happens to run on. That rule
+is about delivery and it still holds — nothing here writes an escape sequence,
+spawns ``notify-send`` or constructs an OS notification.
+
+What was missing is the other half. The desktop app (local-operator-ui) owns
+its own delivery surface but had no facts to render, so it hardcoded "Turn
+complete / The agent finished its turn." while the session's name, its outcome
+category and its last assistant line were all reachable in the backend and none
+of them were on the wire. Composing here rather than in the renderer means one
+place reads the ``display.notification_session_name`` privacy flag, one place
+owns the wording, and a wording fix ships as a backend release rather than as a
+signed Electron build.
+
+See ``docs/design/descriptive-notifications.md`` for the decision record.
+"""
+
+from local_operator.notifications.compose import (
+    NOTIFICATION_CONTRACT_VERSION,
+    ComposedNotification,
+    NotificationKind,
+    compose,
+    gate_body,
+)
+
+__all__ = [
+    "NOTIFICATION_CONTRACT_VERSION",
+    "ComposedNotification",
+    "NotificationKind",
+    "compose",
+    "gate_body",
+]

--- a/local_operator/notifications/compose.py
+++ b/local_operator/notifications/compose.py
@@ -1,0 +1,342 @@
+"""Render one notification's text from the facts, for every surface at once.
+
+Pure composition, no delivery. The vocabulary (:data:`~local_operator.tui.
+notify.CONTEXTS`, :data:`~local_operator.tui.notify.BODIES`, the budgets) is
+imported from ``tui/notify.py`` rather than copied or relocated: the constants
+already have ten import sites and a second declaration of the same wording is a
+second thing to keep in step. Importing them here is safe in both directions —
+``tui/notify.py`` pulls in no Textual, which is why the desktop bridge and the
+detached runtime can both reach this module without dragging a terminal UI into
+a server process.
+
+WHY THE BACKEND COMPOSES AT ALL. Three surfaces show the same completion: the
+TUI's own notifier, the detached runtime's OS fallback, and the desktop app.
+Only the backend can read ``display.notification_session_name``, so only the
+backend can decide whether a banner may carry the conversation's name or a line
+of its content. A renderer composing its own strings would either re-derive a
+privacy rule it cannot see, or ship the wording inside a signed binary where a
+fix costs a full release. Both halves of the result travel (the rendered
+strings AND the facts they came from) so a future surface can re-render — a
+localisation, a narrower budget — without the backend guessing who is asking.
+
+THE PRIVACY FLAG GATES BOTH THE NAME AND THE SNIPPET, on purpose. The flag
+exists to keep model-written session text off a screen other people can see,
+and a snippet is strictly more session-derived than a name: a name is a topic,
+a snippet is content. A user who opted out of the name has necessarily opted
+out of the snippet, so there is no second setting — one clear promise instead
+of a flag that lets conversation content leak while the name is hidden.
+
+See ``docs/design/descriptive-notifications.md`` §3 for the full contract and
+the table this module implements literally.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from local_operator.tui.notify import (
+    APP_NAME,
+    BACKGROUND_FALLBACK_TITLE,
+    BACKGROUND_SNIPPET_MAX_CHARS,
+    BODIES,
+    BODY_COMPLETE,
+    CONTEXT_COMPLETE,
+    CONTEXTS,
+    MAX_TITLE_CHARS,
+    sanitize_text,
+    session_names_in_notifications,
+)
+
+logger = logging.getLogger(__name__)
+
+#: The kinds a composed notification may carry. Deliberately the
+#: :data:`~local_operator.tui.notify.CONTEXTS` key set, so the vocabulary
+#: cannot drift from the TUI's. Not every kind is reachable on every surface:
+#: the desktop bridge narrows it further (``BRIDGE_NOTIFIABLE_KINDS``) because
+#: ``ask``/``approval`` already reach that app as ``pending_gate``.
+NotificationKind = Literal["complete", "error", "interrupted", "ask", "approval"]
+
+#: Wire contract version for the ``notification`` frame's payload shape,
+#: advertised as ``features.notification_contract`` in ``/v1/capabilities``.
+#:
+#: Bumped ONLY on a breaking change to field names or types; an additive field
+#: does not bump it, because the renderer reads fields by name and ignores the
+#: ones it does not know. If a field is ever removed or retyped, the old one is
+#: kept beside the new one for one release — a renderer is a signed binary the
+#: user updates on their own schedule, so the backend cannot assume the two
+#: ship together.
+NOTIFICATION_CONTRACT_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ComposedNotification:
+    """One notification's rendered text plus the facts it was rendered from.
+
+    Both halves travel. The strings are what every surface shows, so wording
+    parity across the TUI, the detached-runtime fallback and the desktop app is
+    free; the facts are what lets a future consumer re-render without the
+    backend having to guess which surface is asking.
+    """
+
+    kind: NotificationKind
+    #: Banner title: the session's name, :data:`APP_NAME` when the privacy flag
+    #: is off, or :data:`BACKGROUND_FALLBACK_TITLE` when a completion's session
+    #: has no stored title.
+    title: str
+    #: Short state category from :data:`CONTEXTS` ("Complete", "Input
+    #: required", "Needs attention", "Interrupted"). Rendered as the subtitle
+    #: where a surface has one and folded into the body where it does not.
+    status: str
+    #: The content line. A last-assistant-line snippet for ``complete`` when
+    #: the privacy flag allows and one exists; the house sentence otherwise.
+    body: str
+    #: True when ``body`` is model-written text rather than a house constant.
+    #: Nothing reads it today; it exists so a surface that must not show
+    #: conversation content (a shared screen, a recording) can degrade without
+    #: re-deriving the privacy rule this module owns.
+    body_is_snippet: bool
+    #: Whether ``title`` is the conversation's real name. False when the
+    #: privacy flag is off or the session is untitled.
+    title_is_session_name: bool
+    #: True when ``body`` is the PROVIDER's failure text rather than a house
+    #: constant. Separate from :attr:`body_is_snippet` because the two are
+    #: different kinds of untrusted text and a surface may reasonably treat
+    #: them differently: a snippet is the model's own prose about the user's
+    #: work, while this is an error envelope that may name a provider, a model
+    #: or a quota. Never both true at once — a body is one thing or the other.
+    #:
+    #: Defaulted, and LAST, because it was added after the first draft of this
+    #: dataclass: a caller constructing one positionally keeps working.
+    body_is_failure: bool = False
+
+
+def gate_body(kind: str, gate_title: str, gate_detail: str) -> str:
+    """The body for a parked ``ask``/``approval``: the action, or the sentence.
+
+    Extracted so the detached runtime's OS fallback
+    (``runtime/serving.py::_announce_pending``) and any other gate surface
+    cannot drift from each other's wording.
+
+    NOT ``f"{title}: {detail}"``. A tool's ``describe_approval`` already leads
+    with its own action word (``_describe_path_approval`` emits ``"write:
+    /path"``) and the title IS the tool name, so the naive form rendered every
+    such approval as ``"write: write: /path"`` — on the release's headline
+    surface, every time (round 4, Q3). The prefix is applied only when the
+    detail does not already carry it.
+
+    An empty detail falls back to the house vocabulary rather than to the bare
+    tool name: "write" alone says less than "Waiting for approval", and an
+    ``ask`` with no text used to render as a single word with no hint that it
+    was a question rather than an approval.
+    """
+    subject = (gate_detail or "").strip()
+    if subject and gate_title and not subject.lower().startswith(gate_title.lower()):
+        subject = f"{gate_title}: {subject}".strip().rstrip(":").strip()
+    return subject or BODIES.get(kind, BODY_COMPLETE)
+
+
+def compose(
+    kind: NotificationKind,
+    *,
+    session_dir: Path | None,
+    session_name: str = "",
+    gate_title: str = "",
+    gate_detail: str = "",
+) -> ComposedNotification:
+    """Render one notification. Pure apart from two best-effort disk reads.
+
+    ``session_dir`` is read for the stored title and, for ``complete``, the
+    last assistant line. ``session_name`` is the caller's already-resolved name
+    (the TUI holds it live; the desktop bridge reads ``conversation_title`` off
+    the frontend snapshot) and WINS over the stored title when non-empty,
+    because a rename reaches the live state before it reaches the sidecar — a
+    toast naming a session by the name it had ten seconds ago is worse than one
+    naming it by none.
+
+    ``gate_title``/``gate_detail`` are used only for ``ask``/``approval``; they
+    carry the tool name and the action being authorised, in the shape
+    ``_announce_pending`` already builds. Ignored for every other kind.
+
+    NEVER RAISES. A notification is chrome and this runs on paths that must not
+    fail for it: the desktop bridge's 1 s attention poll, and the TUI's turn-end
+    handler. Every read is guarded and degrades to the house vocabulary, which
+    asserts nothing about the conversation and is therefore always safe to show.
+
+    The privacy flag is read PER CALL rather than cached, because ``/settings``
+    writes it live: a value resolved once at construction keeps leaking the name
+    for the rest of a session that had just turned it off.
+    """
+    names_ok = _names_allowed()
+    status = CONTEXTS.get(kind, CONTEXT_COMPLETE)
+
+    title, title_is_session_name = _compose_title(
+        kind, names_ok=names_ok, session_dir=session_dir, session_name=session_name
+    )
+    body, body_is_snippet, body_is_failure = _compose_body(
+        kind,
+        names_ok=names_ok,
+        session_dir=session_dir,
+        gate_title=gate_title,
+        gate_detail=gate_detail,
+    )
+    return ComposedNotification(
+        kind=kind,
+        title=title,
+        status=status,
+        body=body,
+        body_is_snippet=body_is_snippet,
+        body_is_failure=body_is_failure,
+        title_is_session_name=title_is_session_name,
+    )
+
+
+def _names_allowed() -> bool:
+    """The privacy flag, with a settings store that cannot be read treated as OFF.
+
+    Failing CLOSED is the only defensible direction here: the flag's whole
+    purpose is to keep model-written text off a screen other people can see, so
+    an unreadable or corrupt settings file must not be the thing that puts a
+    conversation's name on a lock screen. The cost of the wrong answer is
+    asymmetric — a missed name is a duller banner, a leaked one is the failure
+    the setting exists to prevent.
+    """
+    try:
+        return session_names_in_notifications()
+    except Exception:  # noqa: BLE001 — chrome; see the docstring for the direction
+        logger.debug("notification privacy flag unavailable; assuming off", exc_info=True)
+        return False
+
+
+def _compose_title(
+    kind: str, *, names_ok: bool, session_dir: Path | None, session_name: str
+) -> tuple[str, bool]:
+    """``(title, title_is_session_name)`` per the §3.2 table.
+
+    The nameless case splits on kind, and the split is deliberate: "A session
+    finished" is a true sentence for a completion and a false one for a parked
+    question, so a gate with no resolvable name falls back to the brand — which
+    is what the detached runtime's own gate fallback already does.
+
+    :data:`MAX_TITLE_CHARS` is 80, and the state category never rides in the
+    title: macOS clips a banner title at roughly 43 characters, so appending
+    anything after the name is appending the part that gets cut.
+    """
+    if not names_ok:
+        # The opt-out keeps the BRAND, which is exactly what a user who turned
+        # this off is asking for: no statement about their sessions at all.
+        return APP_NAME, False
+    name = sanitize_text(session_name, MAX_TITLE_CHARS)
+    if not name and session_dir is not None:
+        name = sanitize_text(_stored_title(session_dir), MAX_TITLE_CHARS)
+    if name:
+        return name, True
+    if kind in ("ask", "approval"):
+        return APP_NAME, False
+    return BACKGROUND_FALLBACK_TITLE, False
+
+
+def _compose_body(
+    kind: str,
+    *,
+    names_ok: bool,
+    session_dir: Path | None,
+    gate_title: str,
+    gate_detail: str,
+) -> tuple[str, bool, bool]:
+    """``(body, body_is_snippet, body_is_failure)`` per the §3.2 table.
+
+    THE SNIPPET IS FOR ``complete`` ONLY, and the restriction is a correctness
+    rule rather than a stylistic one. An errored or interrupted session's last
+    assistant line is whatever it happened to be saying before it stopped,
+    which routinely reads as a success ("All 412 tests pass.") beside a state
+    that says it failed. "Snippet iff complete" is decidable from the kind
+    alone; any rule that asked whether a particular line reads honestly would
+    depend on a judgement no code here can make, on a lock screen where prose
+    is read once with nothing beside it to check it against.
+
+    ``error`` GETS THE FAILURE TEXT INSTEAD, which is the exception that
+    proves that rule rather than a hole in it. "Stopped with an error" names a
+    state the user must act on while withholding the only fact that says WHICH
+    action — top up a quota, fix a credential, or just retry (design round 1,
+    D4). The text comes from the session's own ``session_incident`` record, so
+    it describes the failure itself and cannot be mistaken for a claim about
+    the work, which is precisely what made the last-assistant-line unsafe here.
+    """
+    if kind in ("ask", "approval"):
+        return gate_body(kind, gate_title, gate_detail), False, False
+    if kind == "error" and names_ok and session_dir is not None:
+        # Same privacy gate as the snippet, and for a stronger reason: a
+        # provider's error envelope can quote a prompt fragment, a file path or
+        # an account identifier. A user who opted out of seeing their session
+        # named has certainly opted out of that.
+        failure = sanitize_text(_failure(session_dir), BACKGROUND_SNIPPET_MAX_CHARS)
+        if failure:
+            return failure, False, True
+    if kind != "complete" or not names_ok or session_dir is None:
+        return BODIES.get(kind, BODY_COMPLETE), False, False
+    # `max_chars` is PASSED rather than applied afterwards, so the
+    # word-boundary ellipsis `session_preview` computes lands against the
+    # budget the banner actually has; trimming a 200-char preview down to 120
+    # afterwards cuts mid-word after the ellipsis was already placed elsewhere.
+    preview = _preview(session_dir)
+    # `sanitize_text` re-applies the budget as its `limit`; deliberate
+    # belt-and-braces, since stripping control characters can only shorten the
+    # string and the two bounds therefore agree. The scrub itself is required:
+    # this text reaches argv (`cmux notify`, `notify-send`) and an AppleScript
+    # string literal.
+    snippet = sanitize_text(preview, BACKGROUND_SNIPPET_MAX_CHARS)
+    if snippet:
+        return snippet, True, False
+    return BODIES.get("complete", BODY_COMPLETE), False, False
+
+
+def _stored_title(session_dir: Path) -> str:
+    """The session's stored title, or ``""`` for anything that goes wrong.
+
+    Imported inside the function because ``resume`` drags the session-directory
+    machinery, and this module is imported by the detached runtime's gate path
+    where that cost buys nothing until a gate actually parks.
+    """
+    try:
+        from local_operator.resume import stored_session_title
+
+        return stored_session_title(session_dir)
+    except Exception:  # noqa: BLE001 — a title is chrome; delivery is not
+        logger.debug("notification title unavailable for %s", session_dir, exc_info=True)
+        return ""
+
+
+def _failure(session_dir: Path) -> str:
+    """The last failure's raw text, or ``""`` for anything that goes wrong.
+
+    Guarded and imported lazily for the same reasons as :func:`_preview`, and
+    it shares that function's bounded tail window, so adding it costs one more
+    read of an already-warm 64 KiB region rather than a second scan strategy.
+    """
+    try:
+        from local_operator.resume import session_failure_summary
+
+        return session_failure_summary(session_dir, max_chars=BACKGROUND_SNIPPET_MAX_CHARS)
+    except Exception:  # noqa: BLE001 — a body is chrome; delivery is not
+        logger.debug("notification failure text unavailable for %s", session_dir, exc_info=True)
+        return ""
+
+
+def _preview(session_dir: Path) -> str:
+    """The last assistant line, or ``""`` for anything that goes wrong.
+
+    ``session_preview`` already returns ``""`` for a missing, unreadable or
+    assistant-text-free transcript and swallows ``OSError`` itself; the broad
+    guard is for everything above that contract — bytes that decode into
+    something unexpected, a directory that vanished between the two calls.
+    """
+    try:
+        from local_operator.resume import session_preview
+
+        return session_preview(session_dir, max_chars=BACKGROUND_SNIPPET_MAX_CHARS)
+    except Exception:  # noqa: BLE001 — a body is chrome; delivery is not
+        logger.debug("notification preview unavailable for %s", session_dir, exc_info=True)
+        return ""

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -377,6 +377,20 @@ PREVIEW_SCAN_BYTES = 64_000
 #: every row in the list is pure weight.
 PREVIEW_MAX_CHARS = 200
 
+#: ``incidents.SESSION_INCIDENT_MESSAGE_TYPE``, spelled out rather than
+#: imported. This module's contract (see the module docstring, and
+#: ``tests/unit/test_import_graph.py``) is that importing it drags in nothing —
+#: not the engine, not the providers, not ``asyncio`` — because it is on the
+#: path of ``local-operator --help`` and of every picker row. ``incidents`` is
+#: a cheap module today, but the guard is about the GRAPH, not about today's
+#: cost, and a literal keeps this module's import list empty.
+#:
+#: The duplication is pinned by a test that imports both and asserts they are
+#: equal, so a rename cannot silently turn this scan into one that matches
+#: nothing (which would degrade to the house sentence and look like "this
+#: session had no failure" rather than like a bug).
+_SESSION_INCIDENT_TYPE = "session_incident"
+
 #: The marker that says a fragment is a user message, and the first COMPLETE
 #: JSON string value of a ``text`` key. Both tolerate whitespace around the
 #: colon: the session writer emits compact JSON, but a transcript written by
@@ -1949,6 +1963,69 @@ def session_preview(session_dir: Path, *, max_chars: int = PREVIEW_MAX_CHARS) ->
     missing, unreadable, or contains no assistant text, and the caller renders
     its own empty state.
     """
+    for entry in _tail_entries(session_dir):
+        if entry.get("type") != "message":
+            continue
+        payload = entry.get("payload")
+        if not isinstance(payload, dict) or payload.get("role") != "assistant":
+            continue
+        text = _first_text(payload.get("content"))
+        if text.strip():
+            return _condense(text, max_chars)
+    return ""
+
+
+def session_failure_summary(session_dir: Path, *, max_chars: int = PREVIEW_MAX_CHARS) -> str:
+    """The raw text of this session's most recent failure, or ``""``.
+
+    The conversation-list preview answers "where did it get to"; this answers
+    "what went wrong", for the one banner where the first question has no
+    honest answer. A notification that says only "Stopped with an error" tells
+    the user a thing they must act on while withholding the only fact that
+    would let them act — whether to top up a quota, fix a credential, or simply
+    retry (design round 1, D4).
+
+    Read from the ``session_incident`` record's ``details.raw``, which is the
+    UNRENDERED provider text. Deliberately not ``details.text``: that is the
+    formatted model-facing block, several lines long and tailed with "This is
+    why the previous turn ended. Take it into account before repeating the same
+    request." — an instruction addressed to the model, which on a lock screen
+    reads as nonsense. ``raw`` is the sentence a human wants.
+
+    No new durable path is introduced. ``incidents.py`` already journals this
+    record on every classified failure, precisely so a resumed session can
+    explain itself, and it is persisted for the same reason this needs it.
+
+    Bounded and tolerant exactly like :func:`session_preview`, and for the same
+    reasons — it shares that function's tail window, so the cost is the same
+    single bounded read and is independent of transcript size. Returns ``""``
+    for a missing, unreadable or incident-free transcript, and the caller falls
+    back to the house sentence.
+    """
+    for entry in _tail_entries(session_dir):
+        payload = entry.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("custom_type") != _SESSION_INCIDENT_TYPE:
+            continue
+        details = payload.get("details")
+        if not isinstance(details, dict):
+            continue
+        raw = details.get("raw")
+        if isinstance(raw, str) and raw.strip():
+            return _condense(raw, max_chars)
+    return ""
+
+
+def _tail_entries(session_dir: Path) -> list[dict[str, Any]]:
+    """Parsed entries from the transcript's tail window, NEWEST FIRST.
+
+    Factored out of :func:`session_preview` when
+    :func:`session_failure_summary` needed the identical scan: one bounded
+    seek, the first (fragment) line dropped, newest-first iteration, and every
+    unparseable line skipped because a live writer may be mid-append. Two
+    copies of that would be two places for the window arithmetic to drift.
+    """
     transcript = session_dir / TRANSCRIPT_NAME
     try:
         size = transcript.stat().st_size
@@ -1963,7 +2040,8 @@ def session_preview(session_dir: Path, *, max_chars: int = PREVIEW_MAX_CHARS) ->
             else:
                 window = handle.read()
     except OSError:
-        return ""
+        return []
+    entries: list[dict[str, Any]] = []
     for line in reversed(window.decode("utf-8", "replace").splitlines()):
         line = line.strip()
         if not line:
@@ -1974,15 +2052,9 @@ def session_preview(session_dir: Path, *, max_chars: int = PREVIEW_MAX_CHARS) ->
             # Normal for a live session: the writer appends and we may read
             # mid-write, so the final line can be half-written.
             continue
-        if not isinstance(entry, dict) or entry.get("type") != "message":
-            continue
-        payload = entry.get("payload")
-        if not isinstance(payload, dict) or payload.get("role") != "assistant":
-            continue
-        text = _first_text(payload.get("content"))
-        if text.strip():
-            return _condense(text, max_chars)
-    return ""
+        if isinstance(entry, dict):
+            entries.append(entry)
+    return entries
 
 
 def _first_text(content: object) -> str:

--- a/local_operator/server/models/desktop_sessions.py
+++ b/local_operator/server/models/desktop_sessions.py
@@ -112,6 +112,21 @@ class WatchReceipt(BaseModel):
     lease_seconds: Literal[45]
 
 
+class NotificationClaim(BaseModel):
+    """Whether THIS surface may raise the banner for one completion.
+
+    ``false`` is an ordinary answer, not an error: another observer on this
+    machine (a TUI watching the same session) claimed it first, or the token is
+    unknown to the store. Either way the caller's correct behaviour is the
+    same — stay quiet — so the distinction is deliberately not reported.
+
+    Says nothing about whether the user READ anything: the claim writes the
+    delivery watermark only, and the sidebar's unseen mark survives it.
+    """
+
+    claimed: bool
+
+
 class AttentionState(BaseModel):
     """The shared read watermark, mirrored by the UI's `CompletionAttention`.
 

--- a/local_operator/server/routes/capabilities.py
+++ b/local_operator/server/routes/capabilities.py
@@ -34,6 +34,14 @@ async def capabilities():
                 # runtime record's capability LIST is a different namespace and
                 # keeps its versioned `completion-ack-v1` string.
                 "completion_ack": 1,
+                # The `notification` frame's payload shape. A renderer that
+                # sees this owns every completion banner and must stop toasting
+                # on `agent_end`, or the user gets two for one turn; a renderer
+                # that does not see it is talking to a backend that composes
+                # nothing and keeps its legacy path. Absent is therefore a
+                # meaningful answer, which is why this is a plain integer
+                # rather than a boolean with a default.
+                "notification_contract": 1,
                 "mcp": 1,
                 "radient": 1,
             },

--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -31,6 +31,7 @@ from local_operator.server.models.desktop_sessions import (
     CreatedSession,
     HistoryPage,
     MessageAdmission,
+    NotificationClaim,
     SessionList,
     SessionSnapshot,
     WatchReceipt,
@@ -84,6 +85,15 @@ class Input(BaseModel):
 class Seen(Input):
     # A durable completion UUID is the only admission: timestamps or a caller's
     # runtime epoch could accidentally acknowledge a later, unseen outcome.
+    completion_token: RequestID
+
+
+class Notified(Input):
+    # Same admission as `Seen`, and for the same reason: a durable completion
+    # UUID is the only identity that survives a runtime epoch, so nothing a
+    # caller can invent (a timestamp, its own epoch) may enter the watermark.
+    # The two routes are otherwise unrelated — this one claims the right to
+    # notify and NEVER acknowledges a read.
     completion_token: RequestID
 
 
@@ -518,6 +528,28 @@ async def answer(session_id: str, body: Answer, request: Request):
 async def seen(session_id: str, body: Seen, request: Request):
     async with errors():
         return reply(await host(request).acknowledge_attention(session_id, body.completion_token))
+
+
+@router.post(
+    "/v1/desktop/sessions/{session_id}/notified", response_model=CRUDResponse[NotificationClaim]
+)
+async def notified(session_id: str, body: Notified, request: Request):
+    """Claim the right to raise ONE banner for one completion.
+
+    Called by the desktop app immediately before it constructs the OS
+    notification, and only then: claim-then-deliver means the claimant has to
+    be the deliverer, so a renderer that is going to suppress the banner
+    (focused window, stale dedupe key) must not reach here. A claim taken for a
+    toast nobody sees is delivered-to-nobody forever, and no other surface can
+    ever pick it up.
+
+    Cold and receipt-free, unlike ``/seen`` beside it: no bridge is acquired,
+    no runtime is started, and neither ``unseen`` nor the read watermark moves.
+    Notifying is not reading.
+    """
+    async with errors():
+        claimed = await host(request).claim_notification(session_id, body.completion_token)
+        return reply({"claimed": claimed})
 
 
 @router.post("/v1/desktop/sessions/{session_id}/watch", response_model=CRUDResponse[WatchReceipt])

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -359,8 +359,11 @@ class DesktopSessionBridge:
                     # bridge's sequence: `acquire()` mints a new epoch and
                     # resets `sequence` to 0 after a detached interval, so a
                     # seq-keyed dedupe re-toasts the same completion on every
-                    # reconnect.
-                    "dedupe_key": f"complete:{self.session_id}:{token}",
+                    # reconnect. The prefix is the frame's own kind (round 1,
+                    # n1): a token has exactly one kind, so it costs nothing,
+                    # and a store or dedupe-map dump no longer reads as an
+                    # error banner mislabelled `complete:`.
+                    "dedupe_key": f"{composed.kind}:{self.session_id}:{token}",
                     "completion_token": token,
                     "session_name": composed.title if composed.title_is_session_name else None,
                     "focus_policy": "when_unfocused",

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -52,6 +52,21 @@ SUBSCRIBER_COUNT = 32
 BRIDGE_COUNT = 64
 WATCH_TTL = 45.0
 
+#: The completion kinds the DESKTOP BRIDGE may put on the wire as a
+#: ``notification`` frame. Narrower than ``NotificationKind`` on purpose.
+#:
+#: ``ask``/``approval`` are absent because they already reach the desktop as
+#: ``pending_gate`` in the snapshot and update frames, and a second channel for
+#: the same card is the duplicate this whole contract exists to prevent.
+#:
+#: ``interrupted`` is absent because the user pressed Ctrl+C or Esc a moment
+#: ago and already knows — telling them their own stop worked is the definition
+#: of a notification nobody wants, which is the same call the TUI already
+#: makes. The counter-argument (on the desktop an interruption can come from
+#: another surface) is real but undecidable here: ``AgentEndEvent`` carries
+#: ``aborted`` with no actor. One frozenset entry away if that ever changes.
+BRIDGE_NOTIFIABLE_KINDS = frozenset({"complete", "error"})
+
 
 async def _no_takeover() -> None:
     raise RuntimeError("Desktop viewers cannot own a runtime")
@@ -169,7 +184,25 @@ class DesktopSessionBridge:
         sub.queued_bytes = 0
         sub.queue.put_nowait(None)
 
-    def publish(self, kind: str, payload: dict[str, Any]) -> None:
+    def publish(self, kind: str, payload: dict[str, Any], *, replay: bool = True) -> None:
+        """Put one frame on every live subscriber, and normally into replay.
+
+        ``replay=False`` publishes LIVE ONLY. It exists for the ``notification``
+        frame, whose whole value is timeliness: replaying it on reconnect toasts
+        the user about a turn that finished while their laptop lid was shut,
+        possibly hours later. The durable signal for "you missed something" is
+        not lost — the ``attention`` frame and the sidebar's unseen mark both
+        survive a reconnect and are the right surface for it.
+
+        THE SEQUENCE STILL ADVANCES for a non-replayed frame, and that is
+        load-bearing rather than incidental. :meth:`events` computes ``gap``
+        from ``after_seq < first - 1`` where ``first`` is the oldest RETAINED
+        frame's seq, so a skipped seq simply never becomes ``first`` and a
+        client reconnecting at the notification's own cursor still satisfies
+        the test against the next retained frame. Not incrementing would
+        instead make ``seq`` non-monotonic across the two paths and break the
+        receipt cursor every renderer keeps.
+        """
         self.sequence += 1
         frame = {
             "session_id": self.session_id,
@@ -179,11 +212,14 @@ class DesktopSessionBridge:
             "payload": payload,
         }
         size = len(json.dumps(frame, separators=(",", ":")).encode())
-        self.replay.append((frame, size))
-        self.replay_bytes += size
-        while self.replay and (len(self.replay) > REPLAY_COUNT or self.replay_bytes > REPLAY_BYTES):
-            _, removed = self.replay.popleft()
-            self.replay_bytes -= removed
+        if replay:
+            self.replay.append((frame, size))
+            self.replay_bytes += size
+            while self.replay and (
+                len(self.replay) > REPLAY_COUNT or self.replay_bytes > REPLAY_BYTES
+            ):
+                _, removed = self.replay.popleft()
+                self.replay_bytes -= removed
         for sub in self.subscribers.values():
             if sub.overflow:
                 continue
@@ -232,7 +268,107 @@ class DesktopSessionBridge:
             # own receipt clock rather than borrowing a runtime sequence.
             if previous:
                 self.publish("attention", state)
+                # THE NOTIFICATION EDGE, published AFTER the attention frame so
+                # a reader that toasts already holds the receipt state that
+                # explains the toast. The same `previous` baseline rule governs
+                # both: a bridge's FIRST read is the session's history, not
+                # news, and opening a conversation must not announce the
+                # completion it ended on last week.
+                await self._maybe_publish_notification(previous, state)
         return state
+
+    async def _maybe_publish_notification(
+        self, previous: dict[str, Any], state: dict[str, Any]
+    ) -> None:
+        """Turn a newly published, unseen completion into one notification frame.
+
+        THE AUTHORITY IS THE ATTENTION PUBLICATION, not any engine event. A
+        `completions` row exists only because ``Session._publish_attention_
+        outcome`` decided the turn produced a notifiable outcome — in the
+        process that owns the job manager, using the same delegated-children
+        check the TUI uses (``job.type == "task" and job.status == "running"``).
+        A delegating parent's premature ``agent_end`` writes an ``eligible:
+        False`` marker and publishes nothing, so there is simply no row for the
+        bridge to see, and each settled child re-enters as a fresh turn whose
+        own completion publishes normally.
+
+        That is why this method asks no questions about jobs, ``agent_end`` or
+        ``turn_end``: reconstructing the decision here would mean making it
+        again in a process with less information, which is how a frontend ends
+        up disagreeing with the TUI about whether a turn finished. The bridge
+        OBSERVES the decision; it does not judge it.
+
+        NO CLAIM IS TAKEN HERE. ``claim_delivery`` is claim-then-deliver, and
+        the claimant must be the deliverer — between this frame and an OS
+        banner lie an SSE socket, the Electron main process, a support check
+        and a focus gate. A claim taken here that the renderer then suppresses
+        would mark the completion delivered while nobody was told, for good. A
+        frame is an OFFER; the renderer claims through ``POST /notified``
+        immediately before it shows the banner.
+
+        Guarded end to end: a notification is chrome, and this runs inside the
+        1 s attention poll whose loop already treats a store error as costing
+        one tick rather than the feature.
+        """
+        token = state.get("completion_token")
+        if (
+            not token
+            or token == previous.get("completion_token")
+            or not state.get("unseen")
+            or state.get("kind") not in BRIDGE_NOTIFIABLE_KINDS
+        ):
+            return
+        try:
+            from local_operator.notifications import (
+                NOTIFICATION_CONTRACT_VERSION,
+                compose,
+            )
+
+            # The LIVE name wins over the sidecar: a rename reaches frontend
+            # state before it reaches `title.json`, and `compose` falls back to
+            # the stored title on its own when this is empty (a cold bridge has
+            # no runtime to ask).
+            remote = self.remote
+            session_name = ""
+            if remote is not None:
+                session_name = getattr(remote.frontend_state, "conversation_title", "") or ""
+            # `compose` reads up to 128 KiB for the title and 64 KB for the
+            # preview, and `refresh_attention` runs on the event loop. Off-loop
+            # for the same reason the store read above is.
+            composed = await asyncio.to_thread(
+                compose,
+                state["kind"],
+                session_dir=self.root / "sessions" / self.session_id,
+                session_name=session_name,
+            )
+            self.publish(
+                "notification",
+                {
+                    "contract": NOTIFICATION_CONTRACT_VERSION,
+                    "kind": composed.kind,
+                    "title": composed.title,
+                    "status": composed.status,
+                    "body": composed.body,
+                    "body_is_snippet": composed.body_is_snippet,
+                    # Additive since the first draft of this frame; a renderer
+                    # that does not know the field simply shows the body, which
+                    # is already the right thing to do with it.
+                    "body_is_failure": composed.body_is_failure,
+                    "title_is_session_name": composed.title_is_session_name,
+                    # Keyed on the DURABLE completion token rather than on this
+                    # bridge's sequence: `acquire()` mints a new epoch and
+                    # resets `sequence` to 0 after a detached interval, so a
+                    # seq-keyed dedupe re-toasts the same completion on every
+                    # reconnect.
+                    "dedupe_key": f"complete:{self.session_id}:{token}",
+                    "completion_token": token,
+                    "session_name": composed.title if composed.title_is_session_name else None,
+                    "focus_policy": "when_unfocused",
+                },
+                replay=False,
+            )
+        except Exception:  # noqa: BLE001 — chrome must not cost the attention poll
+            logger.debug("notification compose failed for %s", self.session_id, exc_info=True)
 
     async def _poll_attention(self) -> None:
         # Read-only polling is shared by every subscriber of this bridge and
@@ -483,6 +619,45 @@ class DesktopSessions:
             )
 
         return await asyncio.to_thread(acknowledge)
+
+    async def claim_notification(self, session_id: str, token: str) -> bool:
+        """Claim the right to TOAST ``token``; exactly one surface ever wins.
+
+        NOTIFYING IS NOT READING, and this is the boundary that keeps the two
+        watermarks apart. ``claim_delivery`` writes ``deliveries`` only: the
+        sidebar's unseen mark and ``receipts.acknowledged`` are untouched, so a
+        session the user was merely *told about* stays unread until they
+        actually open it. Routing this through :meth:`acknowledge_attention`
+        instead would clear the mark for a conversation nobody looked at, which
+        is the one thing ``docs/ATTENTION.md`` forbids outright.
+
+        Cold path, exactly like :meth:`acknowledge_attention`: same session-id
+        validation, no bridge acquire, no runtime spawn. A completion worth
+        announcing is usually one whose owner has already exited, and a banner
+        is never a reason to start a process.
+
+        ``backend="desktop"`` names the claimant. The column is diagnostics
+        only — no decision may read it, because a claim that consulted anything
+        beyond the monotonic sequence would stop being clock-free — but naming
+        it correctly is what makes a store dump readable when two surfaces
+        disagree about who toasted.
+
+        Returns ``False`` for an unknown or foreign token rather than raising:
+        the caller's next step is "show or do not show a banner", and a
+        surface that cannot claim simply stays quiet.
+        """
+
+        def claim() -> bool:
+            if not SESSION_ID.fullmatch(session_id):
+                raise KeyError("Unknown session")
+            path = self.root / "sessions" / session_id
+            if not path.is_dir() or not is_user_session(path):
+                raise KeyError("Unknown session")
+            return AttentionStore(self.root / "attention.db").claim_delivery(
+                f"session/{session_id}", token, "desktop"
+            )
+
+        return await asyncio.to_thread(claim)
 
     async def attachment(self, session_id: str, digest: str) -> tuple[bytes, str]:
         """Decoded bytes and mime type for one content-addressed attachment.

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -902,6 +902,25 @@ class PendingGateState(BaseModel):
     secret: bool = False
     question_index: int = 0
     question_total: int = 1
+    #: The conversation's name, for a surface that renders this card as a
+    #: NOTIFICATION rather than in the session it belongs to. A desktop banner
+    #: saying only "Waiting for approval" cannot be triaged: with several
+    #: sessions open the user cannot tell which run is being held hostage
+    #: without opening each one (design round 1, D3).
+    #:
+    #: EMPTY when ``display.notification_session_name`` is off, and the
+    #: emptiness is decided in the BACKEND for the same reason every other
+    #: notification fact is: only the backend can read that setting, and a
+    #: renderer re-deriving the privacy rule is a renderer that can get it
+    #: wrong in a signed binary the user updates on their own schedule.
+    #:
+    #: ADDITIVE AND DEFAULTED, in both skew directions. An old viewer reading a
+    #: new payload ignores a key it does not know; a new viewer reading an old
+    #: payload gets ``""`` and falls back to the anonymous card it already
+    #: renders. Gates deliberately keep travelling on THIS path rather than
+    #: gaining a ``notification`` frame of their own — a second channel for a
+    #: card the app already receives is how one question becomes two banners.
+    session_name: str = ""
 
 
 class _FrozenSequence(tuple[Any, ...]):

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -3409,7 +3409,16 @@ class RuntimeServer:
         frontend = getattr(self._handle, "_frontend", None)
         mutate = getattr(frontend, "mutate", None)
         if callable(mutate):
-            mutate(pending_gate=pending.to_json() if pending is not None else None)
+            payload = pending.to_json() if pending is not None else None
+            if payload is not None:
+                # Same stamp as `ServingSessionHandle._publish_pending_gate`,
+                # through the handle's own helper so the privacy gate cannot
+                # hold on one publication site and not the other. Reduced hosts
+                # reach the gate contract through here, and a desktop banner
+                # raised from one of them must be as triageable as any other.
+                namer = getattr(self._handle, "_notifiable_session_name", None)
+                payload["session_name"] = namer() if callable(namer) else ""
+            mutate(pending_gate=payload)
         self._schedule_push()
 
 

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -2299,7 +2299,6 @@ class ServingSessionHandle(SessionHandle):
         try:
             from local_operator.tui.notify import (
                 APP_NAME,
-                BODIES,
                 CONTEXTS,
                 detached_notify,
                 sanitize_text,
@@ -2330,22 +2329,17 @@ class ServingSessionHandle(SessionHandle):
             # render as the bare word "question" with no hint it was a
             # question rather than an approval.
             #
-            # NOT `f"{title}: {detail}"`. A tool's `describe_approval` already
-            # leads with its own action word (`_describe_path_approval` emits
-            # "write: /path"), and the title IS the tool name, so prefixing
-            # rendered every approval toast as "write: write: /path" — on the
-            # release's headline surface, every time (round 4, Q3).
-            subject = (detail or "").strip()
-            if not subject:
-                # No description at all: the tool name alone ("write") says
-                # less than the shared vocabulary below, so leave it empty and
-                # let BODIES answer.
-                subject = ""
-            elif title and not subject.lower().startswith(title.lower()):
-                subject = f"{title}: {subject}".strip().rstrip(":").strip()
+            # Composed by `notifications.compose.gate_body` rather than inline,
+            # so this leg and every other gate surface cannot drift: the rule it
+            # carries (never `f"{title}: {detail}"`, because a tool's
+            # `describe_approval` already leads with its own action word and the
+            # title IS the tool name — round 4, Q3) is one that was fixed here
+            # once and would have to be re-fixed in each new surface otherwise.
+            from local_operator.notifications import gate_body
+
             detached_notify(
                 name,
-                subject or BODIES.get(kind, ""),
+                gate_body(kind, title, detail),
                 session_id=self._session_id_for_resume(),
                 subtitle=CONTEXTS.get(kind, ""),
             )
@@ -2393,9 +2387,45 @@ class ServingSessionHandle(SessionHandle):
             # into the queue, so both surfaces can never disagree about which
             # card is current.
             front = self._projection.pending
-            store.mutate(pending_gate=front.to_json() if front is not None else None)
+            payload = front.to_json() if front is not None else None
+            if payload is not None:
+                # The card gains the session's name so a DESKTOP banner for it
+                # can be triaged: "Waiting for approval" with three sessions
+                # open names none of them (design round 1, D3). Stamped here
+                # rather than inside `PendingRequest` because the name is a
+                # property of the SESSION, not of the question, and because the
+                # privacy gate belongs on the publication boundary where every
+                # other notification fact is decided.
+                payload["session_name"] = self._notifiable_session_name()
+            store.mutate(pending_gate=payload)
         except Exception:  # noqa: BLE001 — a card is never worth failing a gate
             logger.debug("could not publish the pending gate", exc_info=True)
+
+    def _notifiable_session_name(self) -> str:
+        """This conversation's name, or ``""`` when banners may not carry it.
+
+        One helper for both gate-publication sites, because the privacy rule
+        must not be able to hold on one and not the other — that asymmetry is
+        exactly the defect ``notify.py``'s own flag documentation records
+        (review round 1, M2: a flag that governed only some banners made its
+        settings copy false).
+
+        Sanitised on the way out for the same reason every other name-bearing
+        path sanitises: it is model-written and reaches argv and an AppleScript
+        literal on the surfaces that render it.
+        """
+        try:
+            from local_operator.tui.notify import (
+                sanitize_text,
+                session_names_in_notifications,
+            )
+
+            if not session_names_in_notifications():
+                return ""
+            return sanitize_text(getattr(self._session, "conversation_name", "") or "")
+        except Exception:  # noqa: BLE001 — a name is chrome; the gate is not
+            logger.debug("could not resolve the gate's session name", exc_info=True)
+            return ""
 
     async def fork_snapshot(self, message: str) -> dict[str, Any]:
         """Snapshot THIS authenticated owner, never a client-supplied path/id."""

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -1246,11 +1246,22 @@ SETTINGS: tuple[Setting, ...] = (
         kind=Kind.BOOL,
         default=True,
         # Leads with the CONSEQUENCE, not the mechanism: the decision being
-        # asked for is whether a model-written session name appears on a lock
-        # screen, which is the one fact that changes someone's answer. The
-        # neighbours ("Fires only while the terminal is unfocused.") are worded
-        # the same way (design round 1, D6).
-        help="A session's name appears on banners, including the lock screen.",
+        # asked for is whether model-written content (session name, last
+        # line, error cause) appears on a lock screen, which is the one fact
+        # that changes someone's answer. The neighbours ("Fires only while
+        # the terminal is unfocused.") are worded the same way (design
+        # round 1, D6). All three legs are named because this flag gates
+        # banner BODIES too, not just names (design round 2, D1): OFF drops
+        # the error cause that makes an error banner actionable, and a row
+        # that hides that trade surprises someone who turns it off.
+        # Implicit concatenation keeps the rendered string one sentence while
+        # holding the line under the 100-column flake8/black budget; a
+        # `noqa: E501` on the joined form is reserved in this repo for
+        # unsplittable content (URLs, embedded code), not prose.
+        help=(
+            "A session's name, last line and error causes appear on banners, "
+            "including the lock screen."
+        ),
         # `off` no longer means "app name only" on every route — a background
         # session with no stored title is titled "A session finished" — so the
         # label names what the user gets rather than a fallback that is now one

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -340,6 +340,7 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
     from local_operator.herdr import HerdrReporter
     from local_operator.info.collect import LiveState
     from local_operator.multiplexer import SessionBroadcast
+    from local_operator.notifications import ComposedNotification, NotificationKind
     from local_operator.providers.controller import CatalogueEntry
     from local_operator.providers.oauth.callback_server import LoginCallbacks
     from local_operator.skills.discovery import Skill
@@ -18850,16 +18851,73 @@ class OperatorApp(App[None]):
         if notifier is None:
             return False
         try:
-            notifier.set_label(self._notify_label())
+            label = self._notify_label()
+            notifier.set_label(label)
+            # COMPOSED BY THE SHARED COMPOSER, so the banner a user gets for
+            # the session they are IN says as much as the one the background
+            # observer already sent for a session they were not in — that
+            # asymmetry was backwards. The composer owns the privacy gate and
+            # the budgets; this method only forwards what it produced.
+            #
+            # INLINE, NOT IN A WORKER, and that is measured rather than
+            # assumed: `compose` reads a bounded transcript tail, and over a
+            # 42 MB transcript it runs in 0.19 ms median / 0.31 ms worst of 20
+            # runs on the maintainer's machine. That is two orders of magnitude
+            # under a frame, so posting it to a thread would buy nothing and
+            # cost the turn-end toast a scheduling hop.
+            composed = self._composed_notification(kind, label)
+            body = composed.body if composed is not None else ""
             if kind == "complete":
-                return notifier.notify_turn_complete(running_children=running_children or 0)
+                return notifier.notify_turn_complete(
+                    running_children=running_children or 0, body=body
+                )
             if kind == "error":
-                return notifier.notify_error()
+                return notifier.notify_error(body=body)
             if kind in ("approval", "ask"):
-                return notifier.notify_waiting(kind)
+                return notifier.notify_waiting(kind, body=body)
         except Exception:  # pragma: no cover - defensive; chrome must not raise
             logger.debug("notification delivery failed", exc_info=True)
         return False
+
+    def _composed_notification(self, kind: str, label: str) -> ComposedNotification | None:
+        """The composed banner text for this session's own edge, or ``None``.
+
+        ``None`` rather than a raise for a session with no resolvable id, which
+        leaves the caller on the house vocabulary it used before this existed.
+
+        The directory is derived from the session ID through ``config_dir()``,
+        the way :meth:`_background_completion_identity` and its neighbours on
+        the observer path already derive it — NOT from ``session.transcript``.
+        That attribute exists on the concrete owner ``Session`` and not on
+        ``AttachedSession``, so reading it here would compose correctly for an
+        owner and silently degrade every VIEWER's banner to the house sentence:
+        a surface that fails only on the viewer path, which is the exact shape
+        of the ``/team`` and ``/agent`` regression the viewer-protocol tests
+        exist to catch. The id is on both.
+
+        The GATE kinds are composed WITHOUT `gate_title`/`gate_detail`, so they
+        resolve to the same house sentence an attached terminal has always
+        shown for a parked question. The action text the composer can render
+        for a gate belongs to the detached runtime's fallback — a different
+        surface, reached only when nothing is watching — and threading the live
+        gate down here would mean carrying state this path does not hold, for a
+        banner the user is looking at the terminal for anyway.
+        """
+        from local_operator.paths import config_dir
+
+        session = self._session
+        session_id = getattr(session, "session_id", "") if session is not None else ""
+        if not session_id:
+            return None
+        directory = config_dir() / "sessions" / session_id
+
+        from local_operator.notifications import compose
+
+        # `kind` is a plain `str` on this funnel because its call sites name
+        # engine events; every value that reaches here is a CONTEXTS key, and
+        # `compose` itself degrades a stray one to the complete vocabulary
+        # rather than raising.
+        return compose(cast("NotificationKind", kind), session_dir=directory, session_name=label)
 
     def _adopt_own_interrupt_notice(self, kind: str, anchor: str) -> bool:
         """Stamp a published outcome onto the row this app already painted.

--- a/local_operator/tui/notify.py
+++ b/local_operator/tui/notify.py
@@ -57,6 +57,17 @@ systems rather than defensiveness:
   *backend* runs on, which is not necessarily where the user is. This module is
   imported only from ``tui/`` for that reason, and :class:`Notifier` still
   refuses to construct without a live driver sink.
+
+  The server now *composes* notification content for that UI, which is a
+  different verb and does not weaken the rule. ``local_operator/notifications/
+  compose.py`` renders ``{title, status, body}`` from this module's vocabulary
+  and puts it on the desktop wire as a ``notification`` frame; the Electron
+  main process decides whether to raise a banner and raises it. Only the
+  backend can read ``display.notification_session_name``, so only the backend
+  can decide whether a banner may carry a session's name or a line of its
+  content — but nothing outside ``tui/`` writes an escape sequence, spawns
+  ``notify-send`` or constructs an OS notification. Composition lives in its
+  own module rather than here precisely so that this import rule stays a rule.
 - **Only when unfocused** (:attr:`Notifier.set_focused`). A toast for a session
   the user is already staring at is pure interruption; Textual reports focus
   through ``AppFocus``/``AppBlur``, which every terminal here supports.
@@ -1044,7 +1055,7 @@ class Notifier:
         """Record terminal focus, from ``AppFocus``/``AppBlur``."""
         self._focused = focused
 
-    def notify_turn_complete(self, *, running_children: int) -> bool:
+    def notify_turn_complete(self, *, running_children: int, body: str = "") -> bool:
         """The parent finished a turn. Returns whether a toast was delivered.
 
         ``running_children`` is the count of live ``task`` jobs, and it is the
@@ -1065,9 +1076,9 @@ class Notifier:
         """
         if running_children > 0:
             return False
-        return self.send("complete")
+        return self.send("complete", body=body)
 
-    def notify_waiting(self, kind: Literal["approval", "ask"]) -> bool:
+    def notify_waiting(self, kind: Literal["approval", "ask"], *, body: str = "") -> bool:
         """The turn is parked on the user. Returns whether a toast was delivered.
 
         Unconditional on subagents, unlike completion: an unanswered approval
@@ -1075,19 +1086,28 @@ class Notifier:
         where a missed notification costs the most — the session sits parked
         indefinitely, which is exactly how an agent run gets abandoned.
         """
-        return self.send(kind)
+        return self.send(kind, body=body)
 
-    def notify_error(self) -> bool:
+    def notify_error(self, *, body: str = "") -> bool:
         """The turn stopped with an error. Returns whether a toast was delivered."""
-        return self.send("error")
+        return self.send("error", body=body)
 
-    def send(self, kind: NotifyKind) -> bool:
+    def send(self, kind: NotifyKind, *, body: str = "") -> bool:
         """Deliver one notification of ``kind``; return whether anything was sent.
 
         The gates, in order of cheapness: disabled, focused (nothing to tell a
         user who is looking at the session), then delivery. cmux is checked
         before the in-band write because cmux hosts Ghostty — both paths would
         otherwise fire and the user would be told twice about one event.
+
+        ``body`` overrides the house sentence from :data:`BODIES` when supplied.
+        It arrives already composed and sanitised by ``notifications.compose``,
+        and this method does NOT re-derive the privacy gate for it: the composer
+        read the flag at the same instant it read the text, and a second read
+        here could disagree with the very text it is gating. It closes an
+        asymmetry the app had — the background OBSERVER path already sent a
+        transcript snippet, so a user got a richer banner for a session they
+        were not in than for the one they were.
         """
         if not self._enabled:
             return False
@@ -1099,17 +1119,32 @@ class Notifier:
         # name for the rest of a session that had just turned it off.
         title = (self._label if session_names_in_notifications() else "") or APP_NAME
         subtitle = CONTEXTS.get(kind, CONTEXT_COMPLETE)
-        body = BODIES.get(kind, BODY_COMPLETE)
+        #: The HOUSE sentence, and the only body the in-band leg below is ever
+        #: allowed to carry. Kept in its own name so the two cannot be confused
+        #: by a later edit.
+        house = BODIES.get(kind, BODY_COMPLETE)
+        composed = body or house
 
         surface = cmux_surface_id(self._env)
         if surface is not None:
-            _spawn_detached(cmux_command(surface, title, subtitle, body))
+            _spawn_detached(cmux_command(surface, title, subtitle, composed))
             return True
 
+        # THE OSC LEG KEEPS THE HOUSE SENTENCE, deliberately, and this is the
+        # one place in this method where the composed body must not be
+        # substituted. `notification_writes` builds an in-band escape sequence,
+        # and an escape sequence is the one wire here where model-written text
+        # could close the sequence early and leave the remainder executing as
+        # terminal commands. `sanitize_text` already strips ESC and BEL, so this
+        # is defence in depth rather than the only guard — but "model text never
+        # reaches an OSC string" is an invariant worth keeping structurally
+        # instead of resting on one regex. The cmux leg above and the D-Bus leg
+        # below take the composed body because both pass it as an argv element,
+        # where the escaping is the OS's and the risk is different.
         for chunk in notification_writes(
             self._protocol,
             title,
-            body,
+            house,
             in_tmux=is_inside_tmux(self._env),
             in_zellij=is_inside_zellij(self._env),
         ):
@@ -1118,5 +1153,5 @@ class Notifier:
         if should_use_desktop_fallback(self._protocol, self._platform, self._env):
             notifier = shutil.which("notify-send")
             if notifier:
-                _spawn_detached(desktop_notify_command(notifier, title, body, URGENCY))
+                _spawn_detached(desktop_notify_command(notifier, title, composed, URGENCY))
         return True

--- a/tests/e2e/test_desktop_sessions.py
+++ b/tests/e2e/test_desktop_sessions.py
@@ -627,7 +627,11 @@ async def test_a_real_turn_emits_exactly_one_notification_after_many_turn_ends(
             assert payload["body"] == "Wrote the report to notification-evidence.txt."
             assert payload["body_is_snippet"] is True
             assert payload["completion_token"]
-            assert payload["dedupe_key"] == f"complete:{sid}:{payload['completion_token']}"
+            # Prefix is the frame's own kind (round 1, n1) — pinned relative to
+            # the kind asserted just above rather than as a separate literal.
+            assert payload["dedupe_key"] == (
+                f"{payload['kind']}:{sid}:{payload['completion_token']}"
+            )
             # The banner follows the receipt state that explains it.
             assert [f["type"] for f in frames].index("attention") < [
                 f["type"] for f in frames

--- a/tests/e2e/test_desktop_sessions.py
+++ b/tests/e2e/test_desktop_sessions.py
@@ -10,6 +10,7 @@ import os
 import secrets
 import socket
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -19,7 +20,7 @@ from local_operator.mobile.attach_client import AttachClient
 from local_operator.server.app import app
 from local_operator.session.runtime.server import RuntimeServer
 from local_operator.session.runtime.serving import ServingSessionHandle
-from tests.e2e.harness import ScriptedStream, build_session, text_turn
+from tests.e2e.harness import ScriptedStream, build_session, text_turn, tool_call_turn
 
 pytestmark = pytest.mark.e2e
 
@@ -99,6 +100,10 @@ async def test_canonical_desktop_over_http(headless_tui_env: Path, workspace: Pa
                 ]
             )
             session = build_session(root / "sessions" / sid, stream, cwd=workspace)
+            # Named so the gate assertion further down is a real one: an
+            # unnamed session would publish an empty `session_name` and the
+            # D3 check would pass vacuously.
+            session.set_conversation_name("HTTP contract run", user_set=True)
             from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
 
             session.team_registry = TeamRegistry(root)
@@ -319,6 +324,13 @@ async def test_canonical_desktop_over_http(headless_tui_env: Path, workspace: Pa
                     and bool(f["payload"]["changes"].get("pending_gate")),
                 )
                 gate = gate_frame["payload"]["changes"]["pending_gate"]
+                # D3: a parked gate carries the conversation's name, so a
+                # desktop banner for it can be triaged. The card travels on
+                # THIS existing path rather than on a second notification
+                # channel, which is why the assertion belongs on the gate frame
+                # a real `_ask_gate` produced rather than on a new frame type.
+                assert gate["session_name"] == session.conversation_name
+                assert gate["session_name"], "a real parked gate published an anonymous card"
                 answer_body = {
                     "epoch": session.frontend_state.epoch,
                     "request_id": gate["request_id"],
@@ -452,6 +464,336 @@ async def test_canonical_desktop_over_http(headless_tui_env: Path, workspace: Pa
     finally:
         if terminal is not None:
             await terminal.detach()
+        server.should_exit = True
+        await asyncio.wait_for(serving, 30)
+        listener.close()
+        if runtime is not None:
+            await runtime.aclose()
+        if handle is not None:
+            await handle.dispose()
+
+
+async def collect_frames(lines, until, *, timeout: float = 30.0) -> list[dict[str, Any]]:
+    """Every frame up to and including the one `until` accepts.
+
+    The notification assertions below are about the CONTENTS OF A SEQUENCE —
+    "exactly one notification after N turn_ends", "zero notifications while a
+    child runs" — and `next_frame` cannot express either, because it discards
+    everything it skipped past. A frame log is the only shape in which "one"
+    and "none" are checkable at all.
+    """
+
+    async def read() -> list[dict[str, Any]]:
+        frames: list[dict[str, Any]] = []
+        async for line in lines:
+            if not line.startswith("data: "):
+                continue
+            frame = json.loads(line[6:])
+            frames.append(frame)
+            if until(frame):
+                return frames
+        raise AssertionError("stream ended before the expected frame")
+
+    return await asyncio.wait_for(read(), timeout)
+
+
+async def serve_app(listener, token: str):
+    """Start uvicorn on `listener` and wait until it is genuinely accepting."""
+    server = uvicorn.Server(uvicorn.Config(app, log_level="error"))
+    serving = asyncio.create_task(server.serve(sockets=[listener]))
+    for _ in range(10000):
+        if server.started:
+            break
+        if serving.done():
+            await serving
+        await asyncio.sleep(0)
+    assert server.started
+    return server, serving
+
+
+@pytest.mark.asyncio
+async def test_a_real_turn_emits_exactly_one_notification_after_many_turn_ends(
+    headless_tui_env: Path, workspace: Path, monkeypatch
+):
+    """The reported defect, proven fixed at the real transport.
+
+    THE DEFECT: the app toasted on every `turn_end` — which is ONE MODEL CALL,
+    not a finished turn — so an agentic turn that called a tool and then
+    answered produced a banner per step, each asserting "The agent finished its
+    turn." This drives exactly that shape (a `write` tool call, then a text
+    answer, so the loop emits two `turn_end`s) over real loopback HTTP with the
+    production Session/RuntimeServer/AttachClient and only the provider stream
+    scripted.
+
+    What is asserted is the ORDERED FRAME LOG, because the property is a count:
+    N `turn_end` frames, one `agent_end`, and exactly ONE `notification` — with
+    the model's own last line as its body, which is the content half of the
+    feature. A `next_frame`-style assertion could not fail on a second banner.
+    """
+    root = headless_tui_env
+    token = secrets.token_hex(32)
+    monkeypatch.setenv("LOCAL_OPERATOR_DESKTOP_TOKEN", token)
+    monkeypatch.delenv("LOCAL_OPERATOR_DESKTOP_ORIGINS", raising=False)
+    (root / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    server, serving = await serve_app(listener, token)
+    runtime = handle = None
+    try:
+        async with httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{listener.getsockname()[1]}", timeout=30
+        ) as client:
+            client.headers["Authorization"] = f"Bearer {token}"
+            path = "/v1/desktop/sessions"
+            created = await client.post(
+                path,
+                json={"request_id": "aaaaaaaa-1111-4111-8111-111111111111", "cwd": str(workspace)},
+            )
+            assert created.status_code == 200, created.text
+            sid = created.json()["result"]["session_id"]
+            target = path + "/" + sid
+
+            from local_operator.tools.builtin import build_write_tool
+
+            written = workspace / "notification-evidence.txt"
+            stream = ScriptedStream(
+                [
+                    tool_call_turn(
+                        text="Writing the report.",
+                        tool_name="write",
+                        tool_call_id="evidence-write",
+                        arguments={"path": str(written), "content": "done"},
+                    ),
+                    text_turn("Wrote the report to notification-evidence.txt."),
+                ]
+            )
+            session = build_session(
+                root / "sessions" / sid, stream, tools=[build_write_tool()], cwd=workspace
+            )
+            # NAMED UP FRONT, and not for cosmetics: an unnamed session fires
+            # the runtime's one-shot auto-naming errand, which is a real
+            # provider call and therefore consumes a `ScriptedStream` entry —
+            # shifting every scripted turn by one and collapsing the multi-step
+            # turn this test exists to produce. Naming it also makes the
+            # banner's title assertion below a real one.
+            session.set_conversation_name("Report run", user_set=True)
+            handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(workspace))
+            runtime = RuntimeServer(handle, kind="daemon")
+            await runtime.start_in_process()
+            (root / "sessions" / sid / ".session.pid").write_text(str(os.getpid()))
+
+            async with client.stream("GET", target + "/events") as response:
+                assert response.status_code == 200
+                lines = response.aiter_lines()
+                await next_frame(lines, lambda f: f["type"] == "snapshot")
+
+                admitted = await client.post(
+                    target + "/messages",
+                    json={
+                        "request_id": "bbbbbbbb-2222-4222-8222-222222222222",
+                        "text": "Write the report",
+                    },
+                )
+                assert admitted.status_code == 200, admitted.text
+
+                # The notification rides the 1 s attention poll, which fires
+                # AFTER `agent_end` — so the log has to run until the banner
+                # arrives, not until the turn ends.
+                frames = await collect_frames(
+                    lines, lambda f: f["type"] == "notification", timeout=45
+                )
+
+            kinds = [f["payload"].get("type") for f in frames if f["type"] == "event"]
+            notifications = [f for f in frames if f["type"] == "notification"]
+            turn_ends = kinds.count("turn_end")
+
+            # The shape the defect needs in order to be visible: MORE THAN ONE
+            # model call in one logical turn. Without this the test would pass
+            # against the buggy code too.
+            assert turn_ends >= 2, f"expected a multi-step turn, saw {kinds}"
+            assert kinds.count("agent_end") == 1
+            assert len(notifications) == 1, (
+                f"{turn_ends} turn_end frames and {kinds.count('agent_end')} agent_end "
+                f"produced {len(notifications)} notifications"
+            )
+
+            payload = notifications[0]["payload"]
+            assert payload["kind"] == "complete"
+            assert payload["status"] == "Complete"
+            assert payload["title"] == "Report run"
+            assert payload["title_is_session_name"] is True
+            assert payload["body"] == "Wrote the report to notification-evidence.txt."
+            assert payload["body_is_snippet"] is True
+            assert payload["completion_token"]
+            assert payload["dedupe_key"] == f"complete:{sid}:{payload['completion_token']}"
+            # The banner follows the receipt state that explains it.
+            assert [f["type"] for f in frames].index("attention") < [
+                f["type"] for f in frames
+            ].index("notification")
+            assert written.read_text() == "done", "the turn really ran its tool"
+
+            # The claim is a separate step the renderer takes, and it is
+            # single-winner: this is the real HTTP route, not the store.
+            claim = await client.post(
+                target + "/notified", json={"completion_token": payload["completion_token"]}
+            )
+            assert claim.status_code == 200, claim.text
+            assert claim.json()["result"]["claimed"] is True
+            again = await client.post(
+                target + "/notified", json={"completion_token": payload["completion_token"]}
+            )
+            assert again.json()["result"]["claimed"] is False
+            # And it did NOT mark the conversation read: notifying is not reading.
+            state = await client.get(target)
+            attention = state.json()["result"]["payload"]["frontend"]["snapshot"]["attention"]
+            assert attention["unseen"] is True
+
+            print(
+                f"Real multi-step turn over HTTP: {turn_ends} turn_end + 1 agent_end frames "
+                f"produced exactly 1 notification, body={payload['body']!r}; "
+                "second /notified claimed=false; session still unseen"
+            )
+    finally:
+        server.should_exit = True
+        await asyncio.wait_for(serving, 30)
+        listener.close()
+        if runtime is not None:
+            await runtime.aclose()
+        if handle is not None:
+            await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_delegating_turn_stays_silent_until_its_child_settles(
+    headless_tui_env: Path, workspace: Path, monkeypatch
+):
+    """The other half of the defect: `agent_end` while children still work.
+
+    The harness's `task` tool returns as soon as a child is REGISTERED, so a
+    delegating parent reaches `agent_end` with the work still running. The app
+    toasted there, telling the user their task was done while it was not.
+
+    This drives a real registered `task` job over the real bridge and asserts
+    ZERO notification frames while the child runs — then releases the child and
+    asserts the banner appears only for the re-entry turn its result opens.
+    Nothing about this is reconstructed in the bridge: the session's own
+    `_publish_attention_outcome` refuses to publish while a `task` job is
+    running, so there is no completion row for the bridge to observe.
+    """
+    root = headless_tui_env
+    token = secrets.token_hex(32)
+    monkeypatch.setenv("LOCAL_OPERATOR_DESKTOP_TOKEN", token)
+    monkeypatch.delenv("LOCAL_OPERATOR_DESKTOP_ORIGINS", raising=False)
+    (root / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    server, serving = await serve_app(listener, token)
+    runtime = handle = None
+    child_release = asyncio.Event()
+    try:
+        async with httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{listener.getsockname()[1]}", timeout=30
+        ) as client:
+            client.headers["Authorization"] = f"Bearer {token}"
+            path = "/v1/desktop/sessions"
+            created = await client.post(
+                path,
+                json={"request_id": "cccccccc-3333-4333-8333-333333333333", "cwd": str(workspace)},
+            )
+            sid = created.json()["result"]["session_id"]
+            target = path + "/" + sid
+
+            stream = ScriptedStream(
+                [
+                    text_turn("Delegated the audit to a subagent."),
+                    text_turn("The subagent finished; the audit is clean."),
+                ]
+            )
+            session = build_session(root / "sessions" / sid, stream, cwd=workspace)
+            # See the note in the test above: an unnamed session spends a
+            # scripted turn on the auto-naming errand, which here would leave
+            # the delegating turn with no script and end it as an `error`
+            # rather than the `complete` this asserts.
+            session.set_conversation_name("Config audit", user_set=True)
+            handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(workspace))
+            runtime = RuntimeServer(handle, kind="daemon")
+            await runtime.start_in_process()
+            (root / "sessions" / sid / ".session.pid").write_text(str(os.getpid()))
+
+            async with client.stream("GET", target + "/events") as response:
+                lines = response.aiter_lines()
+                await next_frame(lines, lambda f: f["type"] == "snapshot")
+
+                # A REAL `task` job on the real manager, registered before the
+                # turn ends — exactly what the `task` tool leaves behind when
+                # it returns at registration.
+                async def child(job_id, signal, progress):
+                    await child_release.wait()
+                    return "audit clean"
+
+                job_id = session.jobs.register("task", "audit subagent", child)
+
+                def job_status() -> str:
+                    """The child's live status. `jobs.get` is Optional by contract."""
+                    row = session.jobs.get(job_id)
+                    assert row is not None, "the registered task job vanished from the manager"
+                    return row.status
+
+                assert job_status() == "running"
+
+                admitted = await client.post(
+                    target + "/messages",
+                    json={
+                        "request_id": "dddddddd-4444-4444-8444-444444444444",
+                        "text": "Audit the config",
+                    },
+                )
+                assert admitted.status_code == 200, admitted.text
+
+                # The parent's turn ends here, with the child still working.
+                during = await collect_frames(
+                    lines,
+                    lambda f: f["type"] == "event" and f["payload"].get("type") == "agent_end",
+                )
+                # Give the 1 s attention poll several chances to fire. A banner
+                # for this turn would be the defect, so the wait has to outlast
+                # the mechanism that would deliver it.
+                await asyncio.sleep(3.0)
+                assert job_status() == "running", "the child must still be live"
+                assert [f for f in during if f["type"] == "notification"] == []
+
+                # Nothing was even published: the refusal is one layer below
+                # every frontend, in the process that owns the job manager.
+                from local_operator.session.attention import AttentionStore
+
+                store = AttentionStore(root / "attention.db")
+                assert store.state(f"session/{sid}")["completion_token"] is None
+
+                # Release the child. Its result re-enters as a fresh turn, and
+                # THAT turn's completion is the notifiable one.
+                child_release.set()
+                after = await collect_frames(
+                    lines, lambda f: f["type"] == "notification", timeout=60
+                )
+
+            notifications = [f for f in after if f["type"] == "notification"]
+            assert len(notifications) == 1
+            payload = notifications[0]["payload"]
+            assert payload["kind"] == "complete"
+            assert payload["body"] == "The subagent finished; the audit is clean."
+            assert job_status() == "completed"
+
+            print(
+                "Delegating turn: agent_end with a live task child produced 0 notifications "
+                "and no completion row; after the child settled, the re-entry turn produced "
+                f"exactly 1, body={payload['body']!r}"
+            )
+    finally:
+        child_release.set()
         server.should_exit = True
         await asyncio.wait_for(serving, 30)
         listener.close()

--- a/tests/unit/notifications/test_compose.py
+++ b/tests/unit/notifications/test_compose.py
@@ -1,0 +1,487 @@
+"""Notification CONTENT: what a banner says, and what it must never say.
+
+The composer is the single place that answers "may this banner carry the
+conversation's name, or a line of its content?", for every surface at once —
+the TUI's own notifier, the detached runtime's OS fallback, and the desktop
+app's `notification` frame. That makes two classes of defect possible here and
+nowhere else, and both are pinned below:
+
+- **A privacy promise that only half holds.** `display.notification_session_
+  name` is one flag over two facts (the name AND the snippet), because a
+  snippet is strictly more session-derived than a name: a name is a topic, a
+  snippet is content. A composer that honoured the flag for the title and
+  leaked the last assistant line would make the settings copy false.
+- **A banner that asserts something untrue about the session.** An errored or
+  interrupted turn's last assistant line routinely reads as a success ("All
+  412 tests pass."), so the snippet is `complete`-only — a rule decidable from
+  the kind alone rather than from a judgement about prose.
+
+Everything here is a pure function over a transcript directory, so the whole
+file is fast and needs no app, no runtime and no store.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from local_operator.notifications import (
+    NOTIFICATION_CONTRACT_VERSION,
+    ComposedNotification,
+    compose,
+    gate_body,
+)
+from local_operator.tui.notify import (
+    APP_NAME,
+    BACKGROUND_FALLBACK_TITLE,
+    BACKGROUND_SNIPPET_MAX_CHARS,
+    BODIES,
+    CONTEXTS,
+    MAX_TITLE_CHARS,
+)
+
+
+def _session(tmp_path: Path, *, assistant: str = "", title: str = "") -> Path:
+    """A session directory with an optional last assistant line and title.
+
+    Writes the sidecar and the transcript in the shapes `resume.py` reads, so
+    this exercises the real `stored_session_title`/`session_preview` rather
+    than a double: the composer's whole job is to be correct against the files
+    a live session actually leaves behind.
+    """
+    session = tmp_path / "sessions" / "abcdef123456"
+    session.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, object]] = [
+        {
+            "id": "user-1",
+            "ts": 1.0,
+            "type": "message",
+            "payload": {"kind": "message", "role": "user", "content": [{"text": "do the thing"}]},
+        }
+    ]
+    if assistant:
+        rows.append(
+            {
+                "id": "assistant-1",
+                "ts": 2.0,
+                "type": "message",
+                "payload": {
+                    "kind": "message",
+                    "role": "assistant",
+                    "content": [{"text": assistant}],
+                },
+            }
+        )
+    (session / "transcript.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+    if title:
+        (session / "title.json").write_text(
+            json.dumps({"text": title, "user_set": True, "names": [title]}), encoding="utf-8"
+        )
+    return session
+
+
+@pytest.fixture
+def names_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`display.notification_session_name` on, whatever the developer's config says."""
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: True)
+
+
+@pytest.fixture
+def names_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: False)
+
+
+def test_a_completion_carries_the_name_the_status_and_the_last_line(
+    tmp_path: Path, names_on: None
+) -> None:
+    """T-C1. The whole point of the feature, in one assertion.
+
+    Before this, every surface said "Turn complete / The agent finished its
+    turn." — the session's name, its outcome and its last line were all
+    reachable and none of them were shown.
+    """
+    session = _session(tmp_path, assistant="Migrated 14 tables.", title="Quota reporting fix")
+    composed = compose("complete", session_dir=session)
+
+    assert isinstance(composed, ComposedNotification)
+    assert composed.title == "Quota reporting fix"
+    assert composed.status == CONTEXTS["complete"] == "Complete"
+    assert composed.body == "Migrated 14 tables."
+    assert composed.body_is_snippet is True
+    assert composed.title_is_session_name is True
+
+
+def test_the_privacy_flag_removes_the_name_AND_the_snippet(tmp_path: Path, names_off: None) -> None:
+    """T-C2. One flag, both facts — a half-honoured promise is the defect.
+
+    A user who opted out of the name has necessarily opted out of the snippet:
+    the flag exists to keep model-written session text off a screen other
+    people can see, and a snippet is content where a name is only a topic. The
+    banner that remains asserts nothing about the conversation at all.
+    """
+    session = _session(tmp_path, assistant="Migrated 14 tables.", title="Quota reporting fix")
+    composed = compose("complete", session_dir=session)
+
+    assert composed.title == APP_NAME
+    assert composed.body == BODIES["complete"] == "Task complete"
+    assert composed.body_is_snippet is False
+    assert composed.title_is_session_name is False
+    # The strongest form of the assertion: neither fact survives anywhere in
+    # the frame, including the structured fields a renderer might read.
+    assert "Quota reporting" not in repr(composed)
+    assert "Migrated" not in repr(composed)
+
+
+def test_an_error_never_borrows_the_last_assistant_line(tmp_path: Path, names_on: None) -> None:
+    """T-C3. Pins review round 1 M1: a failure must not read as a success.
+
+    The last thing a failing turn SAID is whatever it was saying before it
+    stopped, and on a lock screen that sentence sits beside "Needs attention"
+    with nothing to check it against.
+    """
+    session = _session(tmp_path, assistant="All 412 tests pass.", title="Release prep")
+    composed = compose("error", session_dir=session)
+
+    assert composed.body == BODIES["error"] == "Stopped with an error"
+    assert composed.body_is_snippet is False
+    assert composed.status == CONTEXTS["error"] == "Needs attention"
+    # The NAME is still shown: it identifies which session needs attention,
+    # which is the one thing the user has to know to act.
+    assert composed.title == "Release prep"
+    assert composed.title_is_session_name is True
+
+
+def test_an_interruption_likewise_keeps_the_house_sentence(tmp_path: Path, names_on: None) -> None:
+    """T-C4. Same rule, and the reasoning is the same shape.
+
+    An interrupted session whose last assistant turn happened to close a
+    sub-task lands in exactly M1's frame, and nothing in the kind tells the two
+    apart — so the rule is "snippet iff complete", decidable from the kind
+    alone rather than from a judgement about whether a particular line reads
+    honestly.
+    """
+    session = _session(tmp_path, assistant="The migration is complete.", title="Schema work")
+    composed = compose("interrupted", session_dir=session)
+
+    assert composed.body == BODIES["interrupted"] == "Stopped before finishing"
+    assert composed.body_is_snippet is False
+    assert composed.status == CONTEXTS["interrupted"] == "Interrupted"
+
+
+def test_a_long_line_is_cut_to_the_banner_budget_on_a_word_boundary(
+    tmp_path: Path, names_on: None
+) -> None:
+    """T-C5. Proves `max_chars` was PASSED, not applied afterwards.
+
+    `session_preview` defaults to a 200-char list-row budget and computes its
+    word-boundary ellipsis against whatever budget it is given. Trimming its
+    200-char answer down to 120 afterwards would cut mid-word, after the
+    ellipsis had already been placed somewhere else — so the observable
+    difference between the two implementations is exactly the boundary this
+    asserts.
+    """
+    line = " ".join(f"word{n:03d}" for n in range(80))
+    assert len(line) > 400
+    session = _session(tmp_path, assistant=line, title="Long answer")
+    composed = compose("complete", session_dir=session)
+
+    assert composed.body_is_snippet is True
+    assert len(composed.body) <= BACKGROUND_SNIPPET_MAX_CHARS == 120
+    assert composed.body.endswith("…")
+    # The cut landed between words: the text before the ellipsis is a run of
+    # whole tokens, so no partial "wor" tail survives.
+    kept = composed.body.rstrip("…").split()
+    assert all(word in line.split() for word in kept)
+
+
+def test_control_characters_never_reach_the_wire(tmp_path: Path, names_on: None) -> None:
+    """T-C6. Both halves are model-written and both reach argv or an escape.
+
+    ESC and BEL terminate an OSC string, so a session name or a snippet
+    carrying `\\x1b]0;pwned\\x07` would close the sequence early and leave the
+    remainder executing as terminal commands.
+    """
+    attack = "before \x1b]0;pwned\x07 after"
+    session = _session(tmp_path, assistant=attack, title=attack)
+    composed = compose("complete", session_dir=session)
+
+    for value in (composed.title, composed.body):
+        assert "\x1b" not in value
+        assert "\x07" not in value
+        assert "pwned" in value, "the scrub must strip the control bytes, not the text"
+    assert len(composed.title) <= MAX_TITLE_CHARS
+
+
+def test_a_nameless_session_says_something_true_for_its_kind(
+    tmp_path: Path, names_on: None
+) -> None:
+    """T-C7. The fallback splits on kind because one sentence is not true of both.
+
+    "A session finished" is a true sentence for a completion and a false one
+    for a parked question, so a nameless gate falls back to the brand instead —
+    which is what the detached runtime's gate fallback already does.
+    """
+    session = _session(tmp_path, assistant="done")
+    assert compose("complete", session_dir=session).title == BACKGROUND_FALLBACK_TITLE
+    assert compose("error", session_dir=session).title == BACKGROUND_FALLBACK_TITLE
+    assert compose("interrupted", session_dir=session).title == BACKGROUND_FALLBACK_TITLE
+    assert compose("ask", session_dir=session).title == APP_NAME
+    assert compose("approval", session_dir=session).title == APP_NAME
+    for kind in ("complete", "error", "interrupted", "ask", "approval"):
+        assert compose(kind, session_dir=session).title_is_session_name is False
+
+
+def test_a_gate_body_does_not_repeat_the_tool_name(tmp_path: Path, names_on: None) -> None:
+    """T-C8. Pins round 4 Q3: "write: write: /path" on the headline surface.
+
+    A tool's `describe_approval` already leads with its own action word and the
+    title IS the tool name, so the naive `f"{title}: {detail}"` doubled it on
+    every approval toast, every time.
+    """
+    session = _session(tmp_path, title="Deploy")
+    already = compose(
+        "approval", session_dir=session, gate_title="write", gate_detail="write: /etc/hosts"
+    )
+    assert already.body == "write: /etc/hosts"
+    assert already.body.count("write:") == 1
+
+    # The prefix IS applied when the detail does not already carry it, which is
+    # the case the rule must not over-correct.
+    plain = compose("approval", session_dir=session, gate_title="bash", gate_detail="rm -rf /tmp/x")
+    assert plain.body == "bash: rm -rf /tmp/x"
+
+    # No detail at all falls back to the vocabulary: the bare tool name says
+    # less than "Waiting for approval", and an `ask` with no text rendered as a
+    # single word with no hint that it was a question.
+    assert compose("ask", session_dir=session, gate_title="ask").body == BODIES["ask"]
+    assert gate_body("approval", "", "") == BODIES["approval"]
+    # A gate never takes the snippet path even with assistant text on disk.
+    assert compose("ask", session_dir=session).body_is_snippet is False
+
+
+def test_an_unreadable_session_degrades_to_the_house_vocabulary(
+    tmp_path: Path, names_on: None
+) -> None:
+    """T-C9. A notification is chrome; it must never raise into its caller.
+
+    This runs inside the desktop bridge's 1 s attention poll and inside the
+    TUI's turn-end handler. Both treat a failure here as costing the banner,
+    never the poll or the turn — so every route out of `compose` returns a
+    frame that asserts nothing rather than an exception.
+    """
+    missing = tmp_path / "sessions" / "nothinghere12"
+    for kind in ("complete", "error", "interrupted", "ask", "approval"):
+        composed = compose(kind, session_dir=missing)
+        assert composed.body == BODIES[kind]
+        assert composed.status == CONTEXTS[kind]
+        assert composed.body_is_snippet is False
+
+    # `session_dir=None` is the cold-bridge case: no directory to read at all.
+    assert compose("complete", session_dir=None).body == BODIES["complete"]
+
+    # A transcript that is not JSON at all, and a directory where a file is
+    # expected — the two shapes a half-written or hand-mangled session takes.
+    broken = tmp_path / "sessions" / "broken123456"
+    broken.mkdir(parents=True)
+    (broken / "transcript.jsonl").write_bytes(b"\xff\xfe not json at all\n")
+    (broken / "title.json").mkdir()
+    assert compose("complete", session_dir=broken).body == BODIES["complete"]
+
+    # A settings store that cannot be read fails CLOSED: an unreadable config
+    # must not be the thing that puts a conversation's name on a lock screen.
+    session = _session(tmp_path, assistant="secret work", title="Secret client")
+
+    def explode(*_args: object, **_kwargs: object) -> bool:
+        raise RuntimeError("settings unavailable")
+
+    import local_operator.tui.notify as notify_module
+
+    original = notify_module.settings_get
+    notify_module.settings_get = explode  # type: ignore[assignment]
+    try:
+        degraded = compose("complete", session_dir=session)
+    finally:
+        notify_module.settings_get = original  # type: ignore[assignment]
+    assert degraded.title == APP_NAME
+    assert degraded.body == BODIES["complete"]
+
+
+def test_a_live_rename_wins_over_the_stored_title(tmp_path: Path, names_on: None) -> None:
+    """The caller's resolved name beats the sidecar, because a rename lands there first.
+
+    A toast naming a session by the name it had ten seconds ago is worse than
+    one naming it by none: the user goes looking for a conversation that no
+    longer exists under that title.
+    """
+    session = _session(tmp_path, assistant="done", title="Old name")
+    assert compose("complete", session_dir=session, session_name="New name").title == "New name"
+    # An EMPTY live name is "I do not know", not "it has none", so the sidecar
+    # still answers — this is the cold-bridge path.
+    assert compose("complete", session_dir=session, session_name="").title == "Old name"
+
+
+def test_the_contract_version_is_the_one_the_wire_advertises() -> None:
+    """The frame's `contract` field and `/v1/capabilities` must agree.
+
+    They are read by two different consumers (the payload validator and the
+    capability gate that decides whether the renderer owns completion toasts),
+    and a skew between them would silently disable the new path while the
+    frames kept arriving.
+    """
+    import asyncio
+
+    from local_operator.server.routes.capabilities import capabilities
+
+    result = asyncio.run(capabilities()).result
+    # `CRUDResponse.result` is a permissive union, so the shape is asserted
+    # before it is indexed — which is also what makes a failure here say
+    # "capabilities stopped returning a mapping" rather than a TypeError.
+    assert isinstance(result, dict)
+    features = result["features"]
+    assert isinstance(features, dict)
+    assert features["notification_contract"] == NOTIFICATION_CONTRACT_VERSION == 1
+
+
+def _incident(session: Path, raw: str) -> None:
+    """Append the `session_incident` record a classified failure journals.
+
+    The exact shape `incidents.py` writes — a custom message whose `details`
+    carry both the rendered model-facing `text` and the unrendered `raw`. Both
+    are written here because the composer must be seen to pick the right one.
+    """
+    from local_operator.incidents import format_incident_message
+
+    row = {
+        "id": "incident-1",
+        "ts": 3.0,
+        "type": "message",
+        "payload": {
+            "kind": "custom",
+            "custom_type": "session_incident",
+            "details": {"text": format_incident_message(raw, "test", "model"), "raw": raw},
+        },
+    }
+    with (session / "transcript.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row) + "\n")
+
+
+def test_an_error_body_names_what_actually_failed(tmp_path: Path, names_on: None) -> None:
+    """D4. "Stopped with an error" is unactionable; the provider's text is not.
+
+    The banner is the surface where the user decides whether to get up. A
+    state with no cause tells them they must act while withholding the only
+    fact that says WHICH action — top up a quota, fix a credential, or simply
+    retry — so they have to open the session to learn anything at all.
+
+    The text is the incident's `raw`, NOT its rendered `text`: the rendered
+    form is a multi-line model-facing block tailed with "This is why the
+    previous turn ended. Take it into account before repeating the same
+    request.", which is an instruction addressed to the model and reads as
+    nonsense on a lock screen.
+    """
+    session = _session(tmp_path, assistant="All 412 tests pass.", title="Release prep")
+    _incident(session, "rate limit: quota exhausted for anthropic/claude-opus-5")
+    composed = compose("error", session_dir=session)
+
+    assert composed.body == "rate limit: quota exhausted for anthropic/claude-opus-5"
+    assert composed.body_is_failure is True
+    assert composed.status == CONTEXTS["error"] == "Needs attention"
+    # Still never the last assistant line: that is the M1 rule, and the reason
+    # this body is safe is precisely that it describes the FAILURE rather than
+    # the work.
+    assert composed.body_is_snippet is False
+    assert "412 tests pass" not in composed.body
+    # And the two flags are never both true: a body is one kind of text.
+    assert not (composed.body_is_failure and composed.body_is_snippet)
+
+
+def test_a_failure_with_no_recorded_cause_keeps_the_house_sentence(
+    tmp_path: Path, names_on: None
+) -> None:
+    """The fallback, which is what makes the new body safe to add at all.
+
+    Not every error path journals an incident (a failure classified nowhere, a
+    transcript truncated before the record). The absence must read as the old
+    banner rather than as an empty line under a title.
+    """
+    session = _session(tmp_path, assistant="All 412 tests pass.", title="Release prep")
+    composed = compose("error", session_dir=session)
+
+    assert composed.body == BODIES["error"] == "Stopped with an error"
+    assert composed.body_is_failure is False
+
+    # An incident record whose `raw` is missing or blank is the same case.
+    with (session / "transcript.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "id": "incident-blank",
+                    "ts": 4.0,
+                    "type": "message",
+                    "payload": {
+                        "kind": "custom",
+                        "custom_type": "session_incident",
+                        "details": {"text": "rendered only", "raw": "   "},
+                    },
+                }
+            )
+            + "\n"
+        )
+    assert compose("error", session_dir=session).body == BODIES["error"]
+
+
+def test_the_failure_text_is_bounded_and_scrubbed_like_every_other_body(
+    tmp_path: Path, names_on: None
+) -> None:
+    """A provider's error envelope is untrusted text on the same wires.
+
+    It reaches argv (`cmux notify`, `notify-send`) and an AppleScript literal,
+    and it is not length-bounded at the source: a provider may return a wall of
+    JSON. Same `sanitize_text(..., BACKGROUND_SNIPPET_MAX_CHARS)` discipline as
+    the snippet, for the same reasons.
+    """
+    session = _session(tmp_path, title="Release prep")
+    _incident(session, "boom \x1b]0;pwned\x07 " + " ".join(f"detail{n:03d}" for n in range(60)))
+    composed = compose("error", session_dir=session)
+
+    assert composed.body_is_failure is True
+    assert len(composed.body) <= BACKGROUND_SNIPPET_MAX_CHARS == 120
+    assert "\x1b" not in composed.body and "\x07" not in composed.body
+    assert "pwned" in composed.body
+
+
+def test_the_privacy_flag_removes_the_failure_text_too(tmp_path: Path, names_off: None) -> None:
+    """One flag over every session-derived fact, failure text included.
+
+    A provider's error envelope can quote a prompt fragment, a file path or an
+    account identifier, so it is at least as sensitive as the name the flag was
+    written for — a gate that covered the snippet but not this would leak the
+    more identifying of the two.
+    """
+    session = _session(tmp_path, title="Project Atlas")
+    _incident(session, "auth: credential ATLAS_PROD_KEY rejected for acct-99182")
+    composed = compose("error", session_dir=session)
+
+    assert composed.body == BODIES["error"]
+    assert composed.body_is_failure is False
+    assert "ATLAS" not in repr(composed) and "acct-99182" not in repr(composed)
+
+
+def test_the_incident_type_this_scan_keys_on_is_the_one_incidents_writes() -> None:
+    """`resume.py` spells the custom type literally; this is why that is safe.
+
+    The module is import-guarded — nothing may drag the engine onto
+    `local-operator --help` — so it cannot import `incidents` for one string.
+    The duplication is fine only while something fails when the two diverge: a
+    rename would otherwise turn the scan into one that matches nothing, and the
+    banner would quietly degrade to "Stopped with an error" for every failure,
+    looking exactly like a session that recorded no incident.
+    """
+    from local_operator.incidents import SESSION_INCIDENT_MESSAGE_TYPE
+    from local_operator.resume import _SESSION_INCIDENT_TYPE
+
+    assert _SESSION_INCIDENT_TYPE == SESSION_INCIDENT_MESSAGE_TYPE

--- a/tests/unit/server/test_desktop_notifications.py
+++ b/tests/unit/server/test_desktop_notifications.py
@@ -1,0 +1,806 @@
+"""The desktop notification frame: when it is emitted, and when it must not be.
+
+The defect this contract closes is a false statement on a lock screen. The app
+toasted "Turn complete — The agent finished its turn." on every `turn_end` (one
+MODEL CALL, of which an agentic turn has many) and on every `agent_end` (the
+parent's own end, which routinely arrives while `task` children are still
+working). Both assert something untrue, and the second one is the case the TUI
+has always deliberately suppressed.
+
+The fix is a change of AUTHORITY, not a better heuristic: the bridge emits a
+notification if and only if it observes a newly published, unseen `completions`
+row. That row exists only because `Session._publish_attention_outcome` decided
+the turn produced a notifiable outcome, inside the process that owns the job
+manager, using the same delegated-children check the TUI uses. So the bridge
+cannot disagree with the TUI about whether a turn finished — it is reading a
+projection of one decision rather than making the same decision twice.
+
+Two further properties are pinned here because each has a failure mode that is
+invisible until it hits a user:
+
+- **A notification is not replayed.** An edge whose value is timeliness must
+  not arrive hours later on a reconnect, and it must not consume one of the 256
+  replay slots a real transcript event needs.
+- **Claiming a banner is not marking it read.** `POST /notified` writes the
+  DELIVERY watermark only. Routing it through the read watermark would clear
+  the sidebar's unseen mark for a conversation the user never opened.
+
+Cold-path style throughout, mirroring `test_desktop_attention.py`: no runtime
+is started and no bridge is acquired by anything that does not need one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sqlite3
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.notifications import NOTIFICATION_CONTRACT_VERSION
+from local_operator.server.utils.desktop_sessions import (
+    BRIDGE_NOTIFIABLE_KINDS,
+    DesktopSessionBridge,
+    DesktopSessions,
+)
+from local_operator.session.attention import AttentionStore
+from local_operator.tui.notify import BODIES
+
+
+def _publish(root: Path, session_id: str, anchor: str, kind: str = "complete") -> str:
+    token = str(uuid.uuid4())
+    AttentionStore(root / "attention.db").publish(f"session/{session_id}", token, anchor, kind)
+    return token
+
+
+class _Bridge(DesktopSessionBridge):
+    """A bridge with a recording publisher and no runtime behind it.
+
+    The notification edge lives in `refresh_attention`, which reads the store
+    and publishes — neither of which needs an attached session. Driving the
+    real method over a real store while recording frames is what makes the
+    ORDER (`attention` then `notification`) and the COUNT observable, and both
+    are properties no assertion on a single call could see.
+    """
+
+    def __init__(self, root: Path, session_id: str) -> None:
+        super().__init__(root, session_id, str(root))
+        self.frames: list[tuple[dict[str, Any], bool]] = []
+
+    def publish(self, kind: str, payload: dict[str, Any], *, replay: bool = True) -> None:
+        super().publish(kind, payload, replay=replay)
+        self.frames.append(
+            (
+                {
+                    "session_id": self.session_id,
+                    "epoch": self.epoch,
+                    "seq": self.sequence,
+                    "type": kind,
+                    "payload": payload,
+                },
+                replay,
+            )
+        )
+
+    @property
+    def kinds(self) -> list[str]:
+        return [frame["type"] for frame, _ in self.frames]
+
+    def of(self, kind: str) -> list[dict[str, Any]]:
+        return [frame for frame, _ in self.frames if frame["type"] == kind]
+
+
+def _session_dir(root: Path, session_id: str, *, assistant: str = "", title: str = "") -> None:
+    """Give a created session a transcript the composer can read."""
+    import json
+
+    directory = root / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "id": "user-1",
+            "ts": 1.0,
+            "type": "message",
+            "payload": {"kind": "message", "role": "user", "content": [{"text": "go"}]},
+        }
+    ]
+    if assistant:
+        rows.append(
+            {
+                "id": "assistant-1",
+                "ts": 2.0,
+                "type": "message",
+                "payload": {
+                    "kind": "message",
+                    "role": "assistant",
+                    "content": [{"text": assistant}],
+                },
+            }
+        )
+    with (directory / "transcript.jsonl").open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+    if title:
+        (directory / "title.json").write_text(
+            json.dumps({"text": title, "user_set": True, "names": [title]}), encoding="utf-8"
+        )
+
+
+@pytest.fixture(autouse=True)
+def names_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the privacy flag ON, so a developer's own config cannot decide a test."""
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: True)
+
+
+async def _baselined(root: Path, session_id: str) -> _Bridge:
+    """A bridge that has taken its first attention reading, with frames cleared.
+
+    Every test past T-B2 starts here, because the baseline read is what makes
+    a later change NEWS rather than history.
+    """
+    bridge = _Bridge(root, session_id)
+    await bridge.refresh_attention()
+    bridge.frames.clear()
+    return bridge
+
+
+@pytest.mark.asyncio
+async def test_a_published_completion_emits_one_notification_after_the_attention_frame(
+    tmp_path: Path,
+) -> None:
+    """T-B1. The frame, its content, and its position relative to `attention`.
+
+    Ordering is not cosmetic: a reader that toasts should already hold the
+    receipt state that explains the toast, so a renderer never shows a banner
+    for a completion its own sidebar has not yet marked unseen.
+
+    This also pins the ORDERING RISK named in the design (§11.2 item 5): the
+    composer reads the transcript while the session writes it, and the row it
+    fires on is published AFTER message persistence — so the snippet must be
+    the real last line, not a degraded "Task complete".
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Rebuilt the index.", title="Index work")
+    bridge = await _baselined(tmp_path, sid)
+
+    _publish(tmp_path, sid, "result-1")
+    await bridge.refresh_attention()
+
+    assert bridge.kinds == ["attention", "notification"]
+    payload = bridge.of("notification")[0]["payload"]
+    assert payload["contract"] == NOTIFICATION_CONTRACT_VERSION
+    assert payload["kind"] == "complete"
+    assert payload["title"] == "Index work"
+    assert payload["status"] == "Complete"
+    assert payload["body"] == "Rebuilt the index."
+    assert payload["body_is_snippet"] is True
+    assert payload["title_is_session_name"] is True
+    assert payload["session_name"] == "Index work"
+    assert payload["focus_policy"] == "when_unfocused"
+    # The dedupe key is bound to the DURABLE token, not to this bridge's
+    # sequence: `acquire()` resets the sequence after a detached interval, so a
+    # seq-keyed client would re-toast the same completion on every reconnect.
+    assert payload["dedupe_key"] == f"complete:{sid}:{payload['completion_token']}"
+    assert payload["completion_token"] == bridge.attention["completion_token"]
+
+
+@pytest.mark.asyncio
+async def test_the_first_read_of_a_bridges_life_announces_nothing(tmp_path: Path) -> None:
+    """T-B2. Opening a session must not toast the completion it ended on.
+
+    The baseline rule is the same one the `attention` frame already uses: a
+    bridge's first read is the session's HISTORY, not news. Without it, opening
+    the app would raise a banner for every session that finished while it was
+    closed — which is the flood the whole feature is shaped to avoid.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Finished last week.")
+    _publish(tmp_path, sid, "already-there")
+
+    bridge = _Bridge(tmp_path, sid)
+    await bridge.refresh_attention()
+
+    assert bridge.attention["unseen"] is True, "the completion IS outstanding"
+    assert bridge.frames == [], "and it is still not news"
+
+
+@pytest.mark.asyncio
+async def test_the_same_completion_seen_twice_emits_one_frame(tmp_path: Path) -> None:
+    """T-B3. Revision churn must not re-announce a completion.
+
+    `refresh_attention` publishes on full-state inequality, and a heal
+    deliberately republishes a corrected state — so a state change with an
+    unchanged token is routine and must not reach the wire as a second banner.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Done.")
+    bridge = await _baselined(tmp_path, sid)
+
+    token = _publish(tmp_path, sid, "result-1")
+    await bridge.refresh_attention()
+    assert len(bridge.of("notification")) == 1
+
+    # Force a state change that keeps the token: the runtime going live flips
+    # `supported`, which is exactly the churn the emitter must ignore.
+    bridge.attention = dict(bridge.attention, supported=not bridge.attention["supported"])
+    await bridge.refresh_attention()
+    # And an idempotent re-read of the identical state.
+    await bridge.refresh_attention()
+
+    assert len(bridge.of("notification")) == 1
+    assert bridge.of("notification")[0]["payload"]["completion_token"] == token
+
+
+@pytest.mark.asyncio
+async def test_an_interruption_is_not_announced_on_the_desktop(tmp_path: Path) -> None:
+    """T-B4. The user pressed the key themselves a moment ago.
+
+    Telling somebody their own Ctrl+C worked is the definition of a
+    notification nobody wants, and it is the call the TUI already makes. The
+    `attention` frame still goes out, because the SIDEBAR should still show the
+    outcome — the suppression is of the interruption, not of the fact.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Half-finished.")
+    bridge = await _baselined(tmp_path, sid)
+
+    _publish(tmp_path, sid, "result-1", kind="interrupted")
+    await bridge.refresh_attention()
+
+    assert bridge.kinds == ["attention"]
+    assert "interrupted" not in BRIDGE_NOTIFIABLE_KINDS
+    assert BRIDGE_NOTIFIABLE_KINDS == frozenset({"complete", "error"})
+
+
+@pytest.mark.asyncio
+async def test_an_error_is_announced_with_the_house_sentence(tmp_path: Path) -> None:
+    """`error` IS notifiable, and never borrows the last assistant line.
+
+    The pair with T-B4: the two non-success kinds are treated differently on
+    purpose, because a failure is something the user must act on and an
+    interruption is something they just did.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="All 412 tests pass.", title="Release prep")
+    bridge = await _baselined(tmp_path, sid)
+
+    _publish(tmp_path, sid, "completion-abc", kind="error")
+    await bridge.refresh_attention()
+
+    payload = bridge.of("notification")[0]["payload"]
+    assert payload["kind"] == "error"
+    assert payload["status"] == "Needs attention"
+    assert payload["body"] == BODIES["error"]
+    assert payload["body_is_snippet"] is False
+    assert "412 tests pass" not in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_an_agent_end_event_never_produces_a_notification(tmp_path: Path) -> None:
+    """T-B5. The anti-regression test for the reported defect's second half.
+
+    `agent_end` still reaches the wire as an `event` frame — several renderer
+    paths settle the transcript on it, so suppressing it to fix a toast would
+    break painting on every UI version. What changes is that it is no longer a
+    NOTIFICATION trigger: the parent's own end routinely lands while `task`
+    children are still working.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    bridge = await _baselined(tmp_path, sid)
+
+    from local_operator.harness.types import AgentEndEvent
+
+    bridge._event(AgentEndEvent(aborted=False))
+
+    assert bridge.kinds == ["event"]
+    assert bridge.of("event")[0]["payload"]["type"] == "agent_end"
+    assert bridge.of("notification") == []
+
+
+@pytest.mark.asyncio
+async def test_a_turn_end_event_never_produces_a_notification(tmp_path: Path) -> None:
+    """T-B6. The loudest half of the defect: one model call is not a turn.
+
+    An agentic turn is many `turn_end`s, so this fired a banner per STEP. The
+    frame still travels as an `event` for the transcript; it simply has nothing
+    to do with whether the user owes the session anything.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    bridge = await _baselined(tmp_path, sid)
+
+    from local_operator.harness.types import TurnEndEvent
+
+    for _ in range(5):
+        bridge._event(TurnEndEvent(message=None, tool_results=[]))
+
+    assert bridge.kinds == ["event"] * 5
+    assert bridge.of("notification") == []
+
+
+@pytest.mark.asyncio
+async def test_a_notification_is_never_retained_for_replay(tmp_path: Path) -> None:
+    """T-B7. An edge whose value is timeliness must not arrive hours late.
+
+    Replaying it would toast the user about a turn that finished while their
+    laptop lid was shut. The durable signal is not lost: `attention` and the
+    sidebar's unseen mark both survive a reconnect and are the right surface
+    for "you missed something".
+
+    It also costs nothing from the 256-frame replay budget, where every slot it
+    took would push out a real transcript event.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Done.")
+    bridge = await _baselined(tmp_path, sid)
+
+    from local_operator.harness.types import TurnEndEvent
+
+    bridge._event(TurnEndEvent(message=None, tool_results=[]))
+    _publish(tmp_path, sid, "result-1")
+    await bridge.refresh_attention()
+    bridge._event(TurnEndEvent(message=None, tool_results=[]))
+
+    retained = [frame["type"] for frame, _ in bridge.replay]
+    assert "notification" not in retained
+    assert retained == ["event", "attention", "event"]
+    # The transcript events AROUND it are retained, which is the half that
+    # would break if `replay=False` were applied too broadly.
+    assert len(bridge.of("notification")) == 1
+
+
+@pytest.mark.asyncio
+async def test_seq_still_advances_and_a_reconnect_at_it_is_not_gapped(tmp_path: Path) -> None:
+    """T-B8. The gap arithmetic survives a seq that was never retained.
+
+    `events()` computes `gap` from `after_seq < first - 1`, where `first` is
+    the oldest RETAINED frame's seq. A skipped seq therefore never becomes
+    `first`, and a client reconnecting at exactly the notification's cursor
+    still satisfies the test against the next retained frame. Not incrementing
+    would instead make `seq` non-monotonic across the two publish paths and
+    break every renderer's receipt cursor.
+
+    If this is wrong the symptom is a spurious full-snapshot refetch after
+    every completion, which a user sees as a transcript flash.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Done.")
+    bridge = await _baselined(tmp_path, sid)
+
+    from local_operator.harness.types import TurnEndEvent
+
+    bridge._event(TurnEndEvent(message=None, tool_results=[]))
+    _publish(tmp_path, sid, "result-1")
+    await bridge.refresh_attention()
+    bridge._event(TurnEndEvent(message=None, tool_results=[]))
+
+    seqs = [frame["seq"] for frame, _ in bridge.frames]
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs), "seq must stay monotonic"
+    notification_seq = bridge.of("notification")[0]["seq"]
+    assert notification_seq not in [frame["seq"] for frame, _ in bridge.replay]
+
+    # Reconnecting AT the notification's cursor is not a gap, and the frames
+    # after it are replayed.
+    first = bridge.replay[0][0]["seq"]
+    cutoff = bridge.sequence
+    assert not (notification_seq < first - 1 or notification_seq > cutoff)
+    replayed = [f["seq"] for f, _ in bridge.replay if notification_seq < f["seq"] <= cutoff]
+    assert replayed == [cutoff]
+
+
+@pytest.mark.asyncio
+async def test_a_claim_is_taken_once_and_the_second_caller_loses(tmp_path: Path) -> None:
+    """T-B9. `claim_delivery` is the arbiter; exactly one surface ever wins.
+
+    A losing claim is the FEATURE, not a bug: when both a TUI observer and the
+    desktop are eligible for the same completion, one of them silently drops
+    its banner and the user is told once.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    token = _publish(tmp_path, sid, "result-1")
+
+    assert await pool.claim_notification(sid, token) is True
+    assert await pool.claim_notification(sid, token) is False
+
+    # A NEWER completion is a separate claim, so a delivered conversation is
+    # not permanently silenced.
+    newer = _publish(tmp_path, sid, "result-2")
+    assert await pool.claim_notification(sid, newer) is True
+
+
+@pytest.mark.asyncio
+async def test_claiming_a_banner_never_marks_anything_read(tmp_path: Path) -> None:
+    """T-B10. The two watermarks, kept apart on a real store.
+
+    Notifying is cheap and reversible; marking-read is destructive. Routing
+    this through `acknowledge` would clear the sidebar's checkmark for a
+    conversation the user never opened — which `docs/ATTENTION.md` forbids
+    outright and `docs/SESSION_SIDEBAR.md` restates.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    token = _publish(tmp_path, sid, "result-1")
+    store = AttentionStore(tmp_path / "attention.db")
+
+    before = store.state(f"session/{sid}")
+    assert await pool.claim_notification(sid, token) is True
+    after = store.state(f"session/{sid}")
+
+    assert after == before, "the claim must not move ANY field of the read state"
+    assert after["unseen"] is True
+    assert after["revision"] == before["revision"]
+
+    # And the read watermark still works afterwards, so the claim did not
+    # merely fail to write: it wrote somewhere else.
+    assert (await pool.acknowledge_attention(sid, token))["unseen"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_claim_never_acquires_a_bridge_or_starts_a_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """T-B11. Cold path, proven by making the warm path explode.
+
+    A completion worth announcing is usually one whose owner has already
+    exited. Spawning a process to decide whether to show a banner would be a
+    remarkable cost for chrome — and `DesktopSessions.session()` is the only
+    other way in, so an exploding `session()` is what keeps this true if
+    someone later "simplifies" the implementation.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    token = _publish(tmp_path, sid, "result-1")
+
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError("a notification claim must not acquire a session bridge")
+
+    monkeypatch.setattr(DesktopSessions, "session", forbidden)
+    assert await pool.claim_notification(sid, token) is True
+    assert not (tmp_path / "sessions" / sid / ".session.pid").exists()
+    assert not pool.bridges
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_or_foreign_token_claims_nothing(tmp_path: Path) -> None:
+    """T-B12. A claim must not invent a watermark it had no completion for.
+
+    Rejecting a well-formed token belonging to ANOTHER session matters more
+    than rejecting garbage: the ids are uniform, so a mixed-up client would
+    otherwise silence a conversation the user never opened.
+    """
+    pool = DesktopSessions(tmp_path)
+    mine = await pool.create(str(tmp_path))
+    other = tmp_path / "other"
+    other.mkdir()
+    theirs = await pool.create(str(other))
+    foreign = _publish(tmp_path, theirs, "their-result")
+    _publish(tmp_path, mine, "my-result")
+
+    for bad in (foreign, str(uuid.uuid4()), "not-a-uuid"):
+        assert await pool.claim_notification(mine, bad) is False
+
+    store = AttentionStore(tmp_path / "attention.db")
+    assert store.state(f"session/{mine}")["unseen"] is True
+    assert store.state(f"session/{theirs}")["unseen"] is True
+    # The other session's own completion is still claimable, so nothing above
+    # consumed it.
+    assert await pool.claim_notification(theirs, foreign) is True
+
+    # An unknown SESSION is a 404 in the same shape the read receipt uses.
+    for bogus in ("../../etc", "not-hex", "a" * 12, mine.upper(), "", "0123456789ab"):
+        with pytest.raises(KeyError):
+            await pool.claim_notification(bogus, foreign)
+
+
+@pytest.mark.asyncio
+async def test_a_compose_failure_costs_the_banner_not_the_attention_frame(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """T-B13. Chrome must not take out the receipt sync it rides on.
+
+    `refresh_attention` is how the desktop, the phone and the TUI stay in step
+    about what has been read. A composer that raised into it would stop that
+    sync for the life of the bridge — a new way to hide an unread result, which
+    is the failure the attention feature exists to prevent.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Done.")
+    bridge = await _baselined(tmp_path, sid)
+
+    def explode(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("transcript unreadable")
+
+    monkeypatch.setattr("local_operator.notifications.compose", explode)
+    _publish(tmp_path, sid, "result-1")
+    state = await bridge.refresh_attention()
+
+    assert bridge.kinds == ["attention"], "the receipt frame still went out"
+    assert state["unseen"] is True
+    assert bridge.attention["completion_token"] is not None
+
+    # And the bridge recovers on the next completion once compose works again.
+    monkeypatch.undo()
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: True)
+    _publish(tmp_path, sid, "result-2")
+    await bridge.refresh_attention()
+    assert len(bridge.of("notification")) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_live_name_beats_the_sidecar_on_the_wire(tmp_path: Path) -> None:
+    """A rename reaches frontend state before it reaches `title.json`.
+
+    The bridge passes the live `conversation_title` when a runtime is attached
+    and falls back to the stored title for a cold bridge. A banner naming a
+    session by the title it had ten seconds ago sends the user looking for a
+    conversation that no longer exists under that name.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Done.", title="Stale sidecar name")
+    bridge = await _baselined(tmp_path, sid)
+
+    class _Remote:
+        """The two attributes `refresh_attention` reads off an attached session."""
+
+        is_cold = False
+        supports_completion_ack = True
+        frontend_state = type("_State", (), {"conversation_title": "Renamed live"})()
+
+    bridge.remote = _Remote()  # type: ignore[assignment]
+    _publish(tmp_path, sid, "result-1")
+    await bridge.refresh_attention()
+
+    assert bridge.of("notification")[0]["payload"]["title"] == "Renamed live"
+
+
+@pytest.mark.asyncio
+async def test_the_privacy_flag_is_honoured_on_the_wire_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The frame carries neither the name nor the snippet when the flag is off.
+
+    The wire is the surface where a leak is least recoverable: once a
+    conversation's content has left the backend it is in a renderer's memory,
+    its logs and possibly its crash reports. The gate therefore runs before the
+    payload is built, not in the renderer.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Merged the acquisition docs.", title="Project Atlas")
+    bridge = await _baselined(tmp_path, sid)
+
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: False)
+    _publish(tmp_path, sid, "result-1")
+    await bridge.refresh_attention()
+
+    payload = bridge.of("notification")[0]["payload"]
+    assert payload["title"] == "Local Operator"
+    assert payload["body"] == BODIES["complete"]
+    assert payload["session_name"] is None
+    assert payload["title_is_session_name"] is False
+    assert payload["body_is_snippet"] is False
+    assert "Atlas" not in str(payload) and "acquisition" not in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_the_poll_loop_delivers_the_notification_end_to_end(tmp_path: Path) -> None:
+    """The 1 s poll is the real trigger; the hook must actually be reached by it.
+
+    Every test above drives `refresh_attention` directly, which would pass with
+    the hook connected to a method nothing calls. This one publishes into the
+    store and waits for the frame to arrive through the production path: the
+    revision-gated poll a live bridge runs.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="The report is ready.", title="Weekly report")
+
+    bridge = _Bridge(tmp_path, sid)
+    poll = asyncio.create_task(bridge._poll_attention())
+    try:
+        for _ in range(400):
+            if bridge.attention:
+                break
+            await asyncio.sleep(0.01)
+        assert bridge.attention, "the poll never took its baseline reading"
+        bridge.frames.clear()
+
+        _publish(tmp_path, sid, "result-1")
+        for _ in range(400):
+            if bridge.of("notification"):
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        poll.cancel()
+        with contextlib.suppress(BaseException):
+            await poll
+
+    assert bridge.kinds == ["attention", "notification"]
+    assert bridge.of("notification")[0]["payload"]["body"] == "The report is ready."
+
+
+@pytest.mark.asyncio
+async def test_a_store_error_during_the_edge_does_not_end_the_poll(tmp_path: Path) -> None:
+    """A broken store costs one tick, with the notification hook installed.
+
+    `test_desktop_attention.py` pins this for the attention read; repeated here
+    because the hook added a second await inside the same try, and an exception
+    escaping IT would end the loop just as effectively.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Done.")
+    bridge = _Bridge(tmp_path, sid)
+    poll = asyncio.create_task(bridge._poll_attention())
+    try:
+        _publish(tmp_path, sid, "result-1")
+        for _ in range(400):
+            if bridge.attention.get("completion_token"):
+                break
+            await asyncio.sleep(0.01)
+
+        with contextlib.closing(sqlite3.connect(tmp_path / "attention.db")) as conn:
+            conn.execute("DROP TABLE completions")
+            conn.commit()
+        bridge.attention_poll_key = None
+        await asyncio.sleep(2.5)
+        assert not poll.done(), "the poll loop died on a transient store error"
+    finally:
+        poll.cancel()
+        with contextlib.suppress(BaseException):
+            await poll
+
+
+@pytest.mark.asyncio
+async def test_an_error_frame_carries_the_failure_text(tmp_path: Path) -> None:
+    """D4 on the wire: the banner names the cause, not just the state.
+
+    `test_compose.py` pins the composition; this pins that the bridge puts the
+    new field on the frame, because a renderer reads the payload and not the
+    dataclass.
+    """
+    import json as _json
+
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="All 412 tests pass.", title="Release prep")
+    directory = tmp_path / "sessions" / sid
+    with (directory / "transcript.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(
+            _json.dumps(
+                {
+                    "id": "incident-1",
+                    "ts": 3.0,
+                    "type": "message",
+                    "payload": {
+                        "kind": "custom",
+                        "custom_type": "session_incident",
+                        "details": {
+                            "text": "[session incident] rate-limit: ...",
+                            "raw": "rate limit: quota exhausted for anthropic/claude-opus-5",
+                        },
+                    },
+                }
+            )
+            + "\n"
+        )
+    bridge = await _baselined(tmp_path, sid)
+
+    _publish(tmp_path, sid, "completion-abc", kind="error")
+    await bridge.refresh_attention()
+
+    payload = bridge.of("notification")[0]["payload"]
+    assert payload["body"] == "rate limit: quota exhausted for anthropic/claude-opus-5"
+    assert payload["body_is_failure"] is True
+    assert payload["body_is_snippet"] is False
+    assert "412 tests pass" not in str(payload)
+
+
+def test_a_parked_gate_carries_the_session_name_for_a_banner() -> None:
+    """D3: an anonymous gate banner cannot be triaged.
+
+    A toast saying only "Waiting for approval" with three sessions open names
+    none of them, so the user must open each one to find the run being held
+    hostage — on the surface whose entire job is to save them that trip.
+
+    Gates deliberately stay on the EXISTING `pending_gate` path rather than
+    gaining a `notification` frame: the desktop already receives this card in
+    the snapshot and update frames, and a second channel for one question is
+    how one gate becomes two banners. So the fix is a field on the card, not a
+    new wire.
+
+    Driven through `ServingSessionHandle._publish_pending_gate` rather than by
+    calling the helper, because what is under test is that the PUBLICATION
+    stamps it — a helper nothing calls would leave every real gate anonymous.
+    """
+    from local_operator.mobile.types import PendingRequest
+    from local_operator.session.frontend_state import PendingGateState
+
+    published: dict[str, Any] = {}
+
+    class _Store:
+        def mutate(self, **changes: Any) -> None:
+            published.update(changes)
+
+    class _Session:
+        conversation_name = "Quota reporting fix"
+        _frontend_state_store = _Store()
+
+    class _Projection:
+        pending = PendingRequest(
+            request_id="gate-1", kind="approval", title="write", detail="write: /etc/hosts"
+        )
+
+    from local_operator.session.runtime.serving import ServingSessionHandle
+
+    handle = ServingSessionHandle.__new__(ServingSessionHandle)
+    handle._session = _Session()  # type: ignore[attr-defined]
+    handle._projection = _Projection()  # type: ignore[attr-defined]
+
+    handle._publish_pending_gate()
+
+    gate = published["pending_gate"]
+    assert gate["session_name"] == "Quota reporting fix"
+    # The card still validates as the canonical model, which is what makes the
+    # field additive rather than a shape a strict consumer would reject.
+    assert PendingGateState(**gate).session_name == "Quota reporting fix"
+    # And the rest of the card is untouched.
+    assert gate["kind"] == "approval" and gate["detail"] == "write: /etc/hosts"
+
+
+def test_the_gates_session_name_obeys_the_privacy_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The privacy decision stays backend-owned on this path too.
+
+    Only the backend can read `display.notification_session_name`, and a
+    renderer re-deriving it is one that can get it wrong inside a signed binary
+    the user updates on their own schedule. Empty is also the OLD shape, so the
+    opt-out degrades to exactly the anonymous card every existing viewer draws.
+    """
+    from local_operator.mobile.types import PendingRequest
+    from local_operator.session.frontend_state import PendingGateState
+    from local_operator.session.runtime.serving import ServingSessionHandle
+
+    published: dict[str, Any] = {}
+
+    class _Store:
+        def mutate(self, **changes: Any) -> None:
+            published.update(changes)
+
+    class _Session:
+        conversation_name = "Secret client migration"
+        _frontend_state_store = _Store()
+
+    class _Projection:
+        pending = PendingRequest(request_id="gate-1", kind="ask", title="ask", detail="which env?")
+
+    handle = ServingSessionHandle.__new__(ServingSessionHandle)
+    handle._session = _Session()  # type: ignore[attr-defined]
+    handle._projection = _Projection()  # type: ignore[attr-defined]
+
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: False)
+    handle._publish_pending_gate()
+
+    gate = published["pending_gate"]
+    assert gate["session_name"] == ""
+    assert "Secret client" not in str(gate)
+    # An OLD viewer sees a card it fully understands; a NEW viewer reading an
+    # OLD payload (no key at all) gets the same empty default. Additive in both
+    # skew directions, which is the property that lets this ship before the UI.
+    assert PendingGateState(**gate).session_name == ""
+    assert PendingGateState(request_id="g", kind="ask", title="t").session_name == ""

--- a/tests/unit/server/test_desktop_notifications.py
+++ b/tests/unit/server/test_desktop_notifications.py
@@ -50,9 +50,18 @@ from local_operator.session.attention import AttentionStore
 from local_operator.tui.notify import BODIES
 
 
-def _publish(root: Path, session_id: str, anchor: str, kind: str = "complete") -> str:
+def _publish(
+    root: Path,
+    session_id: str,
+    anchor: str,
+    kind: str = "complete",
+    *,
+    baseline_seen: bool | None = None,
+) -> str:
     token = str(uuid.uuid4())
-    AttentionStore(root / "attention.db").publish(f"session/{session_id}", token, anchor, kind)
+    AttentionStore(root / "attention.db").publish(
+        f"session/{session_id}", token, anchor, kind, baseline_seen=baseline_seen
+    )
     return token
 
 
@@ -184,6 +193,8 @@ async def test_a_published_completion_emits_one_notification_after_the_attention
     # The dedupe key is bound to the DURABLE token, not to this bridge's
     # sequence: `acquire()` resets the sequence after a detached interval, so a
     # seq-keyed client would re-toast the same completion on every reconnect.
+    # Literal `complete:` on this side, kind-relative on the error side: the
+    # prefix is the frame's own kind, never a hardcoded row-class label.
     assert payload["dedupe_key"] == f"complete:{sid}:{payload['completion_token']}"
     assert payload["completion_token"] == bridge.attention["completion_token"]
 
@@ -280,6 +291,10 @@ async def test_an_error_is_announced_with_the_house_sentence(tmp_path: Path) -> 
     assert payload["status"] == "Needs attention"
     assert payload["body"] == BODIES["error"]
     assert payload["body_is_snippet"] is False
+    # The dedupe prefix is the frame's own kind (round 1, n1), not a hardcoded
+    # `complete:` — paired with T-B1's literal, the two reachable notifiable
+    # kinds pin the property from both sides.
+    assert payload["dedupe_key"].startswith(f"error:{sid}:")
     assert "412 tests pass" not in str(payload)
 
 
@@ -537,6 +552,35 @@ async def test_a_compose_failure_costs_the_banner_not_the_attention_frame(
     _publish(tmp_path, sid, "result-2")
     await bridge.refresh_attention()
     assert len(bridge.of("notification")) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_new_token_arriving_already_acknowledged_is_not_news(tmp_path: Path) -> None:
+    """T-B14. A token the bridge has NEVER seen can still arrive pre-read.
+
+    The resume-adoption path publishes with ``baseline_seen=True``
+    (``attention.py:243``), which also writes the receipts row at the
+    completion's own sequence: a brand-new token lands with ``unseen: false``.
+    Every OTHER guard clause passes here — the token is new and the kind
+    notifiable — so without the ``unseen`` clause adoption would announce a
+    completion the store already considers read, the T-B2 flood by another
+    route. Pinned as a test because deleting that clause left this whole suite
+    green (review round 1, m1).
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _session_dir(tmp_path, sid, assistant="Ran while the desktop was detached.")
+    bridge = await _baselined(tmp_path, sid)
+
+    token = _publish(tmp_path, sid, "result-1", baseline_seen=True)
+    state = await bridge.refresh_attention()
+
+    # The guard's premises, proven rather than assumed: only the `unseen`
+    # clause can be what held the banner back.
+    assert state["completion_token"] == token
+    assert state["unseen"] is False
+    assert bridge.kinds == ["attention"], "the state frame went out, the banner did not"
+    assert bridge.of("notification") == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_attention.py
+++ b/tests/unit/session/test_attention.py
@@ -672,3 +672,53 @@ def test_a_mismatched_provisional_anchor_cannot_supersede(tmp_path: Path) -> Non
     store.publish("session/a", token, "message-real", "complete")
     assert store.state("session/a")["kind"] == "complete"
     assert store.state("session/a")["anchor_id"] == "message-real"
+
+
+def test_the_desktop_is_just_another_claimant_with_no_special_path(tmp_path: Path) -> None:
+    """A desktop claim and a TUI claim for one completion produce ONE winner.
+
+    The desktop app reaches this primitive through `DesktopSessions.
+    claim_notification`, which passes `backend="desktop"`. The `backend` column
+    is diagnostics only — no decision may read it, because a claim that
+    consulted anything beyond the monotonic sequence would stop being
+    clock-free and two observers with disagreeing clocks would both deliver —
+    so the important property is that naming a new backend buys no privilege
+    whatsoever.
+
+    That matters because the two surfaces are genuinely concurrent in the real
+    configuration this feature ships into: with the desktop window unfocused, a
+    session's `live_state` is `idle`, which makes BOTH a TUI observer and the
+    desktop eligible for the same completion. Exactly one banner is the
+    contract; which one wins is deliberately unspecified.
+    """
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    token = str(uuid.uuid4())
+    store.publish("session/a", token, "result", "complete")
+
+    # Separate stores, as two separate PROCESSES would hold: no shared
+    # connection, no shared cache, only the file.
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        claims = list(
+            pool.map(
+                lambda backend: AttentionStore(path).claim_delivery("session/a", token, backend),
+                ("desktop", "cmux"),
+            )
+        )
+    assert claims.count(True) == 1, "two surfaces both announced one completion"
+
+    # Whoever lost stays locked out, in either order, and a late third surface
+    # inherits the watermark rather than re-firing.
+    assert AttentionStore(path).claim_delivery("session/a", token, "desktop") is False
+    assert AttentionStore(path).claim_delivery("session/a", token, "detached") is False
+
+    # And the claim did not touch the READ watermark on any of those paths:
+    # the sidebar's mark belongs to a human opening the conversation.
+    assert store.state("session/a")["unseen"] is True
+
+    # A NEWER completion is a fresh arbitration, so a delivered conversation is
+    # not permanently silenced on either surface.
+    newer = str(uuid.uuid4())
+    store.publish("session/a", newer, "result-2", "complete")
+    assert AttentionStore(path).claim_delivery("session/a", newer, "desktop") is True
+    assert AttentionStore(path).claim_delivery("session/a", newer, "cmux") is False

--- a/tests/unit/tui/test_notify.py
+++ b/tests/unit/tui/test_notify.py
@@ -704,10 +704,11 @@ def test_the_privacy_flag_governs_the_attached_session_toast_too(
     Review round 1, M2: the flag governed only the observer path, while the
     attached session's own toasts title themselves from ``set_label`` and
     ignored it — and those are the majority of a user's toasts. The settings
-    copy ("A session's name appears on banners, including the lock screen.") is
-    unqualified, so a flag that covered one leg made its own promise false. A
-    privacy control that half works is worse than one that is clearly scoped,
-    because the copy reads as a guarantee.
+    copy ("A session's name, last line and error causes appear on banners,
+    including the lock screen.") is unqualified, so a flag that covered one
+    leg made its own promise false. A privacy control that half works is
+    worse than one that is clearly scoped, because the copy reads as a
+    guarantee.
     """
     monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default: False)
     notifier, sink = unfocused()

--- a/tests/unit/tui/test_notify_wiring.py
+++ b/tests/unit/tui/test_notify_wiring.py
@@ -52,6 +52,11 @@ class RecordingNotifier:
     def __init__(self) -> None:
         self.calls: list[tuple[str, Any]] = []
         self.labels: list[str] = []
+        #: The composed body each call carried, in order. The app now resolves
+        #: this through ``notifications.compose`` before delegating, so a test
+        #: can assert on the TEXT a surface would show without standing up a
+        #: terminal — which is the half ``test_compose.py`` cannot see.
+        self.bodies: list[str] = []
         #: Mirrors the real notifier's focus gate, which is what makes the
         #: DELIVERY-vs-derivation distinction observable here: a suppressed
         #: toast must return False so the app leaves its edge armed.
@@ -64,18 +69,21 @@ class RecordingNotifier:
         self.focused = focused
         self.calls.append(("focus", focused))
 
-    def notify_turn_complete(self, *, running_children: int) -> bool:
+    def notify_turn_complete(self, *, running_children: int, body: str = "") -> bool:
         self.calls.append(("complete", running_children))
+        self.bodies.append(body)
         return running_children == 0 and not self.focused
 
-    def notify_waiting(self, kind: str) -> bool:
+    def notify_waiting(self, kind: str, *, body: str = "") -> bool:
         if self.focused:
             return False
         self.calls.append((kind, None))
+        self.bodies.append(body)
         return True
 
-    def notify_error(self) -> bool:
+    def notify_error(self, *, body: str = "") -> bool:
         self.calls.append(("error", None))
+        self.bodies.append(body)
         return not self.focused
 
     @property
@@ -886,3 +894,205 @@ async def test_a_deferral_armed_without_a_turn_boundary_starts_empty() -> None:
         app.on_subagent_ended(SubagentEnded(job_id="j2", label="b", status="completed"))
         await pilot.pause()
     assert notifier.calls[before:] == []  # `j1` still running: correctly silent
+
+
+# -- composed bodies ---------------------------------------------------------
+#
+# The banner a user gets for the session they are IN used to say less than the
+# one the background observer sent for a session they were NOT in: `send`
+# carried `BODIES[kind]` while the observer path already carried a transcript
+# snippet. That asymmetry is backwards, and closing it is the "every surface
+# agrees" half of this feature. The tests below drive the real app so the
+# composition is exercised where it actually runs — through `_notify`, off a
+# session whose transcript is on disk.
+
+
+class TranscriptSession(JobsSession):
+    """A fake session whose id resolves to a real session directory.
+
+    The composer reads the session's own files, so a fake with no transcript
+    on disk exercises only the degraded path. What makes the assertions below
+    about COMPOSITION rather than about the fallback is that the app can
+    RESOLVE the directory — and it resolves it the way production does, as
+    ``config_dir() / "sessions" / session_id``, which is why these tests
+    redirect the config dir and write the transcript at that exact path rather
+    than handing the session a directory of their own.
+
+    Deliberately NOT a ``transcript`` attribute. That exists on the concrete
+    owner ``Session`` and not on ``AttachedSession``, so a fake carrying one
+    would let a viewer-path regression pass here (see
+    ``test_viewer_protocol.py``); the id is on both.
+    """
+
+    def __init__(self, session_id: str = "sess", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._session_id = session_id
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+
+def _session_dir(tmp_path: Any, monkeypatch: pytest.MonkeyPatch, session_id: str = "sess") -> Any:
+    """Redirect the config dir and return the path the app will resolve.
+
+    ``config_dir()`` reads ``LOCAL_OPERATOR_CONFIG_DIR`` on every call, so
+    pointing it at ``tmp_path`` is what keeps these tests off the operator's
+    real session store while still exercising the production resolution.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    return tmp_path / "sessions" / session_id
+
+
+def _write_transcript(directory: Any, assistant: str) -> None:
+    """One user turn and one assistant reply, in the shape `resume.py` reads."""
+    import json
+
+    directory.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "id": "user-1",
+            "ts": 1.0,
+            "type": "message",
+            "payload": {"kind": "message", "role": "user", "content": [{"text": "go"}]},
+        },
+        {
+            "id": "assistant-1",
+            "ts": 2.0,
+            "type": "message",
+            "payload": {
+                "kind": "message",
+                "role": "assistant",
+                "content": [{"text": assistant}],
+            },
+        },
+    ]
+    (directory / "transcript.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_completed_turns_body_is_the_last_assistant_line(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """T-N1. The banner says what happened, not that something happened.
+
+    "Task complete" is true of every completion ever, so it distinguishes
+    nothing when several sessions finish while the user is away. The last
+    assistant line is the one fact that says WHICH result landed.
+    """
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: True)
+    directory = _session_dir(tmp_path, monkeypatch)
+    _write_transcript(directory, "Rebuilt the search index in 4.1s.")
+    session = TranscriptSession()
+    app, notifier = await _app_with_notifier(session)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        app._notifier = notifier  # type: ignore[assignment]
+        _end_turn(app, TurnEnded(aborted=False, error=None))
+        await pilot.pause()
+
+    assert notifier.kinds == ["complete"]
+    assert notifier.bodies == ["Rebuilt the search index in 4.1s."]
+
+
+@pytest.mark.asyncio
+async def test_the_privacy_flag_keeps_both_the_name_and_the_snippet_off(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """T-N2. One flag over two facts, asserted on the app's real path.
+
+    `test_compose.py` pins the rule on the pure function; this pins that the
+    app reaches it, because a `_notify` that composed with its own arguments
+    (or skipped the composer for a kind) would leak exactly what the setting
+    exists to hide while the composer's own tests stayed green.
+    """
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: False)
+    directory = _session_dir(tmp_path, monkeypatch)
+    _write_transcript(directory, "Merged the acquisition memo.")
+    session = TranscriptSession()
+    app, notifier = await _app_with_notifier(session)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        app._notifier = notifier  # type: ignore[assignment]
+        _end_turn(app, TurnEnded(aborted=False, error=None))
+        await pilot.pause()
+
+    from local_operator.tui.notify import BODIES
+
+    assert notifier.bodies == [BODIES["complete"]]
+    assert "acquisition" not in "".join(notifier.bodies)
+
+
+@pytest.mark.asyncio
+async def test_an_errored_turns_body_is_the_house_sentence(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """T-N3. A failure must not be described by whatever it last said.
+
+    The last thing a failing turn said is routinely a success sentence, and on
+    a lock screen it sits beside "Needs attention" with nothing to check it
+    against (review round 1, M1).
+    """
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: True)
+    directory = _session_dir(tmp_path, monkeypatch)
+    _write_transcript(directory, "All 412 tests pass.")
+    session = TranscriptSession()
+    app, notifier = await _app_with_notifier(session)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        app._notifier = notifier  # type: ignore[assignment]
+        _end_turn(app, TurnEnded(aborted=False, error="provider refused"))
+        await pilot.pause()
+
+    from local_operator.tui.notify import BODIES
+
+    assert notifier.kinds == ["error"]
+    assert notifier.bodies == [BODIES["error"]]
+    assert "412" not in "".join(notifier.bodies)
+
+
+@pytest.mark.asyncio
+async def test_the_in_band_osc_leg_never_carries_model_written_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-N4. BLOCKER-CLASS: model text may reach argv, never an escape sequence.
+
+    The cmux leg and the `notify-send` leg pass the composed body as an ARGV
+    element, where the escaping belongs to the OS. The in-band leg writes an
+    OSC string straight to the terminal, and ESC/BEL inside one close the
+    sequence early and leave the remainder executing as terminal commands.
+
+    `sanitize_text` strips both bytes, so this is defence in depth rather than
+    the only guard — but "model text never reaches an OSC string" is an
+    invariant worth holding structurally instead of resting on one regex, and
+    the regex is exactly the kind of thing a later refactor relaxes. This test
+    drives the REAL notifier (the recorder above cannot see a wire) with a
+    bare OSC 9 terminal and no cmux surface, which is the only configuration
+    where the in-band leg is the one that fires.
+    """
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default=None: True)
+    from local_operator.tui.notify import BODIES, Notifier
+
+    writes: list[str] = []
+    # No `CMUX_SURFACE_ID`: this suite runs inside cmux, whose surface would
+    # otherwise capture the delivery and leave the sink empty — a green run
+    # proving nothing about the wire.
+    notifier = Notifier(
+        writes.append,
+        env={"GHOSTTY_RESOURCES_DIR": "/Applications/Ghostty.app/Contents/Resources"},
+        platform="darwin",
+    )
+    notifier.set_focused(False)
+    notifier.set_label("Index work")
+
+    snippet = "Rebuilt the search index in 4.1s."
+    assert notifier.send("complete", body=snippet) is True
+
+    wire = "".join(writes)
+    assert BODIES["complete"] in wire, "the OSC leg must keep the house sentence"
+    assert snippet not in wire, "model-written text reached an in-band escape"
+    # The title is still the session's name, so this is not passing because
+    # nothing was written at all.
+    assert "Index work" in wire


### PR DESCRIPTION
## Summary

The desktop app toasted **"Turn complete — The agent finished its turn."** on both `agent_end` and `turn_end`, with no session name, no outcome and no context. Both triggers are wrong and the text says nothing: `turn_end` is **one model call**, of which an agentic turn has many, and `agent_end` routinely arrives **while `task` children are still running** because the `task` tool returns at registration. So a single delegating turn produced a burst of banners, each asserting a finish that had not happened.

This implements the backend half of `docs/design/descriptive-notifications.md` (included in this PR): a backend composer, a gated `notification` frame, a claim route, and TUI parity.

Release: minor — desktop notifications now name the session, its outcome and what happened, and fire only on a genuinely finished turn instead of once per step.

## Why the backend composes

Three surfaces show the same completion: the TUI's own notifier, the detached runtime's OS fallback, and the desktop app. Only the backend can read `display.notification_session_name`, so **only the backend can decide** whether a banner may carry a session's name or a line of its content. A renderer composing its own strings would re-derive a privacy rule it cannot see, and would ship the wording inside a signed binary where a fix costs a full release.

`local_operator/notifications/compose.py` renders `{title, status, body}` from `tui/notify.py`'s existing vocabulary. Nothing outside `tui/` writes an escape sequence, spawns `notify-send`, or constructs an OS notification — the import rule that module's docstring rests on is unchanged. The server now *composes*; it still never *delivers*.

## Why the gate moved rather than tightened

The bridge emits a `notification` **iff** it observes a newly published, unseen `completions` row. That row exists only because `Session._publish_attention_outcome` judged the turn notifiable — in the process that owns the job manager, using the same delegated-children check the TUI uses. A delegating parent's premature `agent_end` writes an `eligible: False` marker and publishes nothing, so there is simply no row to observe; each settled child re-enters as a fresh turn whose own completion publishes normally.

The bridge therefore asks **no** questions about jobs, `agent_end` or `turn_end`. Reconstructing that decision in a process with less information is exactly how a frontend ends up disagreeing with the TUI about whether a turn finished.

`BRIDGE_NOTIFIABLE_KINDS = {"complete", "error"}`. `ask`/`approval` already reach the app as `pending_gate` (a second channel for one card is how one question becomes two banners); `interrupted` is suppressed because the user pressed the key themselves a moment ago.

## Two invariants called out as blocker-class

- **The in-band OSC leg keeps `BODIES[kind]`.** Model-written text reaches only the cmux and D-Bus legs, where it is an argv element and the escaping is the OS's. An OSC string is the one wire where ESC/BEL would close the sequence early and leave the remainder executing as terminal commands. `sanitize_text` strips both, so this is defence in depth — but the invariant is held structurally, not by one regex. Pinned by **T-N4**.
- **`claim_delivery` never acknowledges.** `/notified` touches neither `unseen` nor the receipts watermark, and acquires no bridge and spawns no runtime (it mirrors `acknowledge_attention`). Pinned by **T-B10** and **T-B11**, and shown live below.

## Design-round findings folded in (both additive)

- **D4 — an `error` banner names the failure.** The text **is** durably reachable without inventing a path: `incidents.py` journals a `session_incident` record on every classified failure, and its `details.raw` holds the unrendered provider text. `resume.session_failure_summary()` reads it from the same bounded 64 KiB tail window `session_preview` already uses. `raw`, never the rendered `text` (that is a multi-line model-facing block tailed with "Take it into account before repeating the same request.", which reads as nonsense on a lock screen). Same scrub, same 120-char budget, same privacy gate — an error envelope can quote a prompt fragment, a file path or an account id, so it is *more* sensitive than the name the flag was written for. New `body_is_failure` flag; never true alongside `body_is_snippet`. **This does not weaken M1**: the snippet is still `complete`-only, and this text is safe precisely because it describes the *failure* rather than the work, so it cannot read as a success beside a state that says it failed.
- **D3 — a gate banner is triageable.** No second channel, per §5.2: `PendingGateState` gains an additive, optional, defaulted `session_name`, stamped at both publication sites (`ServingSessionHandle._publish_pending_gate` and `RuntimeServer.set_pending`, the latter delegating to the former's helper so the privacy rule cannot hold on one and not the other). `""` when the flag is off — the privacy decision stays backend-owned for the same reason §1 gives for composing in the backend at all. Additive in both skew directions, so this ships before the UI renders it.

Both are recorded in §13 of the design doc.

## E2E evidence — the frame assertions, not a toast

These drive the **assembled** app: real loopback HTTP, real `Session`/`ServingSessionHandle`/`RuntimeServer`/`AttachClient`, only the provider stream scripted. They assert the **ordered frame log**, because the property is a *count* — `next_frame` discards what it skips and could never fail on a second banner.

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e/test_desktop_sessions.py \
    -m e2e -n0 -q -p no:randomly -s -k "notification or delegating"

Real multi-step turn over HTTP: 2 turn_end + 1 agent_end frames produced exactly 1 notification,
body='Wrote the report to notification-evidence.txt.'; second /notified claimed=false; session still unseen
Delegating turn: agent_end with a live task child produced 0 notifications and no completion row;
after the child settled, the re-entry turn produced exactly 1, body='The subagent finished; the audit is clean.'
2 passed, 1 deselected, 5 warnings in 7.44s
```

**Both tests were proven to fail against the defect.** Restoring the old behaviour (publish a notification on every `turn_end`/`agent_end`) turns both red; reverting turns both green:

```
2 failed, 1 deselected, 5 warnings in 8.33s     # defect reintroduced
2 passed, 1 deselected, 5 warnings in 9.79s     # fix restored
```

The same discipline was applied to T-N1/T-N3 (drop the composed body → fail) and T-N4 (let the composed body reach the OSC leg → `AssertionError: the OSC leg must keep the house sentence`).

### Live server, outside pytest

The route was also exercised against a really-running uvicorn under a redirected `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`:

```
capabilities.notification_contract = 1
first  /notified: 200 {'claimed': True}
second /notified: 200 {'claimed': False}
after claims: unseen = True revision = [1, 0]     <- notifying is NOT reading
malformed token: 422
unknown session: 404
wrong bearer: 401
after /seen: unseen = False                        <- the read path still works
```

And D4 against a genuinely failing turn (a provider error raised through the real agent loop):

```
attention kind: error | unseen: True
  title  : Quota reporting fix
  status : Needs attention
  body   : rate_limit_error: quota exhausted for anthropic/claude-opus-5
  flags  : failure=True snippet=False name=True
```

## Gates

| Gate | Result |
|---|---|
| `flake8 .` | clean |
| `black --check .` (26.1.0, CI pin) | 1244 files unchanged |
| `isort --check-only .` (5.13.2) | clean |
| `pyright` (1.1.411, pyproject pin) | **0 errors, 0 warnings** |
| `pytest tests/unit -q` | **18,713 passed**, 18 skipped, 11 pre-existing failures (below) |
| `pytest tests/e2e -m e2e -n0 -q` | **111 passed**, 7 skipped |

**The 11 failures are pre-existing on this base and unrelated.** All are `tests/unit/tui/test_ask_picker.py` footer assertions (`'^e more' in '◆ test/model › ⌂ …'`). Confirmed by stashing this branch's entire diff and re-running on the clean tree: `11 failed, 122 passed`. Same 11 tests, same assertions.

Two failures **were** mine and are fixed: `test_viewer_protocol` / `test_remote_registries` caught `_notify` reading `session.transcript`, which exists on the concrete owner `Session` but not on `AttachedSession` — it would have composed correctly for an owner and silently degraded every **viewer's** banner to the house sentence. The directory is now derived as `config_dir() / "sessions" / session_id`, the way the observer path already derives it. That is the `/team` and `/agent` regression shape those tests exist to catch, and it is exactly the class of defect a green notification suite would not have shown.

## Measured, not assumed

`compose()` over a synthetic **42 MB** transcript: **0.19 ms median, 0.31 ms worst of 20**. Both reads are bounded windows, so cost is independent of transcript size. The TUI therefore composes **inline** (a `run_worker` hop would buy nothing and cost the turn-end toast a scheduling delay); the bridge still threads it, because it runs inside the 1 s poll shared by up to `BRIDGE_COUNT` bridges. Recorded in §9 of the design doc.

## Tests

- `tests/unit/notifications/test_compose.py` — T-C1…T-C9 plus the D4 cases (16 tests)
- `tests/unit/server/test_desktop_notifications.py` — T-B1…T-B13 plus the D3/D4 wire cases (21 tests)
- `tests/unit/tui/test_notify_wiring.py` — T-N1…T-N4
- `tests/unit/session/test_attention.py` — desktop vs TUI claim, exactly one winner
- `tests/e2e/test_desktop_sessions.py` — the two frame assertions above, plus the D3 assertion on a genuinely parked gate
- `tests/unit/tui/test_background_completion_notify.py` — green, untouched

## Docs

`docs/DESKTOP_API.md` (frame list, endpoint table, the `notification` section, and the partly-false sentence at ~line 243 about gate/turn dedupe being unimplemented), `docs/ATTENTION.md` (desktop as a `claim_delivery` claimant with `backend="desktop"`), and `tui/notify.py`'s module docstring (the server still never *delivers*; it now *composes*).

## Not done, deliberately

No version bump. No UI changes — the renderer half is the sibling PR. No `interrupted` on the desktop (one `frozenset` entry away if that judgement changes; `AgentEndEvent` carries `aborted` with no actor, so "who interrupted it" is not decidable here).
