### PR TITLE
fix(tui): pad one row below every tool-call summary at the default density

### DIFF
--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -361,10 +361,48 @@ Screen > .screen--selection {
  * Under `auto` that first measurement resolves to two rows and stays there
  * even after the resize rebuilds the row to fit — a ledger of one-line
  * traces silently doubles in height. Pinning makes the worst case a clipped
- * cell for one frame, which is the right failure. */
+ * cell for one frame, which is the right failure. The pin is therefore
+ * `1 + padding-bottom` rather than a bare `1`: Textual sizes a fixed-height
+ * widget INCLUDING its padding, so the two numbers below move together or
+ * the summary clips instead of gaining air.
+ *
+ * ONE PAD ROW, BELOW THE SUMMARY, and that row is the default rather than a
+ * setting. Reported from the field as "there's essentially no padding between
+ * lines": at `height: 1` the summary's ink filled its slab edge to edge, and
+ * with one ground row between neighbours the ink pitch was 2 — consecutive
+ * actions read as one jammed stack rather than as a ledger of separate
+ * things. This takes the pitch to 3.
+ *
+ * BELOW rather than above, and the two are not interchangeable even though
+ * they cost the same row. A top-only pad is exactly what PR 870 removed from
+ * `.comfortable-rows`: it leaves the card's fill TERMINATING ON AN INKED
+ * LINE, with the summary jammed against the bottom edge of its own slab, and
+ * it was reported from the field in that shape ("a row added above the tool
+ * call and not below"). A bottom pad ends the slab on air, so the run reads
+ * as a column of settled receipts.
+ *
+ * The other rung that buys the same row was measured and rejected: widening
+ * the `.gap-above` ground between neighbours to two rows gives the same pitch
+ * of 3, but it spends the row on GROUND rather than on the card, so each
+ * action stays a one-cell strip of `$lo-surface` and the ledger reads as thin
+ * disconnected bands with more void between them — most visible on the light
+ * palette, where the card fill is the quieter of the two. It also grows no
+ * click target, where this pad doubles one (the whole row is the expand
+ * surface — `ExpandableActionBlock.on_click` is on the widget, so the pad row
+ * is inside it).
+ *
+ * The density cost is honest and is why this is ONE row and not two: a
+ * twelve-action ledger occupies 35 rows against 23. `.comfortable-rows`
+ * remains the airier opt-in above this (pitch 4, 47 rows) and is unchanged —
+ * this is the rung between flush and that, not a replacement for it. */
 ToolCard, WakeBlock, PeerMessageBlock {
-    height: 1;
+    height: 2;
     background: $lo-surface;
+    /* Vertical only. The left/right values are 0 here because the one-cell
+     * LEFT inset is drawn by the row builder instead — see the NOTE below —
+     * and Textual resolves `padding` as ONE declaration per rule, so this
+     * line owns the whole property for these selectors. */
+    padding: 0 0 1 0;
     /* NOTE: the one-cell LEFT inset these cards carry is drawn by the row
      * builder (`ToolCard.ROW_INDENT`), not declared here. It has to yield at
      * narrow widths — see that constant — and the sheet has no width to
@@ -384,7 +422,14 @@ ToolCard, WakeBlock, PeerMessageBlock {
  * row per line of revealed output (each already truncated to width, so
  * nothing reflows). The class beats the type selector above. WakeBlock and
  * PeerMessageBlock use their own class names because they are different
- * widgets; the height contract is the same. */
+ * widgets; the height contract is the same.
+ *
+ * It declares no `padding`, which is deliberate and not an omission: the base
+ * rule's bottom pad CASCADES here, so an expanded card ends on the same row of
+ * its own fill a collapsed one does and the payload's last line is never the
+ * slab's edge. `height: auto` grows to carry that row rather than clipping it,
+ * which is exactly why the pad may only be restated where the height is
+ * pinned. */
 ToolCard.tool-expanded, WakeBlock.wake-expanded, PeerMessageBlock.peer-expanded {
     height: auto;
 }
@@ -392,13 +437,23 @@ ToolCard.tool-expanded, WakeBlock.wake-expanded, PeerMessageBlock.peer-expanded 
 /* COMFORTABLE DENSITY (`display.comfortable_rows`, default ON changed to OFF by maintainer). One padding
  * row above and below an action's summary.
  *
+ * Still an opt-in, and still OFF by default, but it is now the TOP rung of a
+ * three-rung ladder rather than the only alternative to a flush row. The base
+ * rule above pads one row BELOW every summary for everyone (ink pitch 3); this
+ * class adds the second row, ABOVE, and brackets the summary on both sides
+ * (pitch 4). Strictly airier than the default is the contract — a version of
+ * this class that merely restated the default would be a setting that does
+ * nothing, which is how it reads to the user who turns it on.
+ *
  * This is a HIT TARGET, not decoration. The whole row is the click surface
  * for expand/collapse (`ExpandableActionBlock.on_click` is on the widget, so
  * padding rows are inside it), and at one cell tall that target was a single
  * terminal line: a click a row off either landed on a neighbouring action or
  * fell through to the transcript. Three rows triples the target without
  * moving a single glyph — the summary is still exactly one row of text, so
- * the ledger's one-line-per-action reading is unchanged.
+ * the ledger's one-line-per-action reading is unchanged. (The default's own
+ * pad already doubled it; this is the rung for a user who clicks rows often
+ * enough to want the whole bracket.)
  *
  * `height: 3` is `1 + padding-top + padding-bottom`. Textual sizes a
  * fixed-height widget INCLUDING its padding, so the three move together or
@@ -407,7 +462,9 @@ ToolCard.tool-expanded, WakeBlock.wake-expanded, PeerMessageBlock.peer-expanded 
  * SYMMETRIC, and the argument that said otherwise was wrong. This rule read
  * `padding: 1 0 0 0` for its whole life while the comment above promised air
  * "above and below", on the theory that a bottom row would break the dock's
- * EXACTLY ONE ground row between the last block and the composer. It does
+ * EXACTLY ONE ground row between the last block and the composer. (That same
+ * finding is why the base rule's single pad row went BELOW the summary rather
+ * than above it.) It does
  * not, and the reason is the distinction this sheet keeps making everywhere
  * else: the guarantee is about GROUND, not about blankness. With a card last
  * a naive blank-row count returns 2, and only one of them is the
@@ -448,25 +505,31 @@ ToolCard.tool-expanded, WakeBlock.wake-expanded, PeerMessageBlock.peer-expanded 
  * (widgets/tool_card.py — "NO border. Elevation is a background step, never a
  * shadow or line.").
  *
- * The cost is real: a twelve-action ledger occupies 47 rows against 35, so
- * less history fits on a screen. That is why this is a setting rather than a
- * decision made for everyone — a user who reads a long ledger more often
- * than they click one turns it off.
+ * The cost is real: a twelve-action ledger occupies 47 rows against the
+ * default's 35, so less history fits on a screen. That is why this is a
+ * setting rather than a decision made for everyone — a user who reads a long
+ * ledger more often than they click one turns it off, and lands on a default
+ * that is itself no longer flush.
  *
  * Expanded rows are exempt: they are already `height: auto` and content-sized,
  * and the payload gives the pointer plenty to hit. */
 .comfortable-rows ToolCard, .comfortable-rows WakeBlock, .comfortable-rows PeerMessageBlock {
     height: 3;
-    /* Restates the base rule's left inset rather than adding to it: Textual
-     * resolves `padding` as ONE declaration, so writing only the vertical
-     * values here would win the whole property and drop the inset. */
+    /* REPLACES the base rule's `0 0 1 0` rather than adding to it: Textual
+     * resolves `padding` as ONE declaration per rule, so this line owns the
+     * whole property here and has to restate the bottom pad it keeps (and the
+     * zero left/right, which is where the row builder's inset lives). The
+     * height is `1 + top + bottom` for the same reason the base rule's is
+     * `1 + bottom`. */
     padding: 1 0 1 0;
 }
 
 .comfortable-rows ToolCard.tool-expanded, .comfortable-rows WakeBlock.wake-expanded,
 .comfortable-rows PeerMessageBlock.peer-expanded {
     height: auto;
-    /* Left value restated for the same reason as the collapsed rule above. */
+    /* Restated for the same reason as the collapsed rule above — one
+     * declaration wins the whole property, so the bottom pad the base rule
+     * would otherwise cascade has to be written again here. */
     padding: 1 0 1 0;
 }
 

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -39,9 +39,9 @@ _DEFAULT_NOTES: dict[str, Any] = {
     "display.shimmer": True,
     # One padding row above and below a tool row and a user prompt
     # (`.comfortable-rows` in the stylesheet). Default ON was changed to OFF
-    # by the maintainer. OFF is no longer flush: the sheet pads one row BELOW
-    # every action row for everyone, and this setting adds the row ABOVE, so
-    # it remains strictly the airier of the two densities.
+    # by the maintainer. OFF is no longer flush: the default already pads one
+    # row below every action row, and this adds the matching row above — so
+    # turning it on is always a step airier, never a no-op.
     "display.comfortable_rows": False,
     # Nerd Font glyphs on tool rows. Default is None = AUTO: unset means
     # `tui/glyphs.py` decides from the terminal-emulator env markers (a

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -39,7 +39,9 @@ _DEFAULT_NOTES: dict[str, Any] = {
     "display.shimmer": True,
     # One padding row above and below a tool row and a user prompt
     # (`.comfortable-rows` in the stylesheet). Default ON was changed to OFF
-    # by the maintainer.
+    # by the maintainer. OFF is no longer flush: the sheet pads one row BELOW
+    # every action row for everyone, and this setting adds the row ABOVE, so
+    # it remains strictly the airier of the two densities.
     "display.comfortable_rows": False,
     # Nerd Font glyphs on tool rows. Default is None = AUTO: unset means
     # `tui/glyphs.py` decides from the terminal-emulator env markers (a

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -5,6 +5,10 @@ background-filled cards — one elevation step brighter than the ground
 (kit ``surface`` on ``bg``), full-width single rows with 1-cell inner
 padding, NO border. Elevation is a background step, never a shadow or line.
 
+One line of INK, two terminal rows: the sheet pads one row below the summary
+so the card's fill ends on air rather than on the inked line itself. That is
+the default density; ``display.comfortable_rows`` adds the matching row above.
+
 Row anatomy — one COLUMN per field, so a ledger is scanned down, not read
 across::
 
@@ -900,10 +904,13 @@ def _row_text() -> Text:
 
     What actually holds the one-row rule, in order:
 
-    1. ``ToolCard { height: 1 }`` in the stylesheet — the real enforcement. A
-       collapsed card is one cell tall, so wrapped content is clipped, never
-       reflowed. ``ToolCard.tool-expanded`` relaxes it to ``height: auto``
-       precisely because expansion is the one case that may be taller.
+    1. ``ToolCard { height: 2; padding: 0 0 1 0 }`` in the stylesheet — the
+       real enforcement. The pin is ``1 + padding-bottom`` (Textual sizes a
+       fixed-height widget including its padding), so the CONTENT box stays one
+       cell tall and wrapped content is clipped, never reflowed; the second row
+       is the pad that keeps consecutive actions from reading as one stack.
+       ``ToolCard.tool-expanded`` relaxes it to ``height: auto`` precisely
+       because expansion is the one case that may be taller.
     2. The status segment is hard-trimmed to ``width - 3`` in ``_build_row``,
        so no state's label can outgrow its column.
     3. Diff counters are dropped first when the cap bites, so the outcome
@@ -916,7 +923,13 @@ def _row_text() -> Text:
 
 
 class ToolCard(ExpandableActionBlock):
-    """A tool execution: ONE row, on a state-tinted elevation step.
+    """A tool execution: ONE row of ink, on a state-tinted elevation step.
+
+    The widget occupies two terminal rows collapsed, not one: the summary plus
+    a pad row below it in the card's own fill. The ledger is still one LINE per
+    action — the pad carries no glyph — and the extra row is what stops a run
+    of actions reading as a single jammed stack (see the ``ToolCard`` rule in
+    ``local_operator.tcss`` for the ladder and the rejected alternatives).
 
     Lifecycle: construct with ``tool_call_id``/``tool_name`` (running),
     :meth:`mark_done` on success, :meth:`mark_failed` on error,
@@ -1926,10 +1939,11 @@ class ToolCard(ExpandableActionBlock):
         ``Static.update`` reflows by default and a reflow re-arranges the whole
         transcript — 7.8 ms across 173 widgets on a 161-block screen — but a
         card's footprint is its row count and nothing else: collapsed, the
-        sheet pins it to ``height: 1`` and the row cannot reflow anything at
-        all. Without this guard the 1 Hz clock on every running card, and every
-        pointer crossing a card's edge, each reflowed the entire screen to
-        repaint one row.
+        sheet pins it to a one-cell content box (``height: 2`` against a
+        one-row bottom pad) and the row cannot reflow anything at all. Without
+        this guard the 1 Hz clock on every running card, and every pointer
+        crossing a card's edge, each reflowed the entire screen to repaint one
+        row.
         """
         # `fold_width(0)` walks size → container → the parent transcript's
         # scrollable content region, and returns 0 only when none of the three

--- a/scripts/ledger_density_shot.py
+++ b/scripts/ledger_density_shot.py
@@ -1,0 +1,219 @@
+"""Capture the tool-ledger DENSITY ladder: every rung between flush and comfortable.
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/ledger_density_shot.py OUT.svg [COLSxROWS] [RUNG] [PALETTE]
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/ledger_density_shot.py --geometry [COLSxROWS]
+
+The report this exists for was about the ledger's RHYTHM, not about one card:
+"there's essentially no padding between lines". A single card is unreadable as
+evidence of that — the defect only appears in a RUN of consecutive actions,
+where the ink pitch (summary row to next summary row) is what the eye reads as
+crowding. So every rung seeds six real ``ToolCard``s under an ``AssistantBlock``
+through the real ``OperatorApp``, which is also what makes the frames comparable
+to each other and to a live session: the lightweight hosts in the test files
+declare no ``CSS_PATH`` and would not show a padding change at all (``AGENTS.md``,
+"Visual validation").
+
+The rungs, in ink-pitch order. Each is a DIFFERENT way to buy the same row of
+air, and they do not look alike on a filled frame even though the arithmetic
+says they cost the same:
+
+* ``default``     — 1-row card, 1 ground row. Pitch 2. The reported state.
+* ``pad-below``   — 2-row card, the pad row BELOW the summary. Pitch 3.
+* ``pad-above``   — 2-row card, the pad row ABOVE the summary. Pitch 3.
+* ``double-gap``  — 1-row card, TWO ground rows between neighbours. Pitch 3.
+* ``comfortable`` — ``display.comfortable_rows``: 3-row card. Pitch 4.
+
+``pad-below``/``pad-above``/``double-gap`` all cost one row per action and are
+told apart only by WHOSE fill the extra row carries — the card's own
+``$lo-surface`` on the first two, the transcript's ``$lo-bg`` on the third.
+That distinction is the whole design question here (see the ``.comfortable-rows``
+comment in the stylesheet on a fill that "terminated on an inked line"), and it
+is invisible in a height number, which is why this script rasterizes.
+
+Rungs other than the tree's own default are applied as INLINE styles on the
+widgets rather than by editing the sheet, so one process can render the whole
+ladder and a rung is never confused with what the repository ships. Inline
+styles beat the sheet's rules, so what is captured for a rung is that rung —
+but ``default`` is genuinely untouched, and therefore tracks the sheet.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.probe_isolation  # noqa: E402, F401  -- must precede app imports
+from local_operator.tui.app import COMFORTABLE_ROWS_CLASS, OperatorApp  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
+from local_operator.tui.widgets.transcript import (  # noqa: E402
+    GAP_CLASS,
+    TranscriptView,
+    UserBlock,
+)
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: A realistic opening run: the shapes an agent actually emits back to back.
+#: Mixed tools so the icon/name columns vary, mixed durations so the status
+#: column is not a single repeated string, and summaries long enough to reach
+#: the ellipsis at 100 columns — a ledger of short rows understates crowding
+#: because the eye has whitespace to rest in that a real one does not give it.
+CALLS: list[tuple[str, dict[str, object], float]] = [
+    ("bash", {"command": "cd ~/local-operator && git log --oneline -3 && git status --short"}, 0.1),
+    ("read", {"path": "~/local-operator/AGENTS.md"}, 0.0),
+    ("bash", {"command": "ls local_operator && ls scripts && echo '---' && ls tests"}, 0.0),
+    ("grep", {"pattern": "Visual validation", "path": "AGENTS.md", "context_lines": 6}, 0.2),
+    ("read", {"path": "local_operator/tui/local_operator.tcss", "range": "355-505"}, 0.0),
+    ("bash", {"command": "grep -rn 'comfortable_rows' --include='*.py' . | head -40"}, 1.0),
+]
+
+#: Twelve calls is the second measurement the density argument needs: the cost
+#: of a rung is per-action, so it is a screen's worth of ledger that says
+#: whether a rung fits a working session rather than a demo.
+LONG_RUN = 12
+
+RUNGS = ("default", "pad-below", "pad-above", "double-gap", "comfortable")
+
+
+def _apply_rung(app: OperatorApp, rung: str) -> None:
+    """Put the app into ``rung``'s density, on top of whatever the sheet says.
+
+    Inline styles rather than a stylesheet edit: the whole ladder has to be
+    renderable from one tree so the frames differ in density and in nothing
+    else (font, theme, fixture, Textual version). ``height`` and ``padding``
+    are set together for the reason the sheet's own comment gives — Textual
+    sizes a fixed-height widget INCLUDING its padding, so a pad row without
+    the matching height clips the summary instead of bracketing it.
+    """
+    if rung == "comfortable":
+        app.screen.add_class(COMFORTABLE_ROWS_CLASS)
+        return
+    for card in app.query(ToolCard):
+        if rung == "pad-below":
+            card.styles.height = 2
+            card.styles.padding = (0, 0, 1, 0)
+        elif rung == "pad-above":
+            card.styles.height = 2
+            card.styles.padding = (1, 0, 0, 0)
+        elif rung == "double-gap":
+            # The rung that buys its row from the GROUND instead of the card.
+            # Only rows that already carry the adaptive gap are widened, so
+            # this stays a change to the ledger's rhythm rather than a margin
+            # on every block (the "blank row between everything" regression
+            # the base selectors are kept margin-free to prevent).
+            if card.has_class(GAP_CLASS):
+                card.styles.margin = (2, 0, 0, 0)
+
+
+async def _seed(app: OperatorApp, pilot, count: int) -> None:
+    app.query_one(Editor).cursor_blink = False
+    app._append_block(UserBlock("review the tool call lines for padding"))
+    block = AssistantBlock()
+    block.update_text("I'll start by reading the ground-truth docs before touching anything.")
+    app._append_block(block)
+    await pilot.pause()
+    for index in range(count):
+        name, args, seconds = CALLS[index % len(CALLS)]
+        card = ToolCard(f"call-{index}", name, dict(args))
+        card.mark_done("ok", measured_s=seconds)
+        app._append_block(card)
+    for _ in range(4):
+        await pilot.pause()
+
+
+def _report(app: OperatorApp, rung: str, size: tuple[int, int]) -> dict[str, object]:
+    """The numbers behind the frame (``AGENTS.md``, "Check the numbers").
+
+    Pitch is measured summary-row to summary-row on the COMPOSED frame rather
+    than derived from the declarations, because that is the quantity the report
+    was about and the one a padding/margin/height mix-up gets wrong.
+    """
+    view = app.query_one(TranscriptView)
+    cards = [c for c in app.query(ToolCard) if c.region.height]
+    rows: list[str] = []
+    for child in view.children:
+        classes = " ".join(sorted(child.classes)) or "-"
+        rows.append(
+            f"    y={child.region.y:>3} h={child.region.height} "
+            f"fill={child.styles.background} {type(child).__name__} [{classes}]"
+        )
+    tops = [c.region.y for c in cards]
+    pitches = [b - a for a, b in zip(tops, tops[1:])]
+    heights = sorted({c.region.height for c in cards})
+    card_heights = (c.region.height for c in cards)
+    gaps = sorted({b - (a + h) for a, b, h in zip(tops, tops[1:], card_heights)})
+    span = (cards[-1].region.bottom - cards[0].region.y) if cards else 0
+    print(f"  rung={rung} size={size[0]}x{size[1]} calls={len(cards)}")
+    print("\n".join(rows))
+    print(f"    card heights={heights} gap rows={gaps} pitch={pitches} span={span}")
+    return {
+        "rung": rung,
+        "height": heights[0] if heights else 0,
+        "gap": gaps[0] if gaps else 0,
+        "pitch": pitches[0] if pitches else 0,
+        "span": span,
+    }
+
+
+async def _run(rung: str, size: tuple[int, int], palette: str, count: int, out: str | None):
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        app._apply_theme(palette)
+        await _seed(app, pilot, count)
+        _apply_rung(app, rung)
+        for _ in range(4):
+            await pilot.pause()
+        summary = _report(app, rung, size)
+        if out is not None:
+            save_capture(app, out)
+    return summary
+
+
+async def _geometry(size: tuple[int, int]) -> None:
+    table: list[dict[str, object]] = []
+    for rung in RUNGS:
+        short = await _run(rung, size, "dark", len(CALLS), None)
+        # A tall frame so twelve cards are all laid out rather than clipped by
+        # the viewport — the span being measured is the ledger's, not the
+        # screen's.
+        long_run = await _run(rung, (size[0], 60), "dark", LONG_RUN, None)
+        short["span12"] = long_run["span"]
+        table.append(short)
+    print(f"\n| rung | card h | gap rows | ink pitch | span {len(CALLS)} calls | span {LONG_RUN} |")
+    print("|---|---|---|---|---|---|")
+    for row in table:
+        print(
+            f"| {row['rung']} | {row['height']} | {row['gap']} | {row['pitch']} "
+            f"| {row['span']} | {row['span12']} |"
+        )
+
+
+def main() -> None:
+    if sys.argv[1] == "--geometry":
+        size = (100, 30)
+        if len(sys.argv) > 2:
+            cols, rows = sys.argv[2].lower().split("x")
+            size = (int(cols), int(rows))
+        asyncio.run(_geometry(size))
+        return
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].lower().split("x")
+        size = (int(cols), int(rows))
+    rung = sys.argv[3] if len(sys.argv) > 3 else "default"
+    palette = sys.argv[4] if len(sys.argv) > 4 else "dark"
+    if rung not in RUNGS:
+        raise SystemExit(f"unknown rung {rung!r}; expected one of {', '.join(RUNGS)}")
+    asyncio.run(_run(rung, size, palette, len(CALLS), out))
+
+
+main()

--- a/scripts/ledger_density_shot.py
+++ b/scripts/ledger_density_shot.py
@@ -19,8 +19,10 @@ The rungs, in ink-pitch order. Each is a DIFFERENT way to buy the same row of
 air, and they do not look alike on a filled frame even though the arithmetic
 says they cost the same:
 
-* ``default``     — 1-row card, 1 ground row. Pitch 2. The reported state.
+* ``flush``       — 1-row card, 1 ground row. Pitch 2. The REPORTED state,
+  i.e. what the ledger looked like before this pad shipped.
 * ``pad-below``   — 2-row card, the pad row BELOW the summary. Pitch 3.
+  This is what the sheet now ships by default.
 * ``pad-above``   — 2-row card, the pad row ABOVE the summary. Pitch 3.
 * ``double-gap``  — 1-row card, TWO ground rows between neighbours. Pitch 3.
 * ``comfortable`` — ``display.comfortable_rows``: 3-row card. Pitch 4.
@@ -32,11 +34,22 @@ That distinction is the whole design question here (see the ``.comfortable-rows`
 comment in the stylesheet on a fill that "terminated on an inked line"), and it
 is invisible in a height number, which is why this script rasterizes.
 
-Rungs other than the tree's own default are applied as INLINE styles on the
+EVERY rung is applied as an EXPLICIT, SELF-CONTAINED inline override on the
 widgets rather than by editing the sheet, so one process can render the whole
 ladder and a rung is never confused with what the repository ships. Inline
-styles beat the sheet's rules, so what is captured for a rung is that rung —
-but ``default`` is genuinely untouched, and therefore tracks the sheet.
+styles beat the sheet's rules, so what is captured for a rung is that rung.
+
+Self-contained is the load-bearing word, and it is the correction of a real
+defect in this script's first version. That version left one rung deliberately
+un-styled so it would "track the sheet" — which worked only while the sheet was
+flush. The moment the pad shipped, that rung became a duplicate of
+``pad-below``, the ladder lost the before-picture it exists to show, and
+``double-gap``'s margin-only override STACKED on the sheet's new pad and
+measured pitch 4 instead of the pitch-3 alternative the design argument
+rejects. A ladder rung that inherits anything from the thing it is supposed to
+be compared against is not a rung. So each one now pins height, padding AND
+margin outright, and every rung stays reproducible across any future change to
+the sheet's own density.
 """
 
 from __future__ import annotations
@@ -79,37 +92,63 @@ CALLS: list[tuple[str, dict[str, object], float]] = [
 #: whether a rung fits a working session rather than a demo.
 LONG_RUN = 12
 
-RUNGS = ("default", "pad-below", "pad-above", "double-gap", "comfortable")
+RUNGS = ("flush", "pad-below", "pad-above", "double-gap", "comfortable")
+
+#: Per-rung card geometry: ``(height, padding, extra gap rows)``.
+#:
+#: Written as DATA rather than as branches so the three quantities a rung is
+#: made of are visible side by side and cannot drift apart — the defect this
+#: table replaces was exactly a rung whose margin was set without its height,
+#: so it inherited the sheet's padding and stopped being the rung it named.
+#: ``height`` is the BORDER box (Textual sizes a fixed-height widget including
+#: its padding), so it is always ``1 + pad-top + pad-bottom`` or the summary
+#: clips instead of gaining air.
+_RUNG_STYLES: dict[str, tuple[int, tuple[int, int, int, int], int]] = {
+    # The reported state: ink edge to edge on a one-cell slab, one ground row.
+    "flush": (1, (0, 0, 0, 0), 0),
+    # What the sheet now ships: the pad row below the summary.
+    "pad-below": (2, (0, 0, 1, 0), 0),
+    # The rejected twin of `pad-below` — same cost, fill ends on an inked line.
+    "pad-above": (2, (1, 0, 0, 0), 0),
+    # The rung that buys its row from the GROUND instead of the card: a flush
+    # card, with the adaptive gap widened to two rows.
+    "double-gap": (1, (0, 0, 0, 0), 1),
+}
 
 
 def _apply_rung(app: OperatorApp, rung: str) -> None:
-    """Put the app into ``rung``'s density, on top of whatever the sheet says.
+    """Put the app into ``rung``'s density, overriding whatever the sheet says.
 
     Inline styles rather than a stylesheet edit: the whole ladder has to be
     renderable from one tree so the frames differ in density and in nothing
-    else (font, theme, fixture, Textual version). ``height`` and ``padding``
-    are set together for the reason the sheet's own comment gives — Textual
-    sizes a fixed-height widget INCLUDING its padding, so a pad row without
-    the matching height clips the summary instead of bracketing it.
+    else (font, theme, fixture, Textual version).
+
+    Every value is written EXPLICITLY, including the ones that happen to match
+    the sheet today. Leaving one implicit is what made the first version of
+    this script stop rendering the before-picture the moment the sheet's own
+    default moved — a rung has to state its whole geometry to stay a fixed
+    point of comparison.
     """
     if rung == "comfortable":
+        # The one rung that IS a shipped app state, so it is applied the way
+        # the app applies it (`_sync_row_density_class`) rather than by
+        # restating its cell counts here and letting the two drift.
         app.screen.add_class(COMFORTABLE_ROWS_CLASS)
         return
+    height, padding, extra_gap = _RUNG_STYLES[rung]
     for card in app.query(ToolCard):
-        if rung == "pad-below":
-            card.styles.height = 2
-            card.styles.padding = (0, 0, 1, 0)
-        elif rung == "pad-above":
-            card.styles.height = 2
-            card.styles.padding = (1, 0, 0, 0)
-        elif rung == "double-gap":
-            # The rung that buys its row from the GROUND instead of the card.
-            # Only rows that already carry the adaptive gap are widened, so
-            # this stays a change to the ledger's rhythm rather than a margin
-            # on every block (the "blank row between everything" regression
-            # the base selectors are kept margin-free to prevent).
-            if card.has_class(GAP_CLASS):
-                card.styles.margin = (2, 0, 0, 0)
+        card.styles.height = height
+        card.styles.padding = padding
+        # Restated on every rung, not only the one that widens it: a margin
+        # left unset would be inherited from the sheet, which is the class of
+        # defect this table exists to prevent.
+        #
+        # Only rows that already carry the adaptive gap are widened, so
+        # `double-gap` stays a change to the ledger's rhythm rather than a
+        # margin on every block (the "blank row between everything"
+        # regression the base selectors are kept margin-free to prevent).
+        top = 1 + extra_gap if card.has_class(GAP_CLASS) else 0
+        card.styles.margin = (top, 0, 0, 0)
 
 
 async def _seed(app: OperatorApp, pilot, count: int) -> None:
@@ -197,6 +236,14 @@ async def _geometry(size: tuple[int, int]) -> None:
 
 
 def main() -> None:
+    # Usage before indexing: the docstring publishes two invocations, and a
+    # bare run answering with an IndexError traceback teaches neither.
+    if len(sys.argv) < 2:
+        raise SystemExit(
+            "usage: ledger_density_shot.py OUT.svg [COLSxROWS] [RUNG] [PALETTE]\n"
+            "       ledger_density_shot.py --geometry [COLSxROWS]\n"
+            f"rungs: {', '.join(RUNGS)}"
+        )
     if sys.argv[1] == "--geometry":
         size = (100, 30)
         if len(sys.argv) > 2:
@@ -209,7 +256,10 @@ def main() -> None:
     if len(sys.argv) > 2:
         cols, rows = sys.argv[2].lower().split("x")
         size = (int(cols), int(rows))
-    rung = sys.argv[3] if len(sys.argv) > 3 else "default"
+    # `pad-below` rather than a rung called "default": the shipped density is
+    # a NAMED rung here, so the ladder keeps a fixed before-picture (`flush`)
+    # no matter what the sheet's own default becomes later.
+    rung = sys.argv[3] if len(sys.argv) > 3 else "pad-below"
     palette = sys.argv[4] if len(sys.argv) > 4 else "dark"
     if rung not in RUNGS:
         raise SystemExit(f"unknown rung {rung!r}; expected one of {', '.join(RUNGS)}")

--- a/scripts/visual_gallery.py
+++ b/scripts/visual_gallery.py
@@ -48,6 +48,12 @@ def cases() -> list[dict[str, Any]]:
                 "sibling_shot.py",
             }:
                 args += ["100x30", variant]
+            elif script == "ledger_density_shot.py":
+                # Its variants are the two densities the app actually ships:
+                # the default and `display.comfortable_rows`. The rejected
+                # rungs stay reachable from the CLI for a density argument,
+                # but the census renders only what a user can land on.
+                args += ["100x30", variant, "dark"]
             elif script in {"fallback_shot.py", "nerd_glyph_shot.py"}:
                 args += [variant]
             elif script == "sidebar_shot.py":

--- a/scripts/visual_gallery.py
+++ b/scripts/visual_gallery.py
@@ -50,9 +50,11 @@ def cases() -> list[dict[str, Any]]:
                 args += ["100x30", variant]
             elif script == "ledger_density_shot.py":
                 # Its variants are the two densities the app actually ships:
-                # the default and `display.comfortable_rows`. The rejected
-                # rungs stay reachable from the CLI for a density argument,
-                # but the census renders only what a user can land on.
+                # `pad-below` (the default) and `display.comfortable_rows`.
+                # The rungs that exist only for the density ARGUMENT — the
+                # historical `flush` state and the two rejected alternatives —
+                # stay reachable from the CLI, but the census renders only
+                # what a user can land on.
                 args += ["100x30", variant, "dark"]
             elif script in {"fallback_shot.py", "nerd_glyph_shot.py"}:
                 args += [variant]

--- a/scripts/visual_inventory.json
+++ b/scripts/visual_inventory.json
@@ -165,6 +165,10 @@
     ],
     "tui_lag_shot.py": [
       "default"
+    ],
+    "ledger_density_shot.py": [
+      "default",
+      "comfortable"
     ]
   },
   "pages": {

--- a/scripts/visual_inventory.json
+++ b/scripts/visual_inventory.json
@@ -167,7 +167,7 @@
       "default"
     ],
     "ledger_density_shot.py": [
-      "default",
+      "pad-below",
       "comfortable"
     ]
   },

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -1207,7 +1207,18 @@ async def test_the_inset_is_never_what_tips_a_long_subagent_list_over(
 
             def without_inset(self: Any) -> None:
                 original(self)
-                self.query_one("#band").remove_class("has-slot")
+                # Same guard the real `_sync_band_inset` carries one line up,
+                # and for the same reason: this runs on every band refresh
+                # INCLUDING the ones during boot, before `#band` is composed.
+                # The production method swallows that (`except: return`), so a
+                # wrapper that queries unguarded raises `NoMatches` out of a
+                # path the app treats as normal — which showed up as a boot-
+                # timing flake here rather than as a defect in the app.
+                try:
+                    band = self.query_one("#band")
+                except Exception:  # not composed yet (early boot)
+                    return
+                band.remove_class("has-slot")
 
             app._sync_band_inset = without_inset.__get__(app)  # type: ignore[method-assign]
         async with app.run_test(size=(100, height)) as pilot:

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -20,6 +20,7 @@ import pytest
 from rich.style import Style
 from rich.text import Text
 from textual.app import App, ComposeResult
+from textual.css.query import NoMatches
 
 from local_operator.harness.types import ImageContent
 from local_operator.session.naming import ConversationName
@@ -1214,9 +1215,16 @@ async def test_the_inset_is_never_what_tips_a_long_subagent_list_over(
                 # wrapper that queries unguarded raises `NoMatches` out of a
                 # path the app treats as normal — which showed up as a boot-
                 # timing flake here rather than as a defect in the app.
+                #
+                # NARROWER than the production method's bare `except
+                # Exception`, deliberately. There the breadth is the point (a
+                # status surface must not be able to take the app down); here
+                # the only expected failure is the not-yet-composed query, and
+                # a test double that swallowed anything else would hide the
+                # defect it exists to expose.
                 try:
                     band = self.query_one("#band")
-                except Exception:  # not composed yet (early boot)
+                except NoMatches:  # not composed yet (early boot)
                     return
                 band.remove_class("has-slot")
 

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -106,8 +106,50 @@ def _blank_rows_above(app: OperatorApp, selector: str) -> int:
 
 
 def _seam(app: OperatorApp) -> int:
-    """Ground rows between the conversation and the composer panel."""
-    return _blank_rows_above(app, "#input-shell")
+    """GROUND rows between the conversation and the composer panel.
+
+    Counts fills, not blank rows, and the difference is the whole contract.
+    Every action row now carries a pad row below its summary (the ``ToolCard``
+    rule in the sheet), so with a card last the frame above the composer holds
+    TWO blank rows with different owners — the upper one is the card's own pad
+    in ``$lo-surface``, the lower is the transcript's single ground row:
+
+        ...   fill=$lo-surface owner=grep            <- the card's OWN bottom pad
+        ...   fill=$lo-bg      owner=TranscriptView  <- the dock's one ground row
+
+    Counting blanks here reported 2 and read as the seam having grown, which it
+    has not: what the dock guarantees is one row of GROUND, and this module's
+    docstring already says a blank row proves nothing about whose surface it
+    is. ``test_comfortable_rows_still_leaves_exactly_one_ground_row`` reached
+    the same conclusion by hand for the opt-in density; this puts it in the
+    helper so every seam assertion gets it.
+
+    Ownership rather than colour is what separates them, and that is forced:
+    the row is NOT always ``$lo-bg``. The other half of this module's rule is
+    that a docked panel's separator is the dock's own ``$lo-surface`` (see the
+    module docstring), so a helper keyed on the screen's ground colour reports
+    zero for every banded case. What holds in both is that the seam row belongs
+    to no BLOCK — it is the transcript container's padding — while a pad row
+    belongs to the block that painted it.
+
+    Still a real assertion rather than a weakened one: the walk stops at the
+    first row that is inside a block, so a fix that lost the row entirely, or
+    that let a card's own fill reach the composer, still returns 0.
+    """
+    frame = _frame(app)
+    owned = [
+        block.region
+        for block in app.query_one(TranscriptView).children
+        if block.display and block.region
+    ]
+    index = app.query_one("#input-shell").region.y - 1
+    count = 0
+    while index >= 0 and not frame[index].strip():
+        if any(region.y <= index < region.bottom for region in owned):
+            break
+        count += 1
+        index -= 1
+    return count
 
 
 def _fill_at(app: OperatorApp, y: int, x: int) -> str:
@@ -405,6 +447,121 @@ ACTION_ROWS: dict[str, Any] = {
         "ship the release note", {"pid": 7, "conversation_name": "peer-a"}
     ),
 }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+@pytest.mark.parametrize("kind", sorted(ACTION_ROWS))
+async def test_the_default_density_pads_one_row_BELOW_every_action_row(
+    kind: str, size: tuple[int, int]
+) -> None:
+    """The default's own promise, with ``.comfortable-rows`` OFF.
+
+    Reported as "there's essentially no padding between lines": at ``height: 1``
+    the summary's ink filled its slab edge to edge and a run of actions read as
+    one jammed stack. The pad row is measured on the FRAME and by FILL, because
+    the two ways of buying this row look identical in a height number and not at
+    all alike on screen — a wider ``.gap-above`` would leave the extra row in
+    the transcript's ground, where it separates the cards further instead of
+    giving each one air.
+
+    BELOW, specifically. A top-only pad leaves the card's fill terminating on
+    the inked line with the summary against the bottom edge of its own slab,
+    which is the shape PR 870 removed from ``.comfortable-rows`` after it was
+    reported from the field; asserting the side is what stops it coming back
+    here.
+    """
+    app, _session = _app()
+    async with app.run_test(size=size) as pilot:
+        app.query_one(Editor).cursor_blink = False
+        await _settle(pilot)
+        assert not app.screen.has_class(COMFORTABLE_ROWS_CLASS), "this is the DEFAULT density"
+        block = ACTION_ROWS[kind]()
+        app._append_block(UserBlock("what happened"))
+        app._append_block(block)
+        await _settle(pilot, 4)
+
+        assert block.region.height == 2, (block.region, _frame(app)[-8:])
+        summary, pad = block.region.y, block.region.y + 1
+        frame = _frame(app)
+        assert frame[summary].strip(), frame[summary : pad + 1]
+        assert not frame[pad].strip(), frame[summary : pad + 1]
+
+        # The pad row is the widget's OWN fill, which is what makes it air
+        # inside the slab rather than the slab ending early.
+        own = _fill_at(app, summary, 2)
+        assert _fill_at(app, pad, 2) == own, frame[summary : pad + 1]
+        assert own != _fill_at(app, block.region.bottom, 2), "the fill must end with the widget"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+async def test_the_default_density_keeps_one_row_of_ground_between_actions(
+    size: tuple[int, int],
+) -> None:
+    """Two actions stay two targets at the default density too.
+
+    The pad row is interior to a card, so a run of them could in principle fuse
+    into one unbroken ``$lo-surface`` slab if the adaptive gap were ever
+    suppressed to pay for the new row. ``.comfortable-rows`` has this test
+    already; the default needs its own because it is now the density almost
+    every session actually renders.
+    """
+    app, _session = _app()
+    async with app.run_test(size=size) as pilot:
+        app.query_one(Editor).cursor_blink = False
+        await _settle(pilot)
+        app._append_block(UserBlock("run the suite"))
+        for n in range(5):
+            app._append_block(_card(f"bash{n}"))
+        await _settle(pilot, 4)
+
+        transcript = app.query_one(TranscriptView)
+        visible = [
+            c
+            for c in app.query(ToolCard)
+            if c.region.y >= transcript.region.y and c.region.bottom <= transcript.region.bottom
+        ]
+        assert len(visible) >= 2, "need two cards on screen to measure the gap between them"
+
+        for upper, lower in zip(visible, visible[1:]):
+            # Ink pitch 3: summary, the card's own pad, one row of ground.
+            assert lower.region.y - upper.region.y == 3, (upper.region, lower.region)
+            gap = list(range(upper.region.bottom, lower.region.y))
+            assert gap, (upper.region, lower.region, "cards are fused with no row between them")
+            own = _fill_at(app, upper.region.y, 2)
+            for y in gap:
+                assert _fill_at(app, y, 2) != own, (y, "the gap is the card's fill, not ground")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+async def test_comfortable_rows_stay_strictly_airier_than_the_default(
+    size: tuple[int, int],
+) -> None:
+    """The setting keeps meaning something once the default is no longer flush.
+
+    ``display.comfortable_rows`` is OFF by default and buys the row ABOVE the
+    summary that the default does not. If a density change ever levelled the
+    two, the setting would still appear in ``/settings`` and do nothing when
+    toggled, which is worse than not offering it.
+    """
+    heights: dict[bool, int] = {}
+    for comfortable in (False, True):
+        app, _session = _app()
+        async with app.run_test(size=size) as pilot:
+            app.query_one(Editor).cursor_blink = False
+            if comfortable:
+                app.screen.add_class(COMFORTABLE_ROWS_CLASS)
+            await _settle(pilot)
+            app._append_block(UserBlock("what happened"))
+            card = _card("grep")
+            app._append_block(card)
+            await _settle(pilot, 4)
+            heights[comfortable] = card.region.height
+
+    assert heights[True] > heights[False], heights
+    assert (heights[False], heights[True]) == (2, 3), heights
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -135,13 +135,22 @@ def _seam(app: OperatorApp) -> int:
     Still a real assertion rather than a weakened one: the walk stops at the
     first row that is inside a block, so a fix that lost the row entirely, or
     that let a card's own fill reach the composer, still returns 0.
+
+    ``display`` is the only filter, and dropping the ``and block.region``
+    truthiness test that stood beside it is a fix rather than a simplification.
+    ``Region.__bool__`` is false for zero AREA, so it fired on a zero-WIDTH
+    region as readily as on a zero-height one — and a zero-width block with
+    real rows (``Region(x=0, y=5, width=0, height=3)``) does occupy rows 5-7
+    while testing falsy, so the filter could drop a block whose rows then
+    counted as seam. The row-containment test below needs no such guard to
+    begin with: ``region.y <= index < region.bottom`` is vacuously false for
+    any zero-height or unlaid-out region, so such a block contributes nothing
+    either way. Keeping the narrower filter is what made the docstring's claim
+    ("stops at the first row that is inside a block") conditional on a
+    coincidence about widths.
     """
     frame = _frame(app)
-    owned = [
-        block.region
-        for block in app.query_one(TranscriptView).children
-        if block.display and block.region
-    ]
+    owned = [block.region for block in app.query_one(TranscriptView).children if block.display]
     index = app.query_one("#input-shell").region.y - 1
     count = 0
     while index >= 0 and not frame[index].strip():

--- a/tests/unit/tui/test_minimalism.py
+++ b/tests/unit/tui/test_minimalism.py
@@ -127,11 +127,30 @@ def test_gap_class_is_the_only_block_spacing_declaration() -> None:
     # vertical-only: the card's horizontal inset is drawn by the row builder,
     # not by the sheet, precisely so it cannot drift from the value the builder
     # sheds at narrow widths.
-    for block in re.findall(r"^(?:ToolCard|WakeBlock)[^{]*\{([^}]*)\}", text, re.MULTILINE):
-        assert not re.search(r"\bmargin\s*:", block), block
-        for pad in re.findall(r"\bpadding\s*:([^;]*);", block):
-            top, right, bottom, left = pad.split()
-            assert right == left == "0", pad
+    #
+    # The optional `.comfortable-rows` prefix is load-bearing coverage, not
+    # tidiness. Anchored at `^(?:ToolCard|WakeBlock)` this loop reached 6 rule
+    # bodies and NEITHER of the two that carry a four-value padding — both of
+    # those sit under the descendant selector — so the vertical-only assertion
+    # guarded one declaration out of three while its docstring claimed all of
+    # them. Those are also the rules most able to drift, since Textual resolves
+    # `padding` as one declaration per rule and each has to RESTATE the zero
+    # left/right rather than inherit it.
+    action_rows = r"^(?:\.comfortable-rows\s+)?(?:ToolCard|WakeBlock)[^{]*\{([^}]*)\}"
+    bodies = re.findall(action_rows, text, re.MULTILINE)
+    paddings = [pad for body in bodies for pad in re.findall(r"\bpadding\s*:([^;]*);", body)]
+    # Pin the COUNT as well as the shape: a rule that stops matching this
+    # pattern would otherwise silently reduce the loop's reach back to the gap
+    # this comment exists to record, and pass by checking nothing.
+    assert len(paddings) == 3, paddings
+    for body in bodies:
+        assert not re.search(r"\bmargin\s*:", body), body
+    for pad in paddings:
+        # Four values required on purpose: the shorthand forms would let a
+        # horizontal value in through a side door, and every action-row rule
+        # in this sheet writes all four precisely so the inset stays visible.
+        top, right, bottom, left = pad.split()
+        assert right == left == "0", pad
 
 
 def test_tool_card_renders_a_single_row() -> None:

--- a/tests/unit/tui/test_minimalism.py
+++ b/tests/unit/tui/test_minimalism.py
@@ -40,6 +40,12 @@ def test_tcss_pins_card_and_band_heights_rather_than_leaving_them_auto() -> None
     turning a ledger of one-line traces into a double-spaced list. The pin
     makes the worst case a clipped cell for one frame instead.
 
+    The card's pin is ``1 + padding-bottom``, not a bare ``1``: Textual sizes a
+    fixed-height widget INCLUDING its padding, so the default's one pad row
+    below the summary has to be counted into the height or the summary clips
+    instead of gaining air. Both numbers are asserted together because that is
+    the pairing that breaks — either alone is a defect.
+
     The band is TWO rows for one row of content: its top padding row is the gap
     that separates it from the input line above, and because the band and the
     input panel share one fill, a padded row is indistinguishable from a gap.
@@ -63,7 +69,8 @@ def test_tcss_pins_card_and_band_heights_rather_than_leaving_them_auto() -> None
         re.MULTILINE,
     )
     band_block = re.search(r"^#status-band\s*\{([^}]*)\}", text, re.MULTILINE)
-    assert tool_block is not None and "height: 1;" in tool_block.group(1)
+    assert tool_block is not None and "height: 2;" in tool_block.group(1)
+    assert "padding: 0 0 1 0;" in tool_block.group(1)
     assert expanded is not None and "height: auto;" in expanded.group(1)
     assert band_block is not None and "height: 2;" in band_block.group(1)
     # One row of that height is the gap; the band itself still renders one row.
@@ -100,6 +107,14 @@ def test_gap_class_is_the_only_block_spacing_declaration() -> None:
     a `ToolCard` selector would stack on top of it and put two blank rows
     between every pair of actions — the "too much spacing" complaint, moved
     from above the group to inside it.
+
+    PADDING on an action row is a different thing and is allowed: it is
+    INTERIOR to the widget, painted in the card's own fill, so it cannot open a
+    row of ground between blocks and cannot stack with ``.gap-above``. The
+    margin ban is what stays absolute. What the padding rules are still held to
+    is VERTICAL-ONLY with zero left/right — the one-cell left inset is drawn by
+    the row builder (``ToolCard.ROW_INDENT``) so it can yield at narrow widths,
+    and a sheet-side horizontal pad would silently double it.
     """
     text = TCSS.read_text()
     gap = re.search(r"^\.gap-above\s*\{([^}]*)\}", text, re.MULTILINE)
@@ -108,11 +123,15 @@ def test_gap_class_is_the_only_block_spacing_declaration() -> None:
     # No other rule anywhere in the sheet declares a vertical margin.
     margins = re.findall(r"margin(?:-top|-bottom)?\s*:[^;]*;", text)
     assert margins == ["margin-top: 1;"], margins
-    # And no ToolCard rule declares spacing of ANY kind, margin or padding:
-    # the card's own 1-cell inner padding is drawn by the row builder, not by
-    # the sheet, precisely so it cannot become a vertical row.
+    # No ToolCard rule declares a MARGIN, and every padding it does declare is
+    # vertical-only: the card's horizontal inset is drawn by the row builder,
+    # not by the sheet, precisely so it cannot drift from the value the builder
+    # sheds at narrow widths.
     for block in re.findall(r"^(?:ToolCard|WakeBlock)[^{]*\{([^}]*)\}", text, re.MULTILINE):
-        assert not re.search(r"\b(margin|padding)\s*:", block), block
+        assert not re.search(r"\bmargin\s*:", block), block
+        for pad in re.findall(r"\bpadding\s*:([^;]*);", block):
+            top, right, bottom, left = pad.split()
+            assert right == left == "0", pad
 
 
 def test_tool_card_renders_a_single_row() -> None:

--- a/tests/unit/tui/test_peer_message.py
+++ b/tests/unit/tui/test_peer_message.py
@@ -729,8 +729,12 @@ async def test_the_card_shares_the_ledger_spine_with_the_tool_rows() -> None:
         # Same name column, so the two summaries start at the same cell.
         assert peer._name_col(98) == card._name_col(98)
         assert peer.size.height == 1
-        # One blank row between them: the AIRY rule, not a bespoke lead.
-        assert peer.region.y - card.region.y == 2
+        # Ink pitch 3: one row of summary, the widget's own pad row below it,
+        # and one row of ground from the AIRY rule. Sharing the spine means
+        # sharing the pitch — a receipt that kept the old 2 would sit half a
+        # row out of step with the tool rows around it.
+        assert peer.region.height == card.region.height == 2
+        assert peer.region.y - card.region.y == 3
 
 
 @pytest.mark.asyncio
@@ -752,7 +756,7 @@ async def test_real_pointer_hover_and_click_use_the_ledger_contract() -> None:
         await pilot.pause()
 
         assert peer.size.height == 1
-        assert below.region.y - peer.region.y == 2
+        assert below.region.y - peer.region.y == 3
 
         landed = await pilot.hover(peer)
         assert landed, "hover missed the peer card"
@@ -771,7 +775,7 @@ async def test_real_pointer_hover_and_click_use_the_ledger_contract() -> None:
         await pilot.pause()
         assert peer.expanded is False
         assert peer.size.height == 1
-        assert below.region.y - peer.region.y == 2
+        assert below.region.y - peer.region.y == 3
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_spacing.py
+++ b/tests/unit/tui/test_spacing.py
@@ -201,6 +201,12 @@ async def test_a_ledger_of_tool_rows_is_one_row_each_under_the_real_sheet(
     was asked for; the row offsets say what the user sees, and they are what
     catches a `.tool-card` margin sneaking in on top of `.gap-above` and
     doubling it.
+
+    ONE ROW is about the card's INK, and the two numbers below are what keep
+    that honest now that the sheet pads a row below every summary. The content
+    box stays 1 — that is the no-reflow contract, and it is what would break if
+    a card resolved to two rows of TEXT — while the border box is 2 and the
+    pitch is 3: summary, the card's own pad, one row of ground.
     """
     cases: list[tuple[str, dict[str, object]]] = [
         ("bash", {"command": "pytest tests/unit -q"}),
@@ -224,19 +230,30 @@ async def test_a_ledger_of_tool_rows_is_one_row_each_under_the_real_sheet(
         await pilot.pause()
         await pilot.pause()
 
+        # Content box: still exactly one row of text per action, which is the
+        # regression above (a card that resolved to two rows of INK).
         assert [card.size.height for card in cards] == [1, 1, 1, 1]
+        # Border box: the summary plus the sheet's one pad row below it.
+        assert [card.region.height for card in cards] == [2, 2, 2, 2]
         # First meets the top edge; every following action takes its own row
-        # of air. Two cells of pitch for a one-row card IS one blank row.
+        # of ground on top of its own pad.
         assert not cards[0].has_class(GAP_CLASS)
         assert all(card.has_class(GAP_CLASS) for card in cards[1:])
         offsets = [card.region.y for card in cards]
-        assert [b - a for a, b in zip(offsets, offsets[1:])] == [2, 2, 2], offsets
+        assert [b - a for a, b in zip(offsets, offsets[1:])] == [3, 3, 3], offsets
 
 
 @pytest.mark.asyncio
 async def test_a_real_mouse_click_expands_and_collapses_under_the_real_sheet() -> None:
     """The pinned collapsed height must not defeat the expansion, and the one
-    blank row below survives a card growing to four rows and back."""
+    row of ground below survives a card growing and coming back.
+
+    ``size`` is the CONTENT box throughout, so it excludes the pad row the
+    sheet adds below every summary; the pitch below it is measured on regions,
+    which include it. Both are asserted because the pairing is what a
+    height/padding mismatch breaks — a pad row uncounted by the height clips
+    the last line of revealed output, which is the line the card was opened
+    for."""
     app = StyledTranscriptApp()
     async with app.run_test(size=(100, 24)) as pilot:
         view = app.query_one(TranscriptView)
@@ -248,21 +265,23 @@ async def test_a_real_mouse_click_expands_and_collapses_under_the_real_sheet() -
         below.mark_done("/tmp")
         await pilot.pause()
         assert card.size.height == 1
-        assert below.region.y - card.region.y == 2
+        assert below.region.y - card.region.y == 3
 
         await pilot.click(card)
         await pilot.pause()
         assert card.expanded is True
         assert card.size.height == 5  # summary + the call + three output rows
-        # Still exactly one blank row: the expansion added rows to the card,
-        # not to the space under it.
-        assert below.region.y - card.region.y == 6
+        # Still exactly one row of ground: the expansion added rows to the
+        # card, not to the space under it. The pad row rides along with the
+        # content under `height: auto` rather than being clipped by it.
+        assert card.region.height == card.size.height + 1
+        assert below.region.y - card.region.y == 7
 
         await pilot.click(card)
         await pilot.pause()
         assert card.expanded is False
         assert card.size.height == 1
-        assert below.region.y - card.region.y == 2
+        assert below.region.y - card.region.y == 3
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -453,9 +453,13 @@ async def test_empty_assistant_message_mounts_no_block() -> None:
         assert not app.query(AssistantBlock)
         painted = rows(app)
         # The working line TRAILS the row it reports on — it is pinned to the
-        # foot of the transcript — with exactly ONE blank row between them: the
-        # air that says "this is the live status, not another ledger entry".
-        # An eagerly mounted empty prose block would open a second hole.
+        # foot of the transcript — with exactly ONE row of GROUND between them:
+        # the air that says "this is the live status, not another ledger
+        # entry". An eagerly mounted empty prose block would open a second
+        # hole. The distance is 3 rather than 2 because the tool row carries
+        # its own pad row below the summary (see the `ToolCard` rule in the
+        # sheet); the ground row between the two blocks is still exactly one,
+        # which is what this asserts.
         # Found by its spinner head rather than by its words, because the
         # ledger row above it also carries the tool's name.
         working = next(
@@ -466,7 +470,7 @@ async def test_empty_assistant_message_mounts_no_block() -> None:
         tool = next(
             index for index, row in enumerate(painted) if "bash" in row and index != working
         )
-        assert working - tool == 2
+        assert working - tool == 3
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_wake_ui.py
+++ b/tests/unit/tui/test_wake_ui.py
@@ -178,7 +178,10 @@ async def test_real_pointer_hover_and_click_use_the_tool_trace_contract() -> Non
 
         assert wake.size.height == 1
         assert below.has_class(GAP_CLASS)
-        assert below.region.y - wake.region.y == 2
+        # Ink pitch 3: the summary, the card's own pad row, one row of ground.
+        # A wake receipt rides the same action-row rule as a tool call, so it
+        # carries the same pad rather than standing a row shorter beside them.
+        assert below.region.y - wake.region.y == 3
         assert EXPAND_HINT not in _wake_text(wake).plain
 
         landed = await pilot.hover(wake)
@@ -192,13 +195,13 @@ async def test_real_pointer_hover_and_click_use_the_tool_trace_contract() -> Non
         assert wake.expanded is True
         assert wake.size.height == 2
         assert COLLAPSE_HINT in _wake_text(wake).plain
-        assert below.region.y - wake.region.y == 3
+        assert below.region.y - wake.region.y == 4
 
         await pilot.click(wake)
         await pilot.pause()
         assert wake.expanded is False
         assert wake.size.height == 1
-        assert below.region.y - wake.region.y == 2
+        assert below.region.y - wake.region.y == 3
 
 
 def test_retheme_is_the_shared_finalized_re_entry_point() -> None:


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fixes the reported tool-ledger density defect:

> there's essentially no padding between lines, can you add a small, tasteful amount of padding in the tool call lines

Release: patch — every tool-call row gains one row of air below its summary at the **default** density; no API, no config, no migration. `pyproject.toml` is untouched (combined-release rule).

At `height: 1` an action row's ink filled its `$lo-surface` slab edge to edge, and with one `.gap-above` ground row between neighbours the **ink pitch** (summary row to next summary row) was **2**. A run of consecutive actions therefore read as one jammed stack rather than as a ledger of separate things. The only airier option was `display.comfortable_rows` (pitch 4), which the maintainer deliberately defaults OFF because it costs ~2 rows per call. This PR is the rung between them: **pitch 2 → 3, one row per action.**

![before and after, dark, 100x30](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-tool-row-padding/frames/compare-before-after-dark.png)

## The ladder, rendered and looked at

Five candidates were built and **rasterized** (`rsvg-convert`) at 100x30 and 150x40, dark and light, before anything was changed. A new capture fixture drives the real `OperatorApp` with six real `ToolCard`s under an `AssistantBlock`, so what is captured is the stylesheet-loaded screen rather than a bare test host.

![the five rungs](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-tool-row-padding/frames/compare-ladder-dark.png)

| rung | card h | gap rows | **ink pitch** | span, 6 calls | span, 12 calls |
|---|---|---|---|---|---|
| (a) `flush` — the reported state | 1 | 1 | **2** | 11 | 23 |
| (b) `pad-below` — 2-row card, pad **below** ← **chosen, ships as the default** | 2 | 1 | **3** | 17 | 35 |
| (c) `pad-above` — 2-row card, pad **above** | 2 | 1 | **3** | 17 | 35 |
| (d) `double-gap` — 1-row card, **two** ground rows | 1 | 2 | **3** | 16 | 34 |
| (e) `comfortable` — `.comfortable-rows` | 3 | 1 | **4** | 23 | 47 |

Measured on the composed frame with `scripts/ledger_density_shot.py --geometry`, not derived from the declarations. **Reproduces at head `456dc9c35`**: every rung pins its own height, padding and margin, so none of them inherits the sheet's density. (Review round 1 caught this table failing to reproduce at `d38296ace`, where one rung was left un-styled to "track the sheet" and therefore became a duplicate of `pad-below` once the pad shipped — see R1/D1/Q1 and the remediation comments.) The `flush` rung is verified against the real pre-PR tree: captured at this head it is pixel-identical to the same rung captured from a detached worktree at `576741501`, everywhere above the status bar that prints the worktree path.

## Why (b), and why (c) and (d) are not the same thing

(b), (c) and (d) all cost exactly one row per action. They are told apart only by **whose fill carries that row**, which is invisible in a height number and is the entire design question. Per-row pixel probe at column 400, `S` = `$lo-surface` (card), `g` = `$lo-bg` (ground):

```
default      6:S 7:g 8:S 9:g 10:S 11:g 12:S      <- 1-cell strips, pitch 2
pad-above    6:S 7:S 8:g 9:S 10:S 11:g 12:S      <- slab ENDS on the inked line
pad-below    6:S 7:S 8:g 9:S 10:S 11:g 12:S      <- slab ends on air
double-gap   6:g 7:S 8:g 9:g 10:S 11:g 12:g      <- still a 1-cell strip; row is GROUND
```

- **(c) pad above is out on precedent.** It is exactly what PR #870 removed from `.comfortable-rows`: the card's fill "terminated on an inked line" with the summary "jammed against the bottom edge of its own slab", reported from the field as "a row added above the tool call and not below". Re-introducing that shape as the default would re-introduce the finding.
- **(d) double gap is out because it buys the wrong row.** It spends the row on ground, so each action remains a one-cell strip of `$lo-surface` and the ledger reads as thin disconnected bands with *more void between them* — most visible on the light palette, where the card fill is the quieter of the two. It also grows no click target, where (b) doubles one: the whole row is the expand surface (`ExpandableActionBlock.on_click` is on the widget, so the pad row is inside it), which is the hit-target purpose `.comfortable-rows` exists for.

Zoomed slab edges, same frame region — (c) and (d) beside the chosen (b):

| (a) default | (b) pad below ← chosen |
|---|---|
| ![](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-tool-row-padding/frames/zoom-a-default.png) | ![](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-tool-row-padding/frames/zoom-b-pad-below.png) |

| (c) pad above | (d) double gap |
|---|---|
| ![](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-tool-row-padding/frames/zoom-c-pad-above.png) | ![](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-tool-row-padding/frames/zoom-d-double-gap.png) |

**Elevation stays a background step** — no border, no shadow, no rule line — which is the card's own law (`widgets/tool_card.py`) and what rules out "just draw a separator" as a fifth rung.

**The density cost is real and is why this is one row, not two.** A twelve-action ledger goes 23 → 35 rows. That is the cost the maintainer weighed when they turned `comfortable_rows` off; this pays a third of it (one row per action instead of two) for the readability the report asked for, and leaves the full bracket available to anyone who wants it.

**(b) and (c) are the close pair, not (b) and (d).** They are geometrically identical and differ only in which edge the air lands on. The tradeoff: (c) puts air between a card and the *prose above it*, which reads marginally better when a single call follows a paragraph; (b) reads better in a *run* of calls, which is the shape the report was about, and is the side PR #870's finding already settled. If a designer prefers the other edge, it is a one-character change to the same declaration.

## Scope: `WakeBlock` and `PeerMessageBlock` move with `ToolCard` — deliberately

They share the action-row selector, they are ledger rows by `SPACING_KIND`, `PeerMessageBlock.LEDGER_ROW is True`, and `test_peer_message` already asserts they share the tool rows' name column and spacing. A receipt that kept pitch 2 would sit a row out of step with the tool rows it is interleaved with. **This is the design call the designer may want to push back on**, so it is stated rather than slipped in: the alternative is a wake receipt that is visibly a different shape from the call above it.

## Constraints respected (each documented where the code is)

- **The collapsed height stays PINNED**, now `1 + padding-bottom` = `height: 2`. A card is built before it is laid out, so `auto` silently resolves a 1-row card to two rows and never comes back down. Textual sizes a fixed-height widget *including* its padding, so the two numbers move together or the summary clips instead of gaining air. **The CONTENT box is still exactly 1 cell** — the no-reflow contract is unchanged, and `test_spacing` now asserts both boxes.
- **Expanded cards stay `height: auto`** and inherit the pad by cascade (the expanded rule deliberately declares no `padding`), so the payload's last line is never clipped. Verified: `region.height == size.height + 1`, last content row still inked.
- **`padding` is one declaration per rule in Textual**, so `.comfortable-rows` restates the bottom pad it keeps, and the left inset still lives in the row builder (`ROW_INDENT`) because it must yield at narrow widths. `test_minimalism` now enforces that every action-row `padding` is vertical-only with zero left/right.
- **The dock's exactly-one-ground-row contract holds.** With a card last, the frame carries two blank rows with different owners — the card's own pad in `$lo-surface`, then the transcript's one ground row in `$lo-bg`. `_seam` counted *blank rows* and now counts rows owned by *no block*, which is the same reading `test_composer_seam` already applied to the `/btw` aside and to `.comfortable-rows`. Its module docstring says outright that "a blank row proves nothing at all about whose surface it is".
- **`display.comfortable_rows` keeps its default (False) and its meaning**, and is now the top rung of a three-rung ladder rather than the only alternative to a flush row. A new test pins it as *strictly* airier than the default, because a setting that renders identically to the default is worse than not offering one.

## Tests

| file | change |
|---|---|
| `test_composer_seam.py` | `_seam` counts ground-by-ownership, not blank rows (+ why). **3 new tests**: the default pads one row *below* every action-row kind; the default keeps one ground row between neighbours; `.comfortable-rows` stays strictly airier |
| `test_minimalism.py` | pins `height: 2` + `padding: 0 0 1 0` together; margin ban stays absolute, padding allowed but asserted vertical-only across **all three** action-row rules, with the declaration count pinned (round 1, R3) |
| `test_spacing.py` | content box 1 / border box 2 / pitch 3, and the expanded card's pad row under `height: auto` |
| `test_peer_message.py`, `test_wake_ui.py`, `test_steering_approval.py` | pitch 2 → 3 for the shared action-row rule |
| `test_band_panels.py` | **unrelated flake fixed** (below) |

**The new tests were proven able to fail**, not just to pass:

```
mutate padding to `1 0 0 0` (pad above)         -> 9 failed, 3 passed
mutate .comfortable-rows down to the default    -> 3 failed
remove the transcript's own seam padding        -> 12 failed   (the seam helper is still meaningful)
horizontal pad on a .comfortable-rows rule      -> 1 failed    (invisible to the round-1 regex; caught now)
```

### A test-only boot race this change's timing exposed

`test_band_panels`'s `_sync_band_inset` wrapper queried `#band` **unguarded**, while the production method it wraps guards the identical query (`except: return`, "not composed yet (early boot)"). A band refresh during boot therefore raised `NoMatches` out of a path the app treats as normal. Not weather: reproduced **2/10 on this branch, 0/16 on unmodified `origin/main`** in a throwaway worktree, diagnosed to the wrapper, and **12/12 clean** after adding the same guard (re-confirmed 6/6 after round 1 narrowed the catch to `NoMatches`). No production code involved.

## Testing evidence

All gates run locally from the worktree venv, exactly as CI runs them:

```
flake8 .                                                         -> 0
black --check .   (26.1.0, pinned)                               -> 1240 files unchanged
isort --check .   (5.13.2, pinned)                               -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .       -> 0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
                                                                 -> 109 passed, 7 skipped (184s)
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
                                                                 -> 18697 passed, 18 skipped (59m)
```

CI on this head: **all 16 checks green**, including `version-bump-guard` (confirming no bump), both `tui-e2e` jobs, and all five test shards.

> One CI shard failed on the first run in `tests/unit/server/test_desktop_attention.py`, which this diff does not touch. Root-caused rather than re-run blindly: session ids are minted as `uuid.uuid4().hex[:12]` in `local_operator/server/utils/desktop_sessions.py:557` and consumed at `test_desktop_attention.py:61`, where the `sid.upper()` member of the bogus-id loop stops differing from `sid` once the id happens to be **all digits** (p = (10/16)^12 ≈ **1 in 281**) — so that "bogus" case is the real session and `pytest.raises(KeyError)` does not fire. Reproduced deterministically by forcing an all-digit id; QA independently measured the rate at 1 in 282 over 200k draws. Pre-existing and unrelated; left unfixed here to keep this diff in scope — **not addressed**, flagged for a follow-up.

Capture fixture (new, registered in the gallery — `visual_gallery.py --list` shows `ledger_density_shot-pad-below` and `-comfortable`, and both were driven through the gallery itself):

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/ledger_density_shot.py --geometry 100x30
env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/ledger_density_shot.py out.svg 150x40 flush light   # the before-picture, at any size/palette
```

### Geometry, before → after (measured on this head)

| | ToolCard height | content box | gap rows | ink pitch | 6-call span | 12-call span |
|---|---|---|---|---|---|---|
| default **before** | 1 | 1 | 1 | **2** | 11 | 23 |
| default **after** | 2 | 1 | 1 | **3** | 17 | 35 |
| `.comfortable-rows` (unchanged) | 3 | 1 | 1 | **4** | 23 | 47 |

State variants all verified to carry the pad in their own fill, not ground: `tool-success` `#1e1a14`, `tool-error` `#2c1a16`, `tool-running` `#272219`, plus `WakeBlock` and `PeerMessageBlock` at both densities.

### Frames

Light palette at 150x40 (where the card fill is the quieter of the two, so a wrongly-owned row shows worst):

![before and after, light, 150x40](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-tool-row-padding/frames/compare-before-after-light.png)

All 23 frames — the five rungs at both sizes and both palettes, before/after pairs, and the zoomed slab edges — are on the `evidence/pr-tool-row-padding` branch, per AGENTS.md "Evidence goes on the PR, never into the repository".

## Impact

- **User-visible**, TUI only. Every tool/wake/peer row is one terminal row taller; ~12 fewer ledger rows per screen on a twelve-call run.
- No API, no config key, no dependency, no migration. `display.comfortable_rows` unchanged in default and meaning.
- **No version bump**: `pyproject.toml` is byte-identical to `origin/main`.
