### PR TITLE
fix(providers): keep a usage-only attempt retryable

### DIFF
--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -37,6 +37,7 @@ from local_operator.harness.types import (
     StreamModelEvent,
     StreamReasoningDelta,
     StreamStartEvent,
+    StreamUsageEvent,
 )
 from local_operator.model.effort import EFFORT_ORDER, resolve_effort_in
 
@@ -215,6 +216,45 @@ _MID_STREAM_TRANSPORT_LOSS_NAMES = (
     "readtimeout",
     "writetimeout",
     "remoteprotocolerror",
+)
+
+#: The only stream events that may be forwarded WITHOUT making an attempt
+#: non-retryable inside :func:`stream_with_failover`.
+#:
+#: ``forwarded_any`` means exactly one thing: the caller has been handed output
+#: that cannot be un-shown, so replaying this attempt would stream it twice.
+#: Every member here fails that test — it carries NOTHING the caller has seen:
+#:
+#: * ``StreamStartEvent`` is a boundary marker announcing that the provider
+#:   began. Counting it would make every failure landing after acceptance but
+#:   before the first token non-retryable (Anthropic 529s, in-band error chunks
+#:   on a 200 stream), bypassing credential rotation and the whole fallback
+#:   chain. It would also misreport a pre-content transport death as a
+#:   MID-STREAM loss, which is what :func:`is_mid_stream_connectivity_loss`
+#:   infers from this very flag.
+#: * ``StreamReasoningDelta`` carries the model's private reasoning, which
+#:   NOTHING renders: the loop appends text only for its visible channel, no
+#:   frontend handler exists, and the transcript never sees it. Counting it
+#:   re-breaks the case above for the reasoning families this harness runs.
+#: * ``StreamUsageEvent`` carries the provider's token accounting for the call
+#:   so far, which is METADATA and not content: it renders nothing, joins no
+#:   transcript, and its consumers document it as one report per provider call
+#:   (see ``Session.complete_aside``) — so a retry that reports again is
+#:   reporting a second real call, not repeating the first. Only the
+#:   OpenAI-compatible and Responses clients emit usage before the end of a
+#:   stream, which bounds where a lone event can be the FIRST thing forwarded.
+#:
+#: An ALLOWLIST of "safe to retry", deliberately, rather than a list of the
+#: events that count as seen: the two differ in how a FUTURE event type fails.
+#: An unlisted type counts as seen, so a type nobody listed costs at most the
+#: pre-existing behaviour — a retry that was available but not taken — never a
+#: delta the user reads twice. Add a member only after checking every consumer
+#: on the caller's side of the driver for a render, a transcript entry, or
+#: another durable effect.
+_RETRY_SAFE_STREAM_EVENTS: tuple[type[StreamEvent], ...] = (
+    StreamStartEvent,
+    StreamReasoningDelta,
+    StreamUsageEvent,
 )
 
 
@@ -2720,31 +2760,11 @@ async def stream_with_failover(
                     # ``forwarded_any`` gates retry, and it means exactly one
                     # thing: the caller has SEEN output that cannot be un-shown,
                     # so replaying this attempt would stream deltas twice.
-                    # Two events show the user nothing and are carved out for
-                    # that reason:
-                    #
-                    # * ``StreamStartEvent`` is a boundary marker announcing that
-                    #   the provider began. Counting it would make every failure
-                    #   that lands after acceptance but before the first token
-                    #   non-retryable (Anthropic 529s, in-band error chunks on a
-                    #   200 stream), bypassing credential rotation and the whole
-                    #   fallback chain. It would also misreport a pre-content
-                    #   transport death as a MID-STREAM loss, which is what
-                    #   ``is_mid_stream_connectivity_loss`` infers from this very
-                    #   flag.
-                    # * ``StreamReasoningDelta`` carries the model's private
-                    #   reasoning, which NOTHING renders: the loop appends text
-                    #   only for its visible channel, no frontend handler exists,
-                    #   and the transcript never sees it. Counting it would
-                    #   reintroduce exactly the bug above, but only for models
-                    #   that think before they answer -- the reasoning families
-                    #   this harness runs -- so a pre-content 5xx after the first
-                    #   reasoning chunk would stop rotating credentials and stop
-                    #   walking the fallback chain, and a pre-content transport
-                    #   death would be misreported as a mid-stream loss.
-                    #
-                    # Nothing has been rendered, so nothing blocks a retry.
-                    if not isinstance(event, (StreamStartEvent, StreamReasoningDelta)):
+                    # ``_RETRY_SAFE_STREAM_EVENTS`` names the only events that
+                    # carry nothing the caller has seen and therefore block
+                    # nothing; it holds the criterion, the members and the reason
+                    # the test is an allowlist rather than a list of what counts.
+                    if not isinstance(event, _RETRY_SAFE_STREAM_EVENTS):
                         forwarded_any = True
                     yield stamped
                 # This selector just answered: from here on an unknown-model

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -573,28 +573,51 @@ class _FailsAfter:
             [StreamStartEvent(response_id="r1"), StreamReasoningDelta(delta="weighing")],
             True,
         ),
+        # Usage is accounting, not content: it renders nothing, joins no
+        # transcript, and its consumers are documented as firing once per
+        # provider call -- so a lone usage event cannot be a reason not to
+        # retry. It is the shape an OpenAI-compatible aggregator produces when
+        # it reports accounting before any content, and the write that used to
+        # make a trivially retryable pre-content 5xx look like a mid-stream cut.
+        ([StreamUsageEvent(usage=Usage(input_tokens=10, output_tokens=0))], True),
+        (
+            [
+                StreamStartEvent(response_id="r1"),
+                StreamUsageEvent(usage=Usage(input_tokens=10, output_tokens=0)),
+            ],
+            True,
+        ),
         # The control: a VISIBLE delta is output the caller can see, so the
         # attempt must not be replayed. Without this row, a carve-out that
         # swallowed every event would pass every row above.
         ([StreamTextDelta(delta="half an answer")], False),
     ],
-    ids=["nothing", "start", "reasoning", "start-and-reasoning", "visible-text"],
+    ids=[
+        "nothing",
+        "start",
+        "reasoning",
+        "start-and-reasoning",
+        "usage",
+        "start-and-usage",
+        "visible-text",
+    ],
 )
-async def test_a_pre_content_failure_after_a_reasoning_delta_still_walks_the_chain(
+async def test_a_pre_content_failure_after_a_non_content_event_still_walks_the_chain(
     leading: list[Any], walks_chain: bool
 ) -> None:
-    """What gates a retry is output the caller has SEEN, and reasoning is not.
+    """What gates a retry is output the caller has SEEN, and these events are not.
 
     ``forwarded_any`` means exactly that: the caller has seen output that cannot
-    be un-shown, so replaying the attempt would stream it twice. A
-    ``StreamStartEvent`` was already carved out for announcing nothing; a
-    ``StreamReasoningDelta`` announces nothing either -- no consumer renders it
-    (no loop branch, no frontend handler, no transcript entry) -- so counting it
-    would gate the retry on the one channel that cannot be seen. The consequence
-    would be confined to reasoning models, which is every model this harness
-    runs on a hard task: a 5xx arriving after the model started thinking would
-    stop credential rotation and the whole fallback chain, and a pre-content
-    transport death would be misreported as a mid-stream loss.
+    be un-shown, so replaying the attempt would stream it twice. Only the events
+    in ``_RETRY_SAFE_STREAM_EVENTS`` fail that test — a boundary marker, the
+    model's private reasoning, and the provider's token accounting — and each
+    one is exempt for its own reason, spelled out there.
+
+    What this test protects is the CLASS of mistake rather than one instance of
+    it: each carve-out was added after the same bug was found in the wild, one
+    event type at a time, so the rows below are the members that exist plus the
+    control that must never move. A new member needs its own row here; deleting
+    the member from the tuple must fail the matching row and only that row.
 
     The last row is the boundary that must not move: a visible delta still
     blocks the retry, so this cannot degrade into "retry everything".
@@ -624,15 +647,149 @@ async def test_a_pre_content_failure_after_a_reasoning_delta_still_walks_the_cha
 
     assert specs_seen[-1].model_id == "claude-x"
     assert any(isinstance(e, StreamTextDelta) and e.delta == "fallback" for e in got)
-    # The reasoning this attempt produced is still FORWARDED -- carving it out
-    # of the retry gate must not swallow it. Asserted as a set rather than a
-    # count: a pre-content failure is retried on the same target before the
-    # chain is walked, and each of those attempts legitimately re-emits the
-    # channel. How many attempts the ladder burns is the ladder's business.
+    # What this attempt produced is still FORWARDED -- carving a member out of
+    # the retry gate must not swallow it. Asserted as a set rather than a count:
+    # a pre-content failure is retried on the same target before the chain is
+    # walked, and each of those attempts legitimately re-emits the channel. How
+    # many attempts the ladder burns is the ladder's business.
     forwarded = {e.delta for e in got if isinstance(e, StreamReasoningDelta)}
     assert forwarded == {
         event.delta for event in leading if isinstance(event, StreamReasoningDelta)
     }
+    # Same rule for the accounting channel. Compared field-by-field rather than
+    # by identity because ``_stamp_serving_spec`` re-stamps a forwarded usage
+    # event with the serving spec, which is what makes a failover's cost land on
+    # the provider that actually served it.
+    forwarded_usage = [e.usage for e in got if isinstance(e, StreamUsageEvent)]
+    for usage in (event.usage for event in leading if isinstance(event, StreamUsageEvent)):
+        assert any(
+            served.input_tokens == usage.input_tokens
+            and served.output_tokens == usage.output_tokens
+            for served in forwarded_usage
+        ), "a forwarded usage event must survive the retry gate it was carved out of"
+
+
+async def test_a_lone_usage_event_rotates_the_credential_and_walks_the_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The usage carve-out must reach BOTH retry mechanisms, not just the chain.
+
+    ``forwarded_any`` is checked once, but it gates two behaviours: the tier-1
+    sibling rotation inside the provider and the tier-2 walk to the next target.
+    The parametrised test above proves the chain; a lone usage event that still
+    froze rotation would look identical there, because the walk happens anyway
+    once rotation returns "nothing left". So this test keeps a SECOND openai key
+    in the pool and asserts the second key is actually asked -- the observable
+    that distinguishes "rotated, then walked" from "never rotated".
+    """
+    sleeps: list[int] = []
+
+    async def capture_sleep(delay_ms: int, signal: Any) -> None:
+        sleeps.append(delay_ms)
+
+    monkeypatch.setattr("local_operator.providers.failover._abortable_sleep", capture_sleep)
+
+    used_keys: list[str | None] = []
+    specs_seen: list[ModelSpec] = []
+    accounting = Usage(input_tokens=7, output_tokens=0)
+
+    def primary(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        used_keys.append(api_key)
+
+        async def generate() -> AsyncIterator[Any]:
+            # Exactly the real shape: the provider accounts for the call, then
+            # the attempt dies before ANY content is forwarded.
+            yield StreamUsageEvent(usage=accounting)
+            raise ProviderError(500, "boom", retryable=True)
+
+        return generate()
+
+    async def client_for(spec: ModelSpec) -> Any:
+        specs_seen.append(spec)
+        if spec.model_id == "gpt-4o":
+            return _FnClient(primary)
+        return ScriptedClient(
+            [StreamTextDelta(delta="fallback"), StreamEndEvent(stop_reason="stop")]
+        )
+
+    settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}}
+    auth = FakeAuth({"openai": ["k1", "k2"], "anthropic": ["k3"]})
+
+    got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+
+    # Rotated to the sibling account...
+    assert "k2" in used_keys, (
+        "a lone usage event must not stop tier-1 rotation; asked keys were "
+        f"{used_keys} with rotations {auth.rotations}"
+    )
+    assert auth.rotations[0] == ("openai", "k1")
+    # ...on the FAST transient budget, not the patient connectivity one: nothing
+    # about this failure resembles the machine being offline.
+    assert sleeps and max(sleeps) <= BACKOFF_CAP_MS
+    # ...and only then walked to the next provider.
+    assert specs_seen[-1].model_id == "claude-x"
+    assert any(isinstance(e, StreamTextDelta) and e.delta == "fallback" for e in got)
+    # The accounting the failed attempt reported still reached the caller: it is
+    # metadata about a call that really happened, not content to be discarded.
+    assert any(
+        isinstance(e, StreamUsageEvent) and e.usage.input_tokens == accounting.input_tokens
+        for e in got
+    )
+
+
+async def test_a_usage_only_transport_cut_is_not_reported_as_mid_stream() -> None:
+    """The SAME flag feeds the mid-stream inference, so the carve-out must hold
+    on the transport arm too -- and this is the arm where the old behaviour did
+    real harm.
+
+    ``is_mid_stream_connectivity_loss`` reads ``forwarded_any`` through this
+    driver: bytes already forwarded means an interrupted answer, which the loop
+    CONTINUES (patient wait, then re-ask) instead of surfacing. A lone usage
+    event is not an answer, so a socket that dies after one is an ordinary
+    pre-content transport failure: the loop must be told to surface it, not to
+    continue a turn whose text never started.
+
+    The positive control lives next door, in
+    ``test_the_driver_marks_a_cut_that_already_forwarded_bytes``: the same kind
+    of cut after a VISIBLE delta must still be marked continuable.
+    """
+
+    async def client_for(spec: ModelSpec) -> Any:
+        async def generate(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            yield StreamUsageEvent(usage=Usage(input_tokens=7, output_tokens=0))
+            # No client in clients.py catches httpx, so a socket that dies
+            # mid-body reaches the driver raw -- see the driver's own comment.
+            raise httpx.ReadError("")
+
+        return _FnClient(generate)
+
+    forwarded: list[Any] = []
+    with pytest.raises(ProviderError) as excinfo:
+        async for event in stream_with_failover(
+            _request(),
+            FakeAuth({"openai": ["k1"]}),
+            # Budgets floored so a shape that IS retryable still terminates fast.
+            {
+                "retry": {
+                    "baseDelayMs": 1,
+                    "maxRetries": 1,
+                    "connectivityMaxRetries": 0,
+                    "fallbackChains": {},
+                }
+            },
+            client_for,
+        ):
+            forwarded.append(event)
+
+    assert forwarded, "the usage event must reach the caller, not be swallowed"
+    assert not excinfo.value.connectivity_loss, (
+        "a cut that only ever forwarded accounting was marked as an interrupted "
+        "answer, so the loop will continue a turn whose text never started"
+    )
 
 
 async def test_failover_stamps_serving_spec_on_usage() -> None:


### PR DESCRIPTION
# PR Description

## Summary of Changes

`stream_with_failover` decides whether it may retry on another credential or
target by asking whether the caller has already been handed output —
`forwarded_any`. Two event types were carved out of that test because they
carry nothing the caller can see: `StreamStartEvent` (a boundary marker) and,
as of #1001 / `2692a429f`, `StreamReasoningDelta`. `StreamUsageEvent` was not,
and that is the same bug a third time.

A lone usage event is the provider's token accounting for the call so far, not
content: nothing renders it, it joins no transcript, and its consumers document
it as one report per provider call. But forwarding one set `forwarded_any`, so a
**pre-content** failure that arrived after it was treated as a mid-stream cut:

- the fallback chain was not walked and credentials were not rotated, and
- because `is_mid_stream_connectivity_loss` reads this same flag, a socket death
  after a lone usage event was announced as an INTERRUPTED ANSWER — which the
  loop *continues* (patient wait, then re-ask) instead of surfacing, on a turn
  whose text never started.

This is shared harness code: it affects ordinary TUI/CLI/exec sessions, not just
the benchmark.

### The fix: an allowlist, named and documented, instead of a growing carve-out

The two existing carve-outs were written as a negative `isinstance` test in the
hot loop, with their reasoning in a comment beside it. The third member needed
the same treatment, so the predicate now has a name and a home —
`_RETRY_SAFE_STREAM_EVENTS` — holding the criterion ("carries nothing the caller
has seen"), each member's own justification, and the rule for adding one.

**It is deliberately an allowlist of "safe to retry" rather than a list of the
events that count as seen**, because the two fail in opposite directions for a
type nobody has added yet. An unlisted event counts as seen, so the worst case
for a future event type is the pre-existing behaviour — a retry that was
available and not taken. The denylist shape would make `forwarded_any` default
to *false*, i.e. a replay that streams a delta the user reads twice. The
carve-out is equivalent to the allowlist for today's seven event types; it is
not equivalent for the eighth, which is the whole point.

`StreamModelEvent` is deliberately NOT a member: no wire client emits one inside
the stream (`clients.py` has no such site) — the driver emits one itself, before
the attempt and outside this gate — so a member nothing can produce is an
untestable claim. It is also not required for correctness: unlisted counts as
seen, which is the safe direction.

## Reproduction

Driven through the REAL `stream_with_failover` with a client that emits its
scripted events and then dies, a two-target chain, and two rotation candidates
(`/tmp/lo-usage-failover-evidence/repro_usage_carveout.py`). Five leading shapes
× two failure shapes; "WALKED CHAIN" means the fallback target's client was
built and its text reached the caller.

BEFORE (`origin/main`, `2692a429f`):

```
######## failure = http500
  nothing       targets=['openai/gpt-4o', 'anthropic/claude-x']  -> WALKED CHAIN
  start         targets=['openai/gpt-4o', 'anthropic/claude-x']  -> WALKED CHAIN
  reasoning     targets=['openai/gpt-4o', 'anthropic/claude-x']  -> WALKED CHAIN
  usage         targets=['openai/gpt-4o']  mid_stream_loss=False  -> no failover
  visible-text  targets=['openai/gpt-4o']  mid_stream_loss=False  -> no failover

######## failure = transport (raw httpx.ReadError)
  nothing/start/reasoning  -> WALKED CHAIN
  usage         targets=['openai/gpt-4o']  mid_stream_loss=TRUE   -> no failover
  visible-text  targets=['openai/gpt-4o']  mid_stream_loss=TRUE   -> no failover
```

AFTER:

```
######## failure = http500
  usage         targets=['openai/gpt-4o', 'anthropic/claude-x']  -> WALKED CHAIN
  visible-text  targets=['openai/gpt-4o']  -> no failover (unchanged)
######## failure = transport
  usage         targets=['openai/gpt-4o', 'anthropic/claude-x']
                mid_stream_loss=False                            -> WALKED CHAIN
  visible-text  targets=['openai/gpt-4o']  mid_stream_loss=TRUE -> no failover (unchanged)
```

The three pre-existing rows are unchanged in both modes; the visible-text row
must stay "no failover" and does. With a second credential in the pool the same
cell shows the rotation too: asked keys go `k1… k2…`, `auth.rotations` records
`('openai','k1')` then `('openai','k2')`, and only then is the next target
visited.

## Testing Details

- `tests/unit/providers/test_failover.py`: the boundary table is now
  `test_a_pre_content_failure_after_a_non_content_event_still_walks_the_chain`
  with the two usage rows added (7 rows: nothing / start / reasoning /
  start-and-reasoning / **usage** / **start-and-usage** / visible-text control),
  plus `test_a_lone_usage_event_rotates_the_credential_and_walks_the_chain`
  (asserts the sibling key is really asked, on the FAST transient budget, and
  the accounting is still forwarded) and
  `test_a_usage_only_transport_cut_is_not_reported_as_mid_stream` (the transport
  arm, where the misreport did the harm). No new producer/consumer is invented
  for the event: it already had a real emitter and two readers.
- **Mutation-checked per member** (`/tmp/lo-usage-failover-evidence/mutation_check.sh`),
  deleted one at a time: removing `StreamUsageEvent` fails exactly the three
  usage arms and nothing else; removing `StreamReasoningDelta` fails the two
  reasoning rows; removing `StreamStartEvent` fails the three start rows. The
  visible-text control passes under all three mutants.
- Gates, whole tree as CI runs them: `flake8` clean, `black 26.1.0 --check`
  (1243 files unchanged), `isort 5.13.2 --check`, `pyright` 0 errors / 0
  warnings.
- `tests/unit` whole tree (`-n auto` via the repo's own cap):
  **18850 passed, 19 skipped, 1 failed** in 21:33.

  The one failure is
  `tests/unit/evaluation/runner/test_rejection_classes.py::test_every_sealed_rejection_artifact_classifies`
  and it is NOT this change: that test scans the corpus glob
  `~/worktrees/osworld/runs/batch-minimax-m3-*/task_*/evidence/ep-*` — a path
  outside this worktree, owned by the benchmark batch running right now — and
  the in-flight `batch-minimax-m3-canary4` episode it lands on does not classify.
  Re-run with this branch's changes stashed (i.e. against unmodified
  `2692a429f`): **the same test fails the same way, 1 failed in 10s.** It is
  corpus-dependent by construction (`skipif` on a missing corpus, plus a
  rotation skip), so it is green or red depending on what a paid campaign has
  written to that directory at the moment it runs.
- The reproduction script and the mutation harness are evidence, not repo
  content: they live under `/tmp` and are pasted above.

## Impact

**Blast radius — which normal-usage paths see this.** The gate is in
`stream_with_failover`, so every path that can fail over is in scope: the TUI
turn, one-shot CLI runs, `exec`, subagent turns, and isolated errands (naming,
compaction advisor) — the last ones only on their own resolve, since they take
no chain. Reachability of a *lone* usage event needs a wire client that emits
usage before any content: that is the OpenAI-compatible client, which yields
`StreamUsageEvent` ahead of the same chunk's choices (so a provider attaching
accounting to a chunk that also carries content still counts as leading when the
attempt dies before the content is forwarded) and the Responses client. Anthropic
and Gemini emit usage only at the end of the stream, so for them the flag was
already set by content in the shapes where it mattered.

**User-visible behaviour changes, and it is the point:** a session that
previously surfaced a failure now fails over and succeeds when the attempt had
forwarded nothing but accounting. Two consequences worth stating plainly:

1. A turn can now complete where it used to show an error, and can land on a
   fallback provider — the message then names the failure of the PRIMARY attempt
   as a superseded error, exactly as it already does for the start/reasoning
   carve-outs.
2. A retried attempt reports usage a second time. That is not double-counting a
   single call: the failed attempt's accounting is for a call the provider really
   billed, and `on_usage` is documented as firing once per provider call.
   `loop.py` keeps the last usage event for the turn, so the turn's recorded
   usage is the successful attempt's.

No change when any content event (text, tool-call, end) was forwarded: the
`forwarded_any` arm is untouched for those, which is what the third mutant and
the visible-text control pin.

## Related Issue(s)

No issue filed. Found during the #1001 review round and recorded there as
pre-existing and out of that PR's scope (that round fixed the same bug for
`StreamReasoningDelta`); the allowlist form here is the answer to the "next
event type repeats it" note that round left behind.

## Review rounds

Agent review, QA and design rounds to follow on this head; this section is
updated with their verdicts as they land. No design/UX round applies (no
user-visible surface, no interaction flow).

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that my changes work as intended.
- [x] All new and existing tests pass, with one pre-existing, corpus-dependent
      failure unrelated to this change and reproduced on unmodified `main` (see
      the suite result above).
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have commented the WHY and the constraints in every non-obvious change.
- [x] Security considerations: no new data path, no new wire schema, nothing
      logged or rendered that was not before; the change removes a wrong
      retry gate rather than adding a surface.
- [x] No related issue to link (none exists).

## Not addressed

- The other event types are left out of the allowlist on purpose (see above);
  `StreamModelEvent` would be dead code today.
- `_stamp_serving_spec` and the usage consumers are untouched: a usage event
  forwarded by a failed attempt still carries the failed attempt's serving spec,
  which is correct — it *was* served by that provider.

Release: patch — a retry gate stops refusing a retry that was always available;
no API, schema or successful-path behaviour change.
