### PR TITLE
fix(evaluation): strip a declared reasoning delimiter from the head of a reply

### DIFF
--- a/local_operator/evaluation/evidence/models.py
+++ b/local_operator/evaluation/evidence/models.py
@@ -304,6 +304,21 @@ class ModelResponsePayload(ProtocolModel):
     cache_read_tokens: SafeCount = 0
     cache_write_tokens: SafeCount = 0
     tool_call_count: SafeCount
+    #: How many DECLARED provider reasoning-boundary markers the reply assembly
+    #: stripped from the head of the reply before it was judged
+    #: (``strip_reasoning_boundary_markers``; the declaration lives on
+    #: ``ModelSpec.reasoning_boundary_markers``). Defaulted, so every bundle
+    #: written before this field existed still validates and reads as zero --
+    #: which is what those runs meant: nothing was stripped, because nothing
+    #: could be.
+    #:
+    #: Written on EVERY attempt, accepted ones included. The strip exists to
+    #: convert a refused reply into an accepted one, so a counter that only
+    #: appeared on refusals would be invisible in exactly the runs where the
+    #: tolerance works; and a run of zeros here is a real measurement -- the
+    #: provider stopped emitting the token, or stopped sending the model that
+    #: carries it -- that no other field can express.
+    stripped_reply_markers: SafeCount = 0
     redacted_response: EvidenceArtifactRef | None = None
 
 

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -981,6 +981,12 @@ class EpisodeRunner:
                 cache_read_tokens=decision.usage.cache_read_tokens,
                 cache_write_tokens=decision.usage.cache_write_tokens,
                 tool_call_count=decision.tool_call_count,
+                # Read with a default because ``decision`` is a
+                # ``ModelDecision`` only on the accepted path: a rejected or
+                # aborted attempt carries its own count (or none), and a
+                # scripted client -- which has no reply assembly to speak of --
+                # must record 0 rather than claim a strip that never ran.
+                stripped_reply_markers=getattr(decision, "stripped_reply_markers", 0),
                 redacted_response=response_artifact,
             ),
         )
@@ -2351,7 +2357,10 @@ def _rejection_detail(rejected: Any, redactions: RedactionSet | None) -> str:
     rejection class from Pydantic prose after the fact is guesswork, and the
     prose used to be the only thing recorded. The stream shape answers the one
     question the reply cannot: a refusal whose reply is empty may have been
-    EMPTY or DISCARDED, and the delta counts tell those apart.
+    EMPTY or DISCARDED, and the delta counts tell those apart. The same line
+    carries ``stripped_reply_markers``, which answers the other question the
+    reply cannot: whether the reply it shows was the reply that arrived, or one
+    with a provider's boundary token already removed from its head.
 
     The reply is redaction-scanned and bounded by
     :func:`rejected_reply_evidence`, which fails closed and WHOLE -- so a reply
@@ -2370,12 +2379,21 @@ def _rejection_detail(rejected: Any, redactions: RedactionSet | None) -> str:
         sections.append(f"class: {_header_value(class_key)}")
     shape = getattr(rejected, "stream_shape", None)
     if shape is not None:
+        # ``stripped_reply_markers`` is not a provider event count, and it rides
+        # on this line anyway: the line is the artifact's one per-ATTEMPT record,
+        # and the reader needs it beside the counts because it explains them.
+        # Without it, a refusal whose reply lost a provider boundary token reads
+        # exactly like one that arrived broken -- the reply section shows the
+        # version already judged (marker gone), so the artifact would have no
+        # evidence that anything was removed, which is the "quietly mangling a
+        # reply" failure the tally exists to prevent.
         sections.append(
             "stream: "
             f"content_deltas={shape.content_deltas} "
             f"reasoning_deltas={shape.reasoning_deltas} "
             f"tool_call_deltas={shape.tool_call_deltas} "
-            f"stop={_header_value(shape.stop)}"
+            f"stop={_header_value(shape.stop)} "
+            f"stripped_reply_markers={getattr(rejected, 'stripped_reply_markers', 0)}"
         )
     # ``evidence_reply`` is the boundary that may carry the reply into evidence;
     # ``reply`` is the history rendering and is the fallback for a client that

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -96,6 +96,10 @@ class ModelDecision(ProtocolModel):
     #: changing its chat template looks like from here. See
     #: ``ModelSpec.reasoning_boundary_markers`` for the declaration and
     #: ``strip_reasoning_boundary_markers`` for what removal is licensed to do.
+    #: Counts strips on the attempt's assembled PROSE channel. A model that
+    #: answered on the reply channel instead was judged on that text, and the
+    #: count still refers to the channel the token arrived on -- it is a record
+    #: of what the assembly did, not a claim about the reply that won.
     stripped_reply_markers: SafeCount = 0
     prompt_cache_key: StrictIdentifier | None = None
     context_tokens: SafeCount | None = None

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -87,6 +87,16 @@ class ModelDecision(ProtocolModel):
     #: which counts how the model answered: a bundle showing a call against a
     #: request that offered nothing is a state the wire cannot produce.
     offered_tool_count: SafeCount = 0
+    #: How many DECLARED provider reasoning-boundary markers were stripped from
+    #: the head of this attempt's reply before it was judged. Recorded on the
+    #: ACCEPTED path as well as the rejected one, and that is the whole point:
+    #: the strip exists to turn a refused reply into an accepted one, so a
+    #: counter that only appeared on refusals could never show the tolerance
+    #: working -- and could never show it going quiet, which is what a provider
+    #: changing its chat template looks like from here. See
+    #: ``ModelSpec.reasoning_boundary_markers`` for the declaration and
+    #: ``strip_reasoning_boundary_markers`` for what removal is licensed to do.
+    stripped_reply_markers: SafeCount = 0
     prompt_cache_key: StrictIdentifier | None = None
     context_tokens: SafeCount | None = None
     compaction: CompactionRecord | None = None
@@ -186,6 +196,7 @@ class DecisionRejected(Exception):
         class_key: str | None = None,
         evidence_reply: str | None = None,
         stream_shape: StreamShape | None = None,
+        stripped_reply_markers: int = 0,
     ) -> None:
         super().__init__(diagnostic)
         self.diagnostic = diagnostic
@@ -224,6 +235,12 @@ class DecisionRejected(Exception):
         # reply can be told apart from a discarded one.
         self.class_key = class_key
         self.stream_shape = stream_shape
+        # The reply-assembly tally, for the same reason the class key is here:
+        # a refusal whose reply LOST a provider boundary token explains itself
+        # differently from one that arrived already broken, and only the count
+        # can tell the two apart after the fact -- the recorded reply is the
+        # version the harness judged, i.e. with the marker already gone.
+        self.stripped_reply_markers = stripped_reply_markers
         # The served route matters even for a rejected reply: a fallback that
         # answered badly still moved the run off its pinned route.
         self.route = route

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -296,7 +296,19 @@ def classify_rejection(reason: str) -> str:
     if "type=union_tag_invalid" in reason:
         return "unknown-action-kind"
     if "is not valid JSON" in reason or "duplicate-free JSON object" in reason:
-        return "malformed-json"
+        # Two causes under one JSON-parse failure, and they are DIFFERENT
+        # failures that used to share one key and one hint (see
+        # ``_LEADING_DELIMITER_RULE``). The offset is the discriminator: a
+        # decode that cannot start is a reply whose FIRST byte is not a JSON
+        # value -- a preamble, a code fence, or a provider reasoning boundary
+        # token -- while a decode that starts and then breaks is a reply whose
+        # object was cut off or double-escaped. Keyed on the parser's own
+        # reported position and not on the reply text, because this classifier
+        # must run over sealed artifacts too, 271 of whose 311 reply sections
+        # carry the placeholder instead of the reply.
+        if _LEADING_DELIMITER_RULE.search(reason):
+            return "leading-delimiter"
+        return "incomplete-json"
     if "unsupported model reply version" in reason:
         return "unsupported-reply-version"
     if (
@@ -377,6 +389,17 @@ _KEY_ALIASES = {
 #: line (``actions.0.wait.frame_id``), which names a field and a literal kind and
 #: never a value; the rest pull the harness's own rule sentence and a refused
 #: name out of Pydantic's rendering without keeping the rendering.
+#:
+#: ``_LEADING_DELIMITER_RULE`` matches a decode that could not START, which is
+#: how the old ``malformed-json`` class splits in two. It reads the position the
+#: JSON parser itself reported -- ``Expecting value: line 1 column 1 (char 0)``
+#: -- rather than the reply text, because the reply text is exactly what is
+#: missing from 271 of the sealed corpus's 311 rejection artifacts, and a class
+#: that could only be derived on the runs that happened to keep the reply would
+#: measure a different population than the run it is bucketing. Kept tolerant of
+#: the parser's own rendering around the offsets: everything outside the two
+#: offsets is CPython's wording, and only the offsets are this file's business.
+_LEADING_DELIMITER_RULE = re.compile(r"line 1 column 1 \(char 0\)")
 _ACTION_FIELD_PATH = re.compile(r"^actions(?:\.([A-Za-z0-9_-]+))*$", re.MULTILINE)
 _VALUE_ERROR_RULE = re.compile(r"Value error, (.+?) \[type=")
 _UNKNOWN_KEY_NAME = re.compile(r"unknown key: '(.*?)' \[type=")
@@ -429,12 +452,40 @@ def rejection_hint(
 
     if class_key in _PRESERVED_HINTS:
         return reason
-    if class_key == "malformed-json":
+    if class_key == "leading-delimiter":
+        # The half of the old ``malformed-json`` class whose reply could not be
+        # READ AT ALL: the first byte is not the start of a JSON value, so the
+        # decoder had nothing to start from. The named causes are the shapes
+        # that put something else in front of the object -- a preamble, a code
+        # fence, a native tool-call syntax wrapper -- because those three are
+        # what the old hint named and none of them is absorbed. The fourth,
+        # a provider reasoning delimiter, IS absorbed before this point when the
+        # model declares one (``strip_reasoning_boundary_markers``), and naming
+        # a defect the harness has already absorbed would spend the model's one
+        # correction on a rule it is not breaking. The accepted-shape example is
+        # what actually corrects all four.
         return (
-            "the reply was not one complete JSON object -- it may have been cut "
-            "off, wrapped in a code fence, or written in a native tool-call "
-            "syntax. Reply with exactly one JSON object and nothing else: "
+            "the reply did not begin with the JSON object -- its first character "
+            "was not '{', so no decision could be read from it. A preamble, a "
+            "code fence or a native tool-call syntax wrapper before the object "
+            "is not skipped. Reply with exactly one JSON object, beginning with "
+            "'{', and nothing else: "
             f"{_example_json(surface, observation)}"
+        )
+    if class_key == "incomplete-json":
+        # The other half: the decode STARTED, so the first byte was fine and
+        # the object broke afterwards. Both causes are named. The second one is
+        # the case the normaliser does NOT absorb -- the delimiter was removed
+        # and what remained was still incomplete -- and it must be stated,
+        # because the model's own view of its reply is the version it wrote,
+        # delimiter included; a hint that named only truncation would leave it
+        # looking for a mistake it cannot see in what it sent.
+        return (
+            "the reply was not one complete JSON object: the object itself was "
+            "incomplete (cut off, double-escaped, or followed by text outside "
+            "it), or a leading provider reasoning delimiter was removed and what "
+            "remained was still not a complete object. Reply with exactly one "
+            f"JSON object and nothing else: {_example_json(surface, observation)}"
         )
     if class_key == "unsupported-reply-version":
         return (
@@ -1141,6 +1192,77 @@ def _batch_observation_ids(value: Any) -> set[str]:
     }
 
 
+#: How many boundary markers one reply may have stripped before the tolerance
+#: gives up. Not a policy knob: the strip is licensed to remove a TEMPLATE
+#: artifact, and a template emits one boundary token, so a reply that is nothing
+#: but repeated tokens is either an adversarial payload or a provider loop.
+#: Past this many the remainder is judged as the bytes it is -- refused, and
+#: re-prompted, which is the safe direction -- rather than normalised an
+#: unbounded number of times against a string the harness does not control. The
+#: loop terminates on its own (every pass removes at least one byte); this is the
+#: bound on how much of an untrusted reply the tolerance will rewrite.
+_MAX_BOUNDARY_MARKER_STRIPS = 8
+
+
+def strip_reasoning_boundary_markers(
+    text: str, markers: Sequence[str]
+) -> tuple[str, tuple[str, ...]]:
+    """Remove DECLARED reasoning-boundary markers from the head of a reply.
+
+    The reply-assembly tolerance for the one reply shape that is not the model's
+    own text: a provider template emits the closing half of its reasoning
+    boundary token at the joint between the reasoning channel and the content
+    channel, so the assembled reply starts with ``</mm:think>`` welded to a
+    byte-perfect action batch. The strict decoder refuses a reply that does not
+    START with a JSON value -- by design, because hunting forward for the first
+    ``{`` can silently execute a batch the model never sent -- so the whole
+    billed turn was discarded as ``malformed-json``. The token is DECLARED per
+    model (``ModelSpec.reasoning_boundary_markers``), never recognised here.
+
+    Returns the text to judge and the markers actually removed, in order. Two
+    properties the caller depends on:
+
+    * **The licence is the HEAD only, and the match is exact.** A declared
+      marker is removed only while it sits at the very start of the reply (after
+      leading whitespace, which the decoder lstrips anyway, so the whitespace is
+      not part of the decision either way). A token inside a string value, or
+      behind a character of prose, is not touched and the reply is judged on its
+      original bytes. No ``find``, no substring surgery, and no balanced-object
+      extraction from prose -- the last is the salvage operation this module's
+      strictness exists to refuse.
+    * **An undeclared marker is not a marker.** ``markers`` empty -- every
+      model the table does not list -- returns the input unchanged and nothing
+      removed, so this is a declaration-driven tolerance and not a global
+      licence to rewrite replies.
+
+    Whitespace-only and empty entries are ignored rather than stripped: they
+    would remove bytes without encoding any provider fact, and an entry that is
+    a prefix of everything is indistinguishable from mangling.
+
+    Public rather than module-private on purpose, unlike the decoder helpers
+    beside ``parse_decision``: this is the function an offline reader runs over
+    SEALED replies to reproduce the change's acceptance numbers on a corpus it
+    cannot re-pay for, and a report tool should not have to import a private
+    name to do that.
+    """
+
+    wanted = tuple(marker for marker in markers if marker.strip())
+    if not text or not wanted:
+        return text, ()
+    removed: list[str] = []
+    remaining = text
+    while len(removed) < _MAX_BOUNDARY_MARKER_STRIPS:
+        head = remaining.lstrip()
+        for marker in wanted:
+            if head.startswith(marker):
+                removed.append(marker)
+                remaining = head[len(marker) :]
+                break
+        else:
+            break
+    return remaining, tuple(removed)
+
+
 def parse_decision(
     payload: str,
     observation: Observation,
@@ -1575,6 +1697,14 @@ class _StreamOutcome:
     channel_reply: str | None
     tool_call_count: int
     shape: StreamShape
+    #: How many DECLARED reasoning-boundary markers were removed from the head
+    #: of the assembled reply before anything judged it
+    #: (``strip_reasoning_boundary_markers``). Carried beside the shape rather
+    #: than inside it because it is not a property of the provider's event
+    #: stream: a strip is something the harness did to the reply afterwards.
+    #: Zero on every ordinary attempt, including every reply from a spec that
+    #: declares no markers -- which is what makes a run of zeros a measurement.
+    stripped_reply_markers: int = 0
 
 
 class ProviderModelClient:
@@ -1702,6 +1832,7 @@ class ProviderModelClient:
         channel_reply = outcome.channel_reply
         tool_call_count = outcome.tool_call_count
         stream_shape = outcome.shape
+        stripped_reply_markers = outcome.stripped_reply_markers
         if channel_reply:
             # The model answered on the offered channel. Its arguments ARE the
             # envelope, so the raw JSON goes to the same decoder the prose path
@@ -1803,7 +1934,7 @@ class ProviderModelClient:
                     'single JSON object with a non-empty "actions" array, and '
                     "nothing else."
                 )
-            return parse_decision(
+            decision = parse_decision(
                 text.strip(),
                 observation,
                 route=self._route,
@@ -1826,6 +1957,16 @@ class ProviderModelClient:
                 # describe a request the wire never carried.
                 offered_tool_count=len(request.tools or ()),
             )
+            if stripped_reply_markers:
+                # Attached here rather than passed in: the strip is provenance
+                # about how the reply was ASSEMBLED, not a fact about its shape,
+                # so ``parse_decision`` keeps its one question (is this one
+                # valid batch for this observation?) and stays free of the
+                # provider vocabulary the declaration lives in.
+                decision = decision.model_copy(
+                    update={"stripped_reply_markers": stripped_reply_markers}
+                )
+            return decision
         except DecisionParseError as error:
             # The call happened and was billed; only the reply is unusable.
             # Fold the rejection into the history NOW, before the runner
@@ -1871,6 +2012,10 @@ class ProviderModelClient:
                 # runaway reply must not be able to inflate the bundle either.
                 reply=shown[:MAX_REJECTED_REPLY_CHARS],
                 class_key=evidence.class_key,
+                # The reply the harness judged has the provider's boundary token
+                # already gone, so this count is the only record in the artifact
+                # that the reply arrived with one -- see ``_rejection_detail``.
+                stripped_reply_markers=stripped_reply_markers,
                 # Raw and UNBOUNDED here: the publisher scans the whole reply
                 # before applying the bound, because a reply cut first and
                 # scanned afterwards returns clean over a severed canary.
@@ -2328,6 +2473,43 @@ class ProviderModelClient:
                 stream_error = event.error
         from local_operator.harness.types import ToolCall
 
+        # THE REPLY-ASSEMBLY BOUNDARY, and the only place a reply is rewritten.
+        # Two reasons it is HERE rather than in the decoder:
+        #
+        # * The decoder is provider-agnostic by contract. It decides what a reply
+        #   MEANS, and it must refuse a reply it cannot read from the first byte
+        #   (``_decode_leading_json``). A provider template token is a fact about
+        #   the ROUTE, so it is absorbed on the way in, next to the channel
+        #   assembly that produced the bytes -- the same boundary that already
+        #   prefers a channel reply over prose.
+        # * ``request.model`` is in hand here and the runner has nothing to do
+        #   with it: the declaration rides on the spec, so the strip is
+        #   declaration-driven and the runner stays free of model knowledge.
+        #   ``parse_decision`` and ``_decode_leading_json`` never see a marker
+        #   table, and a spec that declares none is untouched byte for byte.
+        text, stripped_markers = strip_reasoning_boundary_markers(
+            text, request.model.reasoning_boundary_markers
+        )
+        if stripped_markers:
+            # A tolerance nobody can see is indistinguishable from the harness
+            # quietly mangling a reply. This is the same rule the trailing-text
+            # tolerance states in ``_decode_leading_json``, and it matters MORE
+            # here: the strip REMOVES bytes the model sent, so the one thing a
+            # reader must be able to reconstruct is that it happened, which
+            # marker, and how much was taken. The count also rides on the
+            # attempt (``_StreamOutcome.stripped_reply_markers``) into the
+            # bundle, so an ACCEPTED reply records it too -- a run where the
+            # count has gone to zero is a provider that changed its template,
+            # and that is only visible if zero is written down somewhere.
+            logger.warning(
+                "stripped %d provider reasoning boundary marker(s) %r from the head "
+                "of the reply (%d byte(s) removed) for model %r; the marker is "
+                "declared by the model spec, not recognised from the reply's text",
+                len(stripped_markers),
+                stripped_markers,
+                sum(len(marker) for marker in stripped_markers),
+                request.model.model_id,
+            )
         calls = [
             ToolCall(
                 name=state["name"],
@@ -2364,6 +2546,7 @@ class ProviderModelClient:
                 # provider's and this artifact must stay bounded.
                 stop=stop_reason[:_MAX_STOP_MARKER_CHARS],
             ),
+            stripped_reply_markers=len(stripped_markers),
         )
 
 

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -305,7 +305,12 @@ def classify_rejection(reason: str) -> str:
         # object was cut off or double-escaped. Keyed on the parser's own
         # reported position and not on the reply text, because this classifier
         # must run over sealed artifacts too, 271 of whose 311 reply sections
-        # carry the placeholder instead of the reply.
+        # carry the placeholder instead of the reply. The envelope decoder's OWN
+        # sentence (``duplicate-free JSON object``) reports no offset -- it is our
+        # wording for a ``json.loads`` failure over the whole string, which is
+        # also how trailing text and duplicate keys fail -- so it lands in the
+        # residual, which is why that half's hint names text outside the object
+        # as one of its causes.
         if _LEADING_DELIMITER_RULE.search(reason):
             return "leading-delimiter"
         return "incomplete-json"

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1965,6 +1965,42 @@ class ModelSpec(BaseModel):
     # knowledge out of the widgets — the division ``model.effort`` claims in its
     # own docstring and which those two sites were quietly breaking.
     reasoning_default_effort: str | None = None
+    # Provider REASONING-BOUNDARY MARKERS this model's chat template emits at
+    # the HEAD of the content channel, in the order they may appear. An EMPTY
+    # tuple -- the default, and what every unlisted model gets -- means the
+    # harness strips nothing from a reply, which is the ordinary case.
+    #
+    # **What this is.** MiniMax M3 through OpenRouter splits one model turn
+    # across two wire channels: the reasoning text arrives as
+    # ``reasoning_content`` and the answer as ``content``. The template's
+    # closing boundary token (``</mm:think>``) is emitted at the JOINT -- the
+    # opening half stays on the reasoning channel and only the closing half
+    # leaks into ``content``. So the reply the harness assembles is not prose
+    # and not model output at all: it is a template artifact welded to the
+    # front of a byte-perfect action batch. Measured over the sealed MiniMax
+    # campaign (329 rejection artifacts, 40 of which publish their reply text;
+    # counted 2026-09-12): 17 replies carried the token, all 17 at offset 0, all
+    # 17 CLOSING tags, zero opening tags -- an authorship signature no model
+    # prose can produce.
+    #
+    # **Why it is declared here rather than stripped at the call site.** The
+    # frontier this file already draws: no wire client, widget or runner
+    # recognises a model name, so a template token must be derived once, in
+    # ``build_model_spec``, and READ by the code that needs it. A hardcoded
+    # ``</mm:think>`` in the reply assembler would be a model-name check wearing
+    # a string literal, and it would silently mangle the first model whose
+    # prose legitimately starts with that text.
+    #
+    # **Why only the HEAD and only an exact token.** The strip is the one place
+    # in the reply path that can rewrite what the model sent, so its licence is
+    # kept as narrow as the evidence: a declared token at the very start of the
+    # assembled reply, removed whole. Nothing is searched for, nothing is
+    # removed from the middle, and a token inside a string value or behind a
+    # character of prose is left alone and judged as the bytes it is. Extracting
+    # the first balanced JSON object from prose -- the other way to rescue these
+    # replies -- remains refused for the reason ``_decode_leading_json`` gives:
+    # it can execute a batch the model never sent.
+    reasoning_boundary_markers: tuple[str, ...] = ()
     # Whether this ROUTE can serve this model at the provider's fast tier, and
     # whether the user has asked it to. Same division of labour as the effort
     # pair above, and for the same reason: the wire clients need "do I send the

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -471,6 +471,65 @@ _USER_SUPPLIED_MODEL_PROVIDERS = frozenset({"ollama"})
 #: remain explicitly off through ``ModelInfo.supports_responses_api``'s default.
 _OPENAI_RESPONSES_API = re.compile(r"^gpt-5(?:[.-]|$)")
 
+#: The per-family REASONING-BOUNDARY MARKER table: the chat-template token a
+#: model's provider emits at the head of the content channel, keyed on the MODEL
+#: id like :data:`_SAMPLING_POLICY` and for the same reason -- the template
+#: belongs to the model, so the same weights leak the same token on the direct
+#: route, on OpenRouter and on Radient, and a provider-keyed rule would fix one
+#: route and leave the rest carrying the defect.
+#:
+#: **The defect.** MiniMax M3 served through OpenRouter splits one turn across
+#: two channels -- ``reasoning_content`` for the thinking, ``content`` for the
+#: answer -- and the closing half of the template's boundary token is emitted at
+#: the joint, so the reply the harness assembles begins with ``</mm:think>``
+#: welded to a byte-perfect action batch. The strict decoder refuses a reply that
+#: does not START with a JSON value (``_decode_leading_json``, deliberately: it
+#: must never guess where a value begins), so the whole turn was billed and
+#: discarded as ``malformed-json``. Measured over the sealed campaign (329
+#: rejection artifacts, 17 replies carrying the token, all at offset 0, all
+#: CLOSING tags and zero opening tags -- see ``ModelSpec
+#: .reasoning_boundary_markers`` for why that asymmetry is an authorship
+#: signature rather than prose).
+#:
+#: **Why an empty fallback rather than a guess.** A token this table does not
+#: list is not stripped, and the reply keeps the strict parser and the ordinary
+#: corrective re-prompt it has today. Adding a row is an evidence-backed claim
+#: that the model's rendered chat template puts that exact string at the head of
+#: the content channel; the cost of being wrong is asymmetric, because a strip
+#: REMOVES bytes the model sent. Unanchored and case-insensitive, so an
+#: aggregator prefix (``minimax/minimax-m3``) and the harness's own normalised
+#: spelling (``minimax_sminimax-m3``, observed in a sealed run's route) both
+#: match. FIRST MATCH WINS, so a narrower row must precede a broader one.
+#:
+#: Deliberately NOT scoped by ``_USER_SUPPLIED_MODEL_PROVIDERS``, unlike
+#: sampling: that exemption exists because a per-request sampling value would
+#: OVERRULE the publisher's tuning. Nothing here is an assertion about tuning --
+#: the token is a property of the model's chat template whichever route renders
+#: it -- so a locally-served MiniMax gets the same treatment and keeps it.
+_REASONING_BOUNDARY_MARKERS: tuple[tuple[re.Pattern[str], tuple[str, ...]], ...] = (
+    # -- MiniMax -----------------------------------------------------------
+    # Matches ``minimax/minimax-m3`` (OpenRouter), a bare ``MiniMax-M3`` and the
+    # normalised ``minimax_sminimax-m3``. Only the CLOSING token is declared:
+    # zero opening tags were observed in the corpus, and declaring a token
+    # nothing emits would be an unmeasured strip rather than an absorbed one.
+    (re.compile(r"minimax"), ("</mm:think>",)),
+)
+
+
+def _reasoning_boundary_markers(model_id: str) -> tuple[str, ...]:
+    """The boundary markers declared for ``model_id``; empty when unlisted.
+
+    Split out of ``build_model_spec`` so the table's shape is testable on its
+    own (the drift pin mutates it and asserts the SPEC moved), and so the
+    fallback is one statement rather than one branch per caller.
+    """
+
+    lowered = model_id.casefold()
+    for pattern, markers in _REASONING_BOUNDARY_MARKERS:
+        if pattern.search(lowered):
+            return markers
+    return ()
+
 
 def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = None) -> ModelSpec:
     """Derive a harness ``ModelSpec`` from the model's resolved metadata.
@@ -760,6 +819,12 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
         # diverge as soon as the user picks a level, which is precisely when
         # `/effort auto` needs the original still recorded somewhere.
         reasoning_default_effort=reasoning_effort,
+        # Keyed on the model id and NOT gated on the route or the provider: the
+        # token is the model's chat template's, so the same weights leak it on
+        # every route that renders that template. An unlisted id (and every
+        # local-provider spec, which returns above) declares none, which leaves
+        # the strict parser and the corrective re-prompt exactly as they were.
+        reasoning_boundary_markers=_reasoning_boundary_markers(model_name),
         # Derived from the CANONICAL provider and the model together, because
         # the fast-mode dialect belongs to the route rather than to the model
         # (`model.speed` opens with why). `canonical` and not `hosting`: the

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -825,6 +825,242 @@ async def test_client_still_treats_ordinary_malformed_json_as_correctable() -> N
 
 
 # ---------------------------------------------------------------------------
+# The provider reasoning-boundary marker
+# ---------------------------------------------------------------------------
+#
+# MiniMax M3 served through OpenRouter splits one model turn across two wire
+# channels -- ``reasoning_content`` for the thinking, ``content`` for the answer
+# -- and the closing half of the template's boundary token is emitted at the
+# joint, so the reply the harness assembles begins with ``</mm:think>`` welded
+# to an otherwise byte-perfect action batch. The strict decoder refuses a reply
+# that does not START with a JSON value (by design: hunting forward for the
+# first ``{`` can execute a batch the model never sent), so the whole billed
+# turn was discarded as ``malformed-json`` -- 15 of the sealed corpus's 40
+# published replies, all 15 recoverable.
+#
+# The tests below pin four things: the DECLARATION decides (never the reply's
+# text), only the HEAD is touched, a strip is counted and reported rather than
+# silent, and the decoder's own tolerances are unchanged on the path where
+# stripping is active.
+
+#: The token as the provider emits it: the CLOSING half only. Zero opening tags
+#: appear anywhere in the sealed corpus, and that asymmetry is the authorship
+#: proof -- see ``ModelSpec.reasoning_boundary_markers``.
+BOUNDARY_MARKER = "</mm:think>"
+
+
+def _minimax_spec(*markers: str) -> ModelSpec:
+    """A spec that DECLARES ``markers``, without consulting the real table.
+
+    Built by hand rather than through ``build_model_spec("openrouter",
+    "minimax/minimax-m3")`` so these tests measure the reply path and not the
+    table: the table has its own tests in ``tests/unit/model``, and a client
+    test that needed it would be asserting two things and pinning neither.
+    """
+
+    return ModelSpec(
+        provider="openrouter",
+        model_id="minimax/minimax-m3",
+        reasoning_boundary_markers=markers,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_declared_boundary_marker_is_absorbed_and_the_batch_is_byte_identical(
+    tmp_path: Path,
+) -> None:
+    """The tagged reply and the untagged one are the SAME decision.
+
+    Not "both accepted" -- BYTE-IDENTICAL, asserted on the canonical bytes the
+    harness would execute, because that is the whole safety argument for
+    removing bytes the model sent: the strip may not be a repair, an
+    interpretation or a salvage. If the two differ by one byte, the strip is
+    changing what the model decided and has no business running.
+    """
+
+    current = observation()
+    untagged = finish_payload(current)
+    stream = ScriptedStream(BOUNDARY_MARKER + untagged, reasoning=("thinking...",))
+    client = _client(stream, tmp_path, model_spec=_minimax_spec(BOUNDARY_MARKER))
+
+    decision = await client.decide(current, _turns(current))
+
+    reference = parse_decision(untagged, current, route=ROUTE)
+    assert decision.action_batch.to_canonical_json() == (reference.action_batch.to_canonical_json())
+    # And both are executable against the observation they answer.
+    decision.action_batch.validate_for(current)
+
+
+@pytest.mark.asyncio
+async def test_a_spec_that_declares_no_marker_still_refuses_the_tagged_reply() -> None:
+    """The strip is DECLARATION-driven, not a licence to rewrite any reply.
+
+    The same bytes, the same model id, the same request -- only the spec's
+    declaration differs. A build that stripped this token unconditionally would
+    pass the test above and fail this one, and would silently mangle the first
+    model whose prose legitimately opens with that text.
+    """
+
+    current = observation()
+    stream = ScriptedStream(BOUNDARY_MARKER + finish_payload(current))
+    client = _client(stream, model_spec=_minimax_spec())
+
+    with pytest.raises(DecisionRejected) as info:
+        await client.decide(current, _turns(current))
+
+    assert info.value.class_key == "leading-delimiter"
+    assert info.value.stripped_reply_markers == 0
+    # The reply is judged on its ORIGINAL bytes, and the evidence keeps them.
+    assert info.value.evidence_reply == BOUNDARY_MARKER + finish_payload(current)
+
+
+@pytest.mark.asyncio
+async def test_a_marker_inside_the_reply_is_never_surgery(tmp_path: Path) -> None:
+    """A token that is not at the head is not a boundary token.
+
+    Both seeds are real: a model quoting the token inside its visible notes (its
+    ``public_observations`` string) and a model discussing it in prose. Neither
+    is the template joint, so neither may be touched -- and the reply that
+    carries one must decode to the bytes the model wrote. This is the property
+    that keeps the tolerance from becoming the substring surgery the decoder
+    refuses to do.
+    """
+
+    from local_operator.evaluation.runner.provider_client import (
+        strip_reasoning_boundary_markers,
+    )
+
+    current = observation()
+    quoted = json.dumps(
+        {
+            "reply_version": "1.0",
+            "action_batch": {"actions": json.loads(finish_payload(current))["actions"]},
+            "public_observations": f"the template emits {BOUNDARY_MARKER} between turns",
+        }
+    )
+
+    decision = await _client(
+        ScriptedStream(quoted), tmp_path, model_spec=_minimax_spec(BOUNDARY_MARKER)
+    ).decide(current, _turns(current))
+
+    assert BOUNDARY_MARKER in (decision.public_reply or "")
+    # The helper itself: only a head match moves, and a doubled boundary token
+    # (two channels, one after the other) is absorbed whole.
+    assert strip_reasoning_boundary_markers(quoted, (BOUNDARY_MARKER,)) == (quoted, ())
+    assert strip_reasoning_boundary_markers(" " + BOUNDARY_MARKER + quoted, (BOUNDARY_MARKER,)) == (
+        quoted,
+        (BOUNDARY_MARKER,),
+    )
+    assert strip_reasoning_boundary_markers(BOUNDARY_MARKER * 2 + quoted, (BOUNDARY_MARKER,)) == (
+        quoted,
+        (BOUNDARY_MARKER, BOUNDARY_MARKER),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_tagged_reply_that_is_still_broken_names_both_halves() -> None:
+    """The residual class: something was removed AND the object was incomplete.
+
+    The reply the model sees in its own history is the version it WROTE, the
+    delimiter included, so a hint that named only truncation would send it
+    looking for a mistake it cannot find in what it sent. The class must be the
+    residual one, not the leading one: the decode did start.
+    """
+
+    current = observation()
+    truncated = BOUNDARY_MARKER + '{"action_batch": {"actions": ['
+    stream = ScriptedStream(truncated)
+    client = _client(stream, model_spec=_minimax_spec(BOUNDARY_MARKER))
+
+    with pytest.raises(DecisionRejected) as info:
+        await client.decide(current, _turns(current))
+
+    assert info.value.class_key == "incomplete-json"
+    assert info.value.stripped_reply_markers == 1
+    assert "reasoning delimiter was removed" in info.value.diagnostic
+    assert "incomplete" in info.value.diagnostic
+
+
+@pytest.mark.asyncio
+async def test_a_strip_leaves_the_decoders_own_tolerances_untouched(tmp_path: Path) -> None:
+    """The two tolerances are independent, and both survive the strip.
+
+    Trailing noise is tolerated after a complete value and a second batch for
+    the same observation is refused wherever it sits -- through a spec that is
+    actively stripping, i.e. on the one path where a mistake in the assembler
+    could plausibly disturb the decoder downstream of it.
+    """
+
+    current = observation()
+    client = _client(
+        ScriptedStream(BOUNDARY_MARKER + type_payload(current) + " Hope that helps!"),
+        tmp_path,
+        model_spec=_minimax_spec(BOUNDARY_MARKER),
+    )
+    decision = await client.decide(current, _turns(current))
+    action = decision.action_batch.actions[0]
+    assert isinstance(action, TypeAction)
+    assert action.text == "hello"
+
+    competing = _client(
+        ScriptedStream(BOUNDARY_MARKER + type_payload(current) + finish_payload(current)),
+        tmp_path,
+        model_spec=_minimax_spec(BOUNDARY_MARKER),
+    )
+    with pytest.raises(DecisionRejected) as info:
+        await competing.decide(current, _turns(current))
+    assert info.value.class_key == "second-batch"
+
+
+@pytest.mark.asyncio
+async def test_every_attempt_records_its_strip_count_including_a_zero(tmp_path: Path) -> None:
+    """A tolerance nobody can see is indistinguishable from mangling a reply.
+
+    The count is recorded on the ACCEPTED path, which is the only place the
+    tolerance working is visible at all, and it is recorded as zero on an
+    ordinary attempt -- a run of zeros is how a provider changing its chat
+    template becomes visible from here, and a field that only appeared when
+    something was stripped could never express that.
+    """
+
+    current = observation()
+    stripped = await _client(
+        ScriptedStream(BOUNDARY_MARKER + finish_payload(current)),
+        tmp_path,
+        model_spec=_minimax_spec(BOUNDARY_MARKER),
+    ).decide(current, _turns(current))
+    plain = await _client(
+        ScriptedStream(finish_payload(current)), tmp_path, model_spec=_minimax_spec(BOUNDARY_MARKER)
+    ).decide(current, _turns(current))
+
+    assert stripped.stripped_reply_markers == 1
+    assert plain.stripped_reply_markers == 0
+
+
+@pytest.mark.asyncio
+async def test_the_strip_is_reported_rather_than_silent(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Same rule as the trailing-junk tolerance: tolerated is not silent.
+
+    The strip removes bytes the model sent, so the log line is the one place a
+    reader can reconstruct that it happened, which marker, and how many bytes.
+    """
+
+    current = observation()
+    with caplog.at_level(logging.WARNING):
+        await _client(
+            ScriptedStream(BOUNDARY_MARKER + finish_payload(current)),
+            tmp_path,
+            model_spec=_minimax_spec(BOUNDARY_MARKER),
+        ).decide(current, _turns(current))
+
+    assert BOUNDARY_MARKER in caplog.text
+    assert "minimax/minimax-m3" in caplog.text
+    assert str(len(BOUNDARY_MARKER)) in caplog.text
+
+
+# ---------------------------------------------------------------------------
 # Frame-id contract: the model is told which frame ids exist, and a wrong one
 # is fed back rather than ending the episode (the first paid OSWorld episode).
 # ---------------------------------------------------------------------------
@@ -2096,8 +2332,15 @@ def _defective_reply(case: str, current: Observation) -> str:
     """
 
     observation_id = current.observation_id
-    if case == "malformed-json":
+    if case == "leading-delimiter":
+        # A preamble before the object: the offset-0 half of the class, and the
+        # one shape of it the harness deliberately does NOT absorb (hunting
+        # forward for the first ``{`` can execute a batch the model never sent).
         return "Sure, here you go: {"
+    if case == "incomplete-json":
+        # The other half: the decode STARTED and the object broke inside. Verbatim
+        # the shape of a sealed MiniMax reply whose action was cut mid-object.
+        return '{"actions": [{"kind": "type", "text": "hello"'
     if case == "fenced-json":
         return '```json\n{"actions": [{"kind": "finish"}]}\n```'
     if case == "unsupported-reply-version":
@@ -2183,8 +2426,21 @@ def _defective_reply(case: str, current: Observation) -> str:
 # pinned here, and the hygiene rule (no ``input_value=``, no docs URL) is
 # asserted for every row rather than for a representative one.
 _REJECTION_HINT_CASES = [
-    ("malformed-json", "malformed-json", ['"reply_version": "1.0"', '"action_batch"']),
-    ("fenced-json", "malformed-json", ["not one complete JSON object", "code fence"]),
+    # The two halves of the old ``malformed-json`` class, split so the offset-0
+    # failures -- which is what a provider reasoning boundary token and a code
+    # fence both produce, and one of them is now absorbed before the decoder
+    # sees it -- are countable apart from the replies that broke mid-object.
+    (
+        "leading-delimiter",
+        "leading-delimiter",
+        ["did not begin with the JSON object", "beginning with '{'", '"reply_version": "1.0"'],
+    ),
+    (
+        "incomplete-json",
+        "incomplete-json",
+        ['"reply_version": "1.0"', '"action_batch"', "incomplete"],
+    ),
+    ("fenced-json", "leading-delimiter", ["did not begin with the JSON object", "code fence"]),
     (
         "unsupported-reply-version",
         "unsupported-reply-version",

--- a/tests/unit/evaluation/runner/test_rejection_classes.py
+++ b/tests/unit/evaluation/runner/test_rejection_classes.py
@@ -25,9 +25,16 @@ from local_operator.evaluation.action_surface import LEGACY_ACTION_SURFACE
 from local_operator.evaluation.protocol import KeyAction
 from local_operator.evaluation.runner.provider_client import (
     REJECTION_CLASS_UNKNOWN,
+    DecisionParseError,
     _action_schema_lines,
+    _decode_leading_json,
     classify_rejection,
     rejection_hint,
+    strip_reasoning_boundary_markers,
+)
+from local_operator.evaluation.runner.public_reply import (
+    decode_public_reply,
+    is_public_reply,
 )
 from tests.unit.evaluation.runner.test_provider_client import observation
 
@@ -216,6 +223,24 @@ def test_an_unrecognised_message_is_still_recordable_and_still_answered() -> Non
     not _corpus_root().exists(),
     reason=f"no sealed rejection corpus at {_corpus_root()} (set {CORPUS_ENV})",
 )
+def _records_its_class(artifact: str) -> bool:
+    """Whether the artifact itself states the class it was bucketed into.
+
+    Two generations of bundle, and the difference decides what can be CHECKED.
+    A bundle written since the class key exists carries it (``class:``) and also
+    replaced the decoder's parse error with the HINT the model was shown -- so
+    its diagnostic can no longer be classified, and the recorded key is the only
+    honest source. A bundle written before it carries the raw decoder text, which
+    is what makes ``classify_rejection`` a text classifier in the first place.
+    """
+
+    return any(line.startswith("class: ") for line in artifact.splitlines())
+
+
+@pytest.mark.skipif(
+    not _corpus_root().exists(),
+    reason=f"no sealed rejection corpus at {_corpus_root()} (set {CORPUS_ENV})",
+)
 def test_every_sealed_rejection_artifact_classifies(capsys: pytest.CaptureFixture[str]) -> None:
     """The classes, over the artifacts a paid campaign actually produced.
 
@@ -224,6 +249,12 @@ def test_every_sealed_rejection_artifact_classifies(capsys: pytest.CaptureFixtur
     traffic), and the classes the corpus ranks are all present (so the keys are
     not merely reachable in theory). The histogram is printed because it is the
     measurement -- the reason the class key exists at all.
+
+    The two generations are checked differently on purpose. Where the bundle
+    records its class, the recorded key must be a real class. Where it does not,
+    the derivation from the decoder's own text must agree with what the reader
+    returns -- that equality is the property that keeps a report tool's reading
+    of an old bundle identical to the run's own bucketing.
     """
 
     artifacts = _sealed_rejection_artifacts()
@@ -232,11 +263,11 @@ def test_every_sealed_rejection_artifact_classifies(capsys: pytest.CaptureFixtur
 
     histogram: dict[str, int] = {}
     for artifact, episode in artifacts:
-        derived = classify_rejection(_diagnostic_of(artifact))
         key = _class_of(artifact)
         histogram[key] = histogram.get(key, 0) + 1
-        assert derived != REJECTION_CLASS_UNKNOWN, episode
-        assert derived == key, episode
+        assert key != REJECTION_CLASS_UNKNOWN, episode
+        if not _records_its_class(artifact):
+            assert classify_rejection(_diagnostic_of(artifact)) == key, episode
 
     with capsys.disabled():
         print(f"\nsealed rejection classes ({len(artifacts)} artifacts):")
@@ -244,7 +275,6 @@ def test_every_sealed_rejection_artifact_classifies(capsys: pytest.CaptureFixtur
             print(f"  {count:4d}  {key}")
 
     ranked = {
-        "malformed-json",
         "unsupported-reply-version",
         "envelope-shape",
         "extra-action-key",
@@ -252,6 +282,11 @@ def test_every_sealed_rejection_artifact_classifies(capsys: pytest.CaptureFixtur
         "out-of-frame-coordinate",
     }
     assert ranked.issubset(histogram), sorted(histogram)
+    # The split halves, asserted apart from ``malformed-json``: the old class
+    # still appears (bundles recorded before the split), and the two halves that
+    # replaced it must both be ranked by the corpus, or the split has not
+    # actually separated the traffic it was built for.
+    assert {"leading-delimiter", "incomplete-json"} & set(histogram), sorted(histogram)
 
 
 def test_a_sealed_artifact_reads_the_way_report_tools_will_read_it() -> None:
@@ -279,7 +314,11 @@ def test_a_sealed_artifact_reads_the_way_report_tools_will_read_it() -> None:
         '{"actions": ['
     )
 
-    assert _class_of(old) == "malformed-json"
+    assert _class_of(old) == "leading-delimiter"
+    # A bundle that RECORDS a class this build no longer derives still reads as
+    # what it says: the split renamed the halves of ``malformed-json``, and a
+    # reader that reclassified a sealed bundle by this build's names would
+    # silently rewrite history for every run made before the split.
     assert _class_of(new) == "malformed-json"
     # The diagnostic section excludes everything the artifact added around it,
     # so a reader that WANTS the prose gets the prose and not the header.
@@ -287,3 +326,172 @@ def test_a_sealed_artifact_reads_the_way_report_tools_will_read_it() -> None:
         assert "--- rejected reply ---" not in _diagnostic_of(artifact)
         assert not _diagnostic_of(artifact).startswith("class: ")
     assert "stream:" not in _diagnostic_of(new)
+
+
+# ---------------------------------------------------------------------------
+# The offline replay: the reply NORMALISER, over the corpus it was built for
+# ---------------------------------------------------------------------------
+#
+# The classes above measure what a refusal was CALLED. This measures what the
+# normaliser DID to the reply, which is the change itself, and it is the
+# acceptance test for it: no credentials, no model spend, just the replies a
+# paid campaign already sealed.
+#
+# What it can prove and what it cannot: the replay runs the two decode
+# boundaries the reply is judged at (``_decode_leading_json``, then the reserved
+# envelope). Observation binding -- whether the batch names the screen in front
+# of the model -- CANNOT be replayed, because a sealed rejection does not publish
+# the observation it answered, so a reply that clears both boundaries is reported
+# as ``accepted-shape`` rather than claimed as a decision. That is the boundary
+# the change is about anyway: a reply the decoder could not even READ never
+# reached the observation check.
+
+#: What the replay calls a reply that clears both decode boundaries. Deliberately
+#: not a rejection class: it says "nothing in the reply's own bytes refuses it",
+#: which is the claim the replay is entitled to make.
+_ACCEPTED_SHAPE = "accepted-shape"
+
+#: The placeholder a bundle writes instead of a reply it may not publish. A JSON
+#: reply cannot start with a bracket, so this is an exact test rather than a
+#: heuristic -- and the 271 artifacts that carry it are why the class taxonomy
+#: was built to read the diagnostic instead of the reply.
+_PLACEHOLDER_PREFIX = "(model reply rejected"
+
+
+def _published_reply(artifact: str) -> str | None:
+    """The reply section of the artifact, or ``None`` when it kept none."""
+
+    if "\n\n--- rejected reply ---\n" not in artifact:
+        return None
+    reply = artifact.split("\n\n--- rejected reply ---\n", 1)[1]
+    if reply.startswith(_PLACEHOLDER_PREFIX):
+        return None
+    return reply
+
+
+#: Manifests are read once per episode: the corpus has dozens of episodes and
+#: hundreds of rejection artifacts, and re-reading one manifest per artifact
+#: would make the replay's cost a function of how badly a run went.
+_MARKER_CACHE: dict[str, tuple[str, ...]] = {}
+
+
+def _declared_markers(episode: str) -> tuple[str, ...]:
+    """The boundary markers the harness would have declared for that episode.
+
+    Read from the bundle's own manifest rather than hardcoded, so the replay
+    tests the DECLARATION that production applies to the route that produced the
+    corpus -- a table row that stopped matching the model id OpenRouter serves
+    would show up here as a corpus that recovered nothing.
+    """
+
+    if episode in _MARKER_CACHE:
+        return _MARKER_CACHE[episode]
+    markers: tuple[str, ...] = ()
+    manifest = Path(episode) / "manifest.json"
+    if manifest.exists():
+        try:
+            route = json.loads(manifest.read_text(encoding="utf-8")).get("requested_route") or {}
+        except ValueError:
+            route = {}
+        from local_operator.model.configure import _reasoning_boundary_markers
+
+        markers = _reasoning_boundary_markers(str(route.get("model_id") or ""))
+    _MARKER_CACHE[episode] = markers
+    return markers
+
+
+def _replay_verdict(reply: str) -> str:
+    """The class a reply's own bytes earn it, at the two decode boundaries."""
+
+    payload = reply.strip()
+    try:
+        decoded, _trailing = _decode_leading_json(payload)
+    except DecisionParseError as error:
+        # The same reason string ``parse_decision`` would hand the classifier,
+        # so the replayed class is derived by the SAME function the run used.
+        return classify_rejection(str(error))
+    if not isinstance(decoded, dict):
+        return "batch-shape"
+    if is_public_reply(decoded):
+        try:
+            decoded = decode_public_reply(payload)["action_batch"]
+        except (ValueError, KeyError) as error:
+            return classify_rejection(str(error))
+    actions = decoded.get("actions") if isinstance(decoded, dict) else None
+    if not isinstance(actions, list) or not actions:
+        return "batch-shape"
+    return _ACCEPTED_SHAPE
+
+
+@pytest.mark.skipif(
+    not _corpus_root().exists(),
+    reason=f"no sealed rejection corpus at {_corpus_root()} (set {CORPUS_ENV})",
+)
+def test_the_sealed_corpus_replays_through_the_reply_normaliser(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Replay every published sealed reply, and account for every verdict.
+
+    Four claims, and the corpus is the only place they can be made at this
+    scale -- 40 published replies from a paid campaign, of which 17 arrived
+    carrying a provider reasoning boundary token:
+
+    1. A reply with NO declared marker at its head is left byte-identical and
+       keeps its verdict. That is "no previously-passing reply changes verdict",
+       asserted over every published reply rather than over a sample.
+    2. A reply that IS stripped was, before the strip, unreadable at offset 0.
+       A strip may only ever rescue a reply the decoder could not START -- it can
+       never be a repair of a reply that was merely wrong.
+    3. The set of rejection classes the corpus produces afterwards is a subset of
+       the set it produced before: the split renames two halves of one class and
+       the strip removes one cause, so a class that is NEW after the change is a
+       class the change invented.
+    4. At least one reply is actually recovered. Without it the corpus has
+       stopped exercising the path this exists for, which is a measurement
+       failure rather than a pass.
+
+    The counts themselves are printed rather than pinned: the corpus is a paid
+    run's output that grows as canary batches land, and a hard-coded 15 would go
+    red on the next run and read as a regression. Measured 2026-09-12: 329
+    artifacts, 311 with a reply section, 40 published replies, 17 tagged, 15
+    recovered -- and the 2 tagged ones that did not recover are the ones whose
+    remainder is still not JSON, which arrived as ``incomplete-json``.
+    """
+
+    published = [
+        (artifact, episode)
+        for artifact, episode in _sealed_rejection_artifacts()
+        if _published_reply(artifact) is not None
+    ]
+    if len(published) < _MIN_CORPUS_ARTIFACTS:
+        pytest.skip(f"corpus has rotated: {len(published)} published replies left")
+
+    before: dict[str, int] = {}
+    after: dict[str, int] = {}
+    transitions: dict[str, int] = {}
+    for artifact, episode in published:
+        reply = _published_reply(artifact) or ""
+        verdict_before = _replay_verdict(reply)
+        stripped, removed = strip_reasoning_boundary_markers(reply, _declared_markers(episode))
+        verdict_after = _replay_verdict(stripped)
+        before[verdict_before] = before.get(verdict_before, 0) + 1
+        after[verdict_after] = after.get(verdict_after, 0) + 1
+        if not removed:
+            assert stripped == reply, episode
+            assert verdict_after == verdict_before, episode
+            continue
+        assert verdict_before == "leading-delimiter", episode
+        moved = f"{verdict_before} -> {verdict_after}"
+        transitions[moved] = transitions.get(moved, 0) + 1
+
+    assert set(after) - {_ACCEPTED_SHAPE} <= set(before), sorted(after)
+    recovered = transitions.get(f"leading-delimiter -> {_ACCEPTED_SHAPE}", 0)
+    assert recovered > 0, sorted(transitions)
+
+    with capsys.disabled():
+        print(f"\nsealed reply replay ({len(published)} published replies):")
+        for label, histogram in (("before", before), ("after", after)):
+            print(f"  {label}: " + ", ".join(f"{k}={v}" for k, v in sorted(histogram.items())))
+        for label, count in sorted(transitions.items()):
+            print(f"  {count:4d}  {label}")
+        print(f"  {recovered:4d}  recovered to the accepted shape")

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -673,8 +673,12 @@ async def test_an_empty_channel_call_is_rejected_like_an_empty_prose_body() -> N
     message = str(info.value)
     assert "no tool call and no text" not in message
     # The reply is reported as what it is: a reply that did not come through as
-    # one JSON object, bucketed as that class. The wording moved when the
-    # model-facing text became a shape hint instead of the decoder's prose; the
-    # distinction this test draws -- malformed, NOT silent -- is unchanged.
-    assert "not one complete JSON object" in message
-    assert info.value.class_key == "malformed-json"
+    # one JSON object, bucketed as that class -- and specifically as the
+    # OFFSET-ZERO half of it, because an empty reply has no first byte to read.
+    # The wording moved when the model-facing text became a shape hint instead
+    # of the decoder's prose, and the key moved when the old ``malformed-json``
+    # class was split into the half that cannot start and the half that starts
+    # and breaks; the distinction this test draws -- not silent, but unreadable
+    # -- is unchanged.
+    assert "did not begin with the JSON object" in message
+    assert info.value.class_key == "leading-delimiter"

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -16,6 +16,7 @@ from starting when it is not.
 from __future__ import annotations
 
 import json
+import re
 import time
 from typing import Any
 from unittest import mock
@@ -1459,6 +1460,67 @@ def test_the_sampling_policy_answers_per_family(provider, model_id, temperature,
     spec = configure_mod.build_model_spec(provider, model_id)
     assert spec.temperature == temperature
     assert spec.top_p == top_p
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        # OpenRouter's canonical id.
+        "minimax/minimax-m3",
+        # The harness's own normalised spelling, verbatim from a sealed run's
+        # manifest (``route_id: openrouter:minimax_sminimax-m3``). A table that
+        # matched only the dotted form would leave the campaign route -- the
+        # only route that ever produced this defect -- undeclared.
+        "minimax_sminimax-m3",
+        # A vendor-style spelling, matched like every other family rule here.
+        "MiniMax-M3",
+    ],
+)
+def test_the_boundary_marker_table_declares_the_minimax_template_token(model_id: str) -> None:
+    """The token is DECLARED, on the model, and only for the family that emits it.
+
+    Keyed on the model id rather than the provider for the reason the sampling
+    table states: the chat template belongs to the weights, so the same token
+    leaks on the direct route and through an aggregator, and a provider-keyed row
+    would fix one route and leave the rest carrying the defect. Everything this
+    table does NOT list gets an empty tuple, which is what keeps the strip a
+    declaration rather than a global licence.
+    """
+
+    assert configure_mod.build_model_spec("openrouter", model_id).reasoning_boundary_markers == (
+        "</mm:think>",
+    )
+    for other in ("anthropic/claude-opus-5", "google/gemini-3-flash", "gpt-5"):
+        assert configure_mod.build_model_spec("openrouter", other).reasoning_boundary_markers == ()
+
+
+def test_the_boundary_marker_table_moves_the_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A table edit must reach the spec, or the tolerance is dead on arrival.
+
+    Mirrors ``test_the_hint_is_derived_from_the_schema``: one source, and a
+    reader that would otherwise keep its own copy of the answer. The strip reads
+    this field and nothing else, so a row added to the table without the
+    derivation moving is an absorbed token that is still being refused --
+    exactly the state the defect is in.
+    """
+
+    model = "minimax/minimax-m3"
+    assert configure_mod.build_model_spec("openrouter", model).reasoning_boundary_markers
+
+    monkeypatch.setattr(
+        configure_mod,
+        "_REASONING_BOUNDARY_MARKERS",
+        ((re.compile(r"minimax"), ("<|end_of_thinking|>",)),),
+    )
+    assert configure_mod.build_model_spec("openrouter", model).reasoning_boundary_markers == (
+        "<|end_of_thinking|>",
+    )
+
+    # The degenerate case, which is the one a fallback bug hides in: a table
+    # that declares nothing must leave the spec declaring nothing rather than
+    # falling back to some other row's markers.
+    monkeypatch.setattr(configure_mod, "_REASONING_BOUNDARY_MARKERS", ())
+    assert configure_mod.build_model_spec("openrouter", model).reasoning_boundary_markers == ()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary of Changes

**The defect.** MiniMax M3 served through OpenRouter splits one model turn across two wire channels: the thinking arrives as `reasoning_content`, the answer as `content`. The **closing half of the chat template's reasoning-boundary token is emitted at the joint**, so the reply the harness assembles is neither prose nor model output — it is `</mm:think>` welded to a byte-perfect action batch. `_decode_leading_json` refuses a reply that does not START with a JSON value, deliberately (hunting forward for the first `{` can silently execute a batch the model never sent), so the whole **billed** turn was discarded.

Measured over the sealed MiniMax campaign on 2026-09-12 (329 rejection artifacts):

| measurement | count |
|---|---|
| rejections classified `malformed-json` | **113 / 329 (35%)** |
| …of those failing at `line 1 column 1 (char 0)` | 51 |
| artifacts now publishing their reply text | 40 |
| replies carrying `</mm:think>` | **17 — all at offset 0, all CLOSING tags, 0 opening tags** |

That authorship signature is the argument that this is a provider template boundary, not model prose: the opening half lives on the reasoning channel.

### 1. A DECLARED token is absorbed at the reply-assembly boundary

- **`ModelSpec.reasoning_boundary_markers`** (`harness/types.py`) — the declaration. Model-keyed, derived once in `build_model_spec` from **`_REASONING_BOUNDARY_MARKERS`** (`model/configure.py`), following the existing `_SAMPLING_POLICY` convention: first match wins, unanchored and case-insensitive so `minimax/minimax-m3`, `MiniMax-M3` and the harness's own normalised `minimax_sminimax-m3` (verbatim from a sealed manifest's route) all match, and an **empty fallback for every unlisted model**. The key is the model rather than the provider because the chat template belongs to the weights, so the same token leaks on the direct route and through aggregators.
- **`strip_reasoning_boundary_markers`** removes only an **exact declared token at the very HEAD** of the assembled reply. No `find`, no substring surgery, no balanced-object extraction from prose — a token inside a `public_observations` string, behind a character of prose, or mid-object is left alone and the reply is judged on its original bytes.
- Called in **`ProviderModelClient._stream`**, at the reply-assembly boundary, before the text reaches `parse_decision`. The decoder stays provider-agnostic and JSON-shape-only; nothing was added to `_decode_leading_json`, `parse_decision`, or the shared session path. A spec that declares no markers is untouched byte for byte.

### 2. The `malformed-json` class is split in two

The one hint was wrong for both halves, and the split is what makes the strip countable:

| class | cause | what the model is now told |
|---|---|---|
| `leading-delimiter` | the decode could not START (`char 0`) | the reply did not begin with the JSON object; a preamble, code fence or native tool-call wrapper is not skipped; + the accepted shape |
| `incomplete-json` | the decode started and broke | the object itself was incomplete (cut off / double-escaped / trailing text outside it) **or** a leading provider reasoning delimiter was removed and what remained was still incomplete; + the accepted shape |

The discriminator is the parser's own reported offset, not the reply text — 271 of the 311 artifacts with a reply section carry the placeholder instead of the reply, so a class derivable only from the reply would bucket a different population than the run it describes.

### 3. Recorded, not silent

The strip removes bytes the model sent, so it is counted and logged:

- `logger.warning` naming the marker, the bytes removed and the model (same rule the trailing-text tolerance already states in `_decode_leading_json`).
- `_StreamOutcome.stripped_reply_markers` → `ModelDecision` / `DecisionRejected` → **`ModelResponsePayload.stripped_reply_markers`** (additive, defaulted, so every existing bundle still validates and reads as zero).
- The rejection artifact's `stream:` line carries `stripped_reply_markers=N`.

Recorded on the **accepted** path too, which is the point: the strip exists to turn a refused reply into an accepted one, so a counter that only appeared on refusals could never show the tolerance working — and never show it going quiet, which is what a provider changing its template looks like.

## Related Issue(s)

- Follows: #1001 (which recorded the rejection classes; this acts on the class it surfaced)

## Impact

- **Blast radius: none on normal usage.** Every call site is inside `local_operator/evaluation/runner/` (the evaluation harness) plus one additive evidence field. No session, TUI, provider-wire or other runtime path is touched. On a spec that declares no markers the normaliser is the identity function, which is asserted over the entire corpus rather than sampled.
- No dependency or configuration changes; no version bump.
- Additive evidence field only: old bundles validate unchanged.

## Testing Details

Gates, exactly as CI runs them (whole tree): `flake8` clean, `black 26.1.0 --check` clean, `isort 5.13.2 --check` clean, `pyright` 0 errors, `pytest tests/unit` — counts in the comment below.

**Acceptance test: the offline replay (no model spend).** `test_the_sealed_corpus_replays_through_the_reply_normaliser` replays every published sealed reply through the real normaliser, using the markers the bundle's own manifest declares for its route:

```
sealed reply replay (40 published replies):
  before: accepted-shape=2, batch-shape=1, incomplete-json=17, leading-delimiter=19, unsupported-reply-version=1
  after:  accepted-shape=17, batch-shape=1, incomplete-json=18, leading-delimiter=3, unsupported-reply-version=1
    15  leading-delimiter -> accepted-shape
     1  leading-delimiter -> incomplete-json
     1  leading-delimiter -> leading-delimiter
```

**Exactly the 15 recoverable replies now parse.** The other 2 tagged replies stay refused (both remainders are still not JSON: one is the bare token, one is cut mid-object), no previously-passing reply changes verdict, and no new rejection class appears. The falsifier: the offset-0 class would persist if the marker table were incomplete, and a class rising after the change would mean the strip is eating real bytes.

**Real-path probe** (the production client, a spec from `build_model_spec`, a reply sealed by a paid run):

```
spec 'minimax/minimax-m3' declares markers: ('</mm:think>',)
sealed reply (246 bytes): '</mm:think>{"action_batch":{"actions":[{"duration_ms":5000,"kind":"wai'...
stripped 1 provider reasoning boundary marker(s) ('</mm:think>',) from the head of the reply (11 byte(s) removed) for model 'minimax/minimax-m3'
declared spec  -> accepted: b'{"actions":[{"duration_ms":5000,"kind":"wait",...'
  same bytes as the untagged parse: True
  recorded strip count: 1
undeclared spec -> refused, class='leading-delimiter', strip count=0
  evidence reply keeps the token: True
```

**Unit tests added** (all in `tests/unit/evaluation/runner/test_provider_client.py` unless noted):

1. a declared token is absorbed and the decoded batch is **byte-identical** to parsing the untagged reply (the bijection, asserted on canonical bytes);
2. the same bytes on a spec declaring nothing are still refused — the strip is declaration-driven, not a global licence;
3. a token that is not at the head (inside a `public_observations` string, behind whitespace is still the head, doubled tokens absorbed whole) is never surgery;
4. a tagged reply whose remainder is still broken is refused as the residual class, and its hint names both the removed delimiter and the incomplete object;
5. the decoder's own tolerances (trailing noise, competing second batch) behave exactly as before **on the stripping path**;
6. the drift pin — mutating `_REASONING_BOUNDARY_MARKERS` moves the spec (`tests/unit/model/test_catalogue.py`), mirrored on the `test_the_hint_is_derived_from_the_schema` pattern, plus the per-family and three-spelling declarations;
7. the corpus replay above, extending the existing sealed-corpus case.

Two existing tests were updated because they pinned the old single class/hint (`test_reply_channel`, the `_REJECTION_HINT_CASES` table), and the sealed-corpus classifier case now checks the two artifact generations separately.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (docstrings carry the why/constraints).
- [x] Security considerations are addressed (the strip only ever removes a declared token at the head; redaction boundaries untouched).
- [x] I have linked all related issues.
