### PR TITLE
chore(release): bump version to 0.54.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.20"
+version = "0.54.21"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed by session **pid 5489** ("Debugging missed wakes in background sessions").

Window — PRs merged since **v0.54.20** (derived with plain `git log v0.54.20..origin/main`, not `--merges`):

- [x] #1004 — `fix(evaluation): record why an adapter observation failed` — merge `15c090206` — Release: patch
- [x] #1001 — `fix(evaluation): record every refused reply by class, and name the accepted shape` — merge `2692a429f` — Release: patch
- [x] #983 — `fix(wakes): never leave an armed wake without a live supervisor, and bound wake lateness` — merge `1a83a9750` — Release: patch

Bump class: **patch** (all three are bug fixes; none clears the step-function bar for a minor). Target: **v0.54.21**.

Ownership check before claiming: asked #1004/#1001's author (pid 86806) and the other lopdev sessions; pid 86806 and pid 82200 both confirmed they do not own the window, and pid 86806 sent its refs for the notes. No open `chore(release)` PR existed when the lock was taken.
