### PR TITLE
chore(release): bump version to 0.54.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.21"
+version = "0.54.22"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed by session **pid 94007** (manager for the failover-notice fix, "Tool switch messages shown as user messages").

Window — PRs merged since **v0.54.21** (derived with plain `git log v0.54.21..origin/main`, not `--merges`):

- [x] #993 — `fix(session): a transient failover notice no longer becomes a user message` — merge `eb8833a8c` — Release: patch

Bump class: **patch** — one bug fix; nothing in the window clears the step-function bar for a minor. Target: **v0.54.22**.

Ownership check before claiming: no open `chore(release)` PR existed, and `git log v0.54.21..origin/main` held only #993. Announced to the live lopdev sessions; pid 60658 (`feat/descriptive-notifications`, #1005) and pid 4316 (#1006) replied that they hold no lock and are still in remediation — both asked me not to hold for them, so their PRs ride the next window if they land after this tag.

Scope: `pyproject.toml` only, one line — `0.54.21` → `0.54.22`.
