### PR TITLE
chore(release): bump version to 0.54.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.22"
+version = "0.54.23"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window bump, post-v0.54.22. Owner session pid: 4316.

One commit, one file, one line: `pyproject.toml` 0.54.22 → 0.54.23.

Window (everything merged since v0.54.22 `c6b0922e1`, re-derived from commits):
- #1006 — `fix(tui)`: one row of air below every tool-call summary at the default density (ink pitch 2 → 3) — merge `9c11dc645`
- #1007 — `fix(providers)`: a retry gate stops refusing a retry that was always available — merge `853a89d5d`

**PATCH** bump: both entries are fixes; nothing clears the minor step-function bar. A late merge inside the window rides the next release (latecomers never hold a window).