### PR TITLE
chore(release): bump version to 0.54.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.23"
+version = "0.54.24"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Combined-release bump for the post-v0.54.23 window (one owner, one bump — see the lopdev combined-release protocol).

**Window contents** (PRs merged since the v0.54.23 tag):

| PR | merge | impact |
|---|---|---|
| #995 | `802cee0d2` | OpenRouter provider cache affinity: keep a conversation on the host that served it (`provider.order`), plus a cache-quality guard that retires a host after two warm no-reuse turns (`provider.ignore`, ≤3), behind `providers.openrouter.provider_affinity` (default on). Fixes ~9.8% of read tokens being re-billed uncached on DeepSeek sessions through OpenRouter. |

Bump class: **patch** — a routing optimisation behind a default-on settings key; no new API, no UI beyond one settings row, no step-function capability.

Scope: pyproject.toml only, one line (`0.54.23` → `0.54.24`). No other change.