### PR TITLE
chore(release): bump version to 0.54.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.24"
+version = "0.54.25"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed (post-v0.54.24). Owner session pid: 16979 (conversation `Session connection failure and performance`, session id 19dd7899) — adopted 2026-09-12T14:04:52Z under the dead-owner rule; previous owner pid 4316 was `2026-09-12T13:41:00Z` stale with no comment and is absent from `lop sessions`.

Window (re-derived from commits; re-derived again immediately before tagging):
- [x] #973 — `Release: patch — a transient runtime-owner loss no longer latches the sidebar or /resume; the sidebar connect stops burning forced full-screen relayouts, /resume gets a bounded redial, and the resume picker's live-state scan drops from 12.5 Hz to ~1 Hz.` — merged at `2b96c3ef9e5cd131993987b9d43954dd6e85244c`
- [ ] #1013 — `revert(tui)`: removes the tool-row padding #1006 landed against the wrong repository — still open, mid-gate

Proposed bump: **PATCH → 0.54.25** (one TUI resilience fix and a single revert; nothing clears the minor step-function bar).

This branch is the lock: no second `chore(release)` PR should be opened while it is open. Requested by the operator to be cut immediately.
