### PR TITLE
fix(secrets): name the broker in process listings, and net the brokers no per-test sweep can see

### DIFF
--- a/local_operator/procname.py
+++ b/local_operator/procname.py
@@ -170,6 +170,23 @@ LABEL_BROWSER = "{brand} [browser bridge] port={port}"
 LABEL_WAKES = "{brand} [wakes]"
 LABEL_TUNNEL = "{brand} [tunnel]"
 LABEL_SERVE = "{brand} [serve] port={port}"
+#: The secret broker, and the ONE field is a digest rather than the config dir
+#: itself. Which store a broker holds is exactly what an operator reading `ps`
+#: needs in order to tell a test's broker from their live one, but the config
+#: dir is an absolute path that can name a user, a project, or a customer — and
+#: argv is world-readable per the rule above. The digest is the SAME one
+#: `protocol._runtime_fallback_dir` already derives from the secrets directory,
+#: so a row here can be matched against the socket directory on disk without
+#: disclosing the path it came from.
+#:
+#: This label exists because of issue #958: every pre-#954 CI teardown listed a
+#: bare, unexplained `Local Operator` child. `_spawn_broker` launches
+#: `[sys.executable, "-m", ...]`, and once a parent has been through
+#: `reexec_branded`, `sys.executable` IS the branded hardlink — so the broker
+#: inherited the product name with nothing to say it was a broker, and on Linux
+#: `comm` truncates at 15 bytes, which made every branded child identical in
+#: that listing. A daemon that can outlive its starter has to say what it is.
+LABEL_BROKER = "{brand} [secret broker] store={digest}"
 
 
 def safe_field(value: object, limit: int = 24) -> str:

--- a/local_operator/procname.py
+++ b/local_operator/procname.py
@@ -179,6 +179,13 @@ LABEL_SERVE = "{brand} [serve] port={port}"
 #: so a row here can be matched against the socket directory on disk without
 #: disclosing the path it came from.
 #:
+#: ORDER MATTERS HERE, because the readers this exists for truncate. `ps` with
+#: stdout not a tty falls back to an 80-column screen width on Linux and cuts the
+#: row (measured on CI: `... -m local_operator.secrets.brok` at exactly 80). The
+#: identity is therefore at the FRONT, so a cut row still says "secret broker"
+#: and still names its store; only the module, which a reader can infer, is lost.
+#: A reader that needs the whole line uses `ps -ww` or `/proc/<pid>/cmdline`.
+#:
 #: This label exists because of issue #958: every pre-#954 CI teardown listed a
 #: bare, unexplained `Local Operator` child. `_spawn_broker` launches
 #: `[sys.executable, "-m", ...]`, and once a parent has been through

--- a/local_operator/secrets/brokerd.py
+++ b/local_operator/secrets/brokerd.py
@@ -14,6 +14,7 @@ import signal
 import sys
 from types import FrameType
 
+from local_operator import procname
 from local_operator.secrets.broker import IDLE_SHUTDOWN_S, run_broker
 
 
@@ -38,6 +39,17 @@ def main(argv: list[str] | None = None) -> int:
         raise KeyboardInterrupt
 
     signal.signal(signal.SIGTERM, _terminate)
+
+    # Linux only, and it does NOT replace the argv label the parent set in
+    # `client._spawn_broker` — the two are independent name axes (see
+    # `procname`). `prctl(PR_SET_NAME)` does not survive an exec, so a child
+    # that wants a `comm` must set its own; without this the broker's `comm` is
+    # whatever image it was exec'd through, which for a branded launch is the
+    # bare product name. `comm` truncates at 15 bytes so only BRAND fits there,
+    # which is exactly why the argv label carries the detail and this call
+    # carries only the family name.
+    procname.brand_this_process()
+
     return run_broker(idle_shutdown_s=args.idle_shutdown)
 
 

--- a/local_operator/secrets/client.py
+++ b/local_operator/secrets/client.py
@@ -277,6 +277,17 @@ def _spawn_broker(base: Path | None) -> None:
     broker being detached is correct (it must outlive its starter), while a
     CLIENT being detached is exactly the attacker shape spike 9 denies. They
     are different processes with different requirements.
+
+    **The child names itself in ``ps``, and that is a bug fix rather than
+    decoration (issue #958).** ``sys.executable`` is the branded hardlink in any
+    process that has been through :func:`procname.reexec_branded` — every real
+    ``lop`` launch — so this spawn used to produce a process whose whole identity
+    in a process listing was the product name, with nothing to say it was a
+    broker or which store it held. That is precisely the unexplained ``Local
+    Operator`` child every pre-#954 CI teardown listed, and on Linux ``comm``
+    truncates at 15 bytes, so no two branded children could be told apart there
+    either. Relabelling ``argv[0]`` fixes it on the one axis that is NOT
+    truncated (``ps -o args``), which is the axis those teardown dumps read.
     """
     environment = os.environ.copy()
     if base is not None:
@@ -285,7 +296,13 @@ def _spawn_broker(base: Path | None) -> None:
         environment[CONFIG_DIR_ENV] = str(base)
     with open(os.devnull, "rb") as devnull_in, open(os.devnull, "wb") as devnull_out:
         subprocess.Popen(
-            [sys.executable, "-m", "local_operator.secrets.brokerd"],
+            # ``argv[0]`` is the label and ``executable=`` is the real image:
+            # the two independent name axes documented in
+            # :mod:`local_operator.procname`. Passing ``executable=`` explicitly
+            # is what lets argv[0] stop being a path at all, which is also why
+            # this works on Linux, where there is no branded image to plant.
+            [_broker_argv0(base), "-m", "local_operator.secrets.brokerd"],
+            executable=sys.executable,
             stdin=devnull_in,
             stdout=devnull_out,
             stderr=devnull_out,
@@ -293,6 +310,33 @@ def _spawn_broker(base: Path | None) -> None:
             env=environment,
             close_fds=True,
         )
+
+
+def _broker_argv0(base: Path | None) -> str:
+    """The ``argv[0]`` label for a broker serving ``base``, or the interpreter path.
+
+    Degrades to ``sys.executable`` — today's exact behaviour — on any failure,
+    because a daemon must never fail to start over its own decoration. That is
+    the same contract every other spawn site in this project holds
+    (``proc.spawn_detached``, ``tools/eval.py``).
+
+    The store digest comes from the SAME derivation
+    :func:`local_operator.secrets.protocol._runtime_fallback_dir` uses for the
+    socket directory name, so the row in ``ps`` and the directory under
+    ``TMPDIR`` carry the same identifier and an operator can match one to the
+    other. It is a digest and not the path itself because argv is world-readable
+    and a config dir can name a user or a project.
+    """
+    try:
+        import hashlib
+
+        from local_operator import procname
+        from local_operator.secrets.keys import secrets_dir
+
+        digest = hashlib.sha256(str(secrets_dir(base)).encode("utf-8")).hexdigest()[:12]
+        return procname.branded_argv0(procname.LABEL_BROKER, digest=digest)
+    except Exception:  # noqa: BLE001 — a label is decoration, never a failure
+        return sys.executable
 
 
 def fetch_master_key(base: Path | None = None) -> bytes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -568,12 +568,16 @@ def _sweep_session_leftovers(basetemp: Path | None) -> int:
 
 
 def _broker_is_still_up(candidate: Path) -> bool:
-    """Did the net's stop attempt leave ``candidate``'s broker answering?
+    """Is ``candidate``'s broker still answering, after a stop was attempted?
+
+    Used by the session-end net's count and by `_stop_brokers_in`'s post-SIGTERM
+    wait loop, so both ask the question the same way.
 
     Conservative in the only direction that is honest: any failure to get an
     answer counts as STILL UP, so the net never claims a reclaim it could not
-    observe. `is_running` deliberately re-raises `BrokerIncompatible`, and a
-    skewed daemon that survived the stop is not a reclaim either.
+    observe and the wait loop never lets a refusal escape cleanup. `is_running`
+    deliberately re-raises `BrokerIncompatible`, and a skewed daemon that survived
+    the stop is not a reclaim either.
     """
     from local_operator.secrets import client
 
@@ -751,8 +755,21 @@ def _stop_brokers_in(candidates: list[Path]) -> None:
             continue
         with suppress(OSError):
             os.kill(pid, signal.SIGTERM)
+        # Wait for the daemon to stop ANSWERING — but ask it through
+        # `_broker_is_still_up` rather than `client.is_running` directly, because
+        # the bare call RAISES for the one daemon that is still there to refuse:
+        # `is_running` re-raises `BrokerIncompatible` on purpose (a version-skewed
+        # broker is live, and answering False would launder it into
+        # "unreachable"), and on the first poll after the signal such a daemon is
+        # very likely still listening. That refusal then escaped cleanup — the
+        # call-phase reap, which runs inside `finally` for every test — so a
+        # version-skewed broker could fail an unrelated passing test. The helper
+        # answers the same question with any failure to answer read as STILL UP,
+        # which keeps this loop bounded by its deadline and keeps the broker's
+        # fate honest: nothing here assumes the daemon died, and the session-end
+        # net re-asks the same question before it counts a candidate as reclaimed.
         deadline = time.monotonic() + 5
-        while time.monotonic() < deadline and client.is_running(candidate):
+        while time.monotonic() < deadline and _broker_is_still_up(candidate):
             time.sleep(0.05)
 
     # The fallback runtime dir is derived from the SECRETS dir and is created

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -557,14 +557,18 @@ def _sweep_session_leftovers(basetemp: Path | None) -> int:
             continue
     if not live:
         return 0
-    _stop_brokers_in(live)
-    # What was actually STOPPED, never what was merely considered.
-    # `_stop_brokers_in` is free to decline a candidate it is then handed — most
-    # notably its third refusal, `pid == os.getpid()`, the in-process broker shape
-    # that once took the xdist worker down with it — and `len(live)` would then
-    # report a broker as reclaimed while it is still running. Re-asking the same
-    # cheap question after the stop is what makes the number match the message.
-    return sum(1 for candidate in live if not _broker_is_still_up(candidate))
+    # Count what the stop path CONFIRMED gone, never what was merely considered.
+    # The confirmation has to come from inside `_stop_brokers_in`: it is the only
+    # place that knows which candidates it signalled and whether the daemon stopped
+    # answering inside the bound, and by the time it returns it has removed every
+    # candidate's fallback runtime dir. On the layout a real candidate takes that
+    # directory IS the socket's parent — a pytest ``tmp_path``'s in-directory socket
+    # path is ~145 bytes against the 103-byte ``sun_path`` limit, so the fallback is
+    # the common case — and a re-probe here would then answer "not running" for the
+    # "no socket file" reason and report a broker that is still alive, including one
+    # the sweep DECLINED to signal (`pid <= 0`, `pid == os.getpid()`). Neither shape
+    # is in the returned set.
+    return len(_stop_brokers_in(live))
 
 
 def _broker_is_still_up(candidate: Path) -> bool:
@@ -686,8 +690,16 @@ def stop_secret_brokers_started_by_this_test(request, isolate_environment) -> It
     _stop_brokers_in(candidates)
 
 
-def _stop_brokers_in(candidates: list[Path]) -> None:
+def _stop_brokers_in(candidates: list[Path]) -> set[Path]:
     """SIGTERM the broker in each candidate config dir, then drop its runtime dir.
+
+    Returns the candidates whose broker was SIGNALLED and CONFIRMED gone — the
+    daemon stopped answering inside the wait bound. Deliberately decided here rather
+    than re-probed by the caller: the runtime-dir removal at the end deletes the
+    fallback socket of every candidate it was handed, INCLUDING the ones it refused
+    to signal, so after this returns a probe cannot tell a reaped broker from a
+    declined one on the layout real candidates take. A declined candidate and an
+    unconfirmable stop are both absent from the set, and neither is assumed dead.
 
     A function rather than an in-fixture loop so the behaviour is reachable from
     a test: `test_broker_sweep.py` drives it against a REAL broker, and against a
@@ -706,7 +718,7 @@ def _stop_brokers_in(candidates: list[Path]) -> None:
     rather than one per entry point.
     """
     if not _broker_daemon_is_available():
-        return
+        return set()  # no daemon to stop, so nothing was confirmed gone
 
     # Imported here rather than at module scope: this conftest is loaded for
     # every test session, and the secrets client drags in fcntl/socket
@@ -714,6 +726,11 @@ def _stop_brokers_in(candidates: list[Path]) -> None:
     from local_operator.secrets import client
     from local_operator.secrets.keys import secrets_dir
     from local_operator.secrets.protocol import _runtime_fallback_dir, socket_path
+
+    # Candidates whose broker stopped answering inside the wait bound, i.e. the
+    # only ones a caller may report as reclaimed. Populated BEFORE the runtime dirs
+    # are removed, because that removal destroys the evidence.
+    stopped: set[Path] = set()
 
     for candidate in candidates:
         # Only ask candidates that actually have a socket. A broker is a
@@ -766,10 +783,20 @@ def _stop_brokers_in(candidates: list[Path]) -> None:
         # version-skewed broker could fail an unrelated passing test. The helper
         # answers the same question with any failure to answer read as STILL UP,
         # which keeps this loop bounded by its deadline and keeps the broker's
-        # fate honest: nothing here assumes the daemon died, and the session-end
-        # net re-asks the same question before it counts a candidate as reclaimed.
+        # fate honest: nothing here assumes the daemon died, and the set returned
+        # below is what the session-end net reports.
         deadline = time.monotonic() + 5
-        while time.monotonic() < deadline and _broker_is_still_up(candidate):
+        while True:
+            if not _broker_is_still_up(candidate):
+                # The probe that ends the wait IS the evidence, and it is taken
+                # before the runtime-dir removal below takes the socket with it.
+                stopped.add(candidate)
+                break
+            if time.monotonic() >= deadline:
+                # Give up unconfirmed: the daemon never stopped answering, so
+                # nothing is claimed about it. Not an error — cleanup never fails
+                # a test, and the net reports only what it can observe.
+                break
             time.sleep(0.05)
 
     # The fallback runtime dir is derived from the SECRETS dir and is created
@@ -777,12 +804,15 @@ def _stop_brokers_in(candidates: list[Path]) -> None:
     # tmp_path is routinely ~145 bytes against a 103-byte limit, so here that is
     # the common case rather than the exotic one. It is created even for a
     # config dir whose store was never initialised, hence the unconditional
-    # removal. AFTER the broker is stopped, since the socket lives inside it.
+    # removal. AFTER the broker is stopped, since the socket lives inside it —
+    # which is also why the confirmed-stopped set above is built first.
     for candidate in candidates:
         # `Exception`, not `OSError`, for the reason above: a test may have
         # replaced the path machinery this line depends on.
         with suppress(Exception):
             shutil.rmtree(_runtime_fallback_dir(secrets_dir(candidate)), ignore_errors=True)
+
+    return stopped
 
 
 def _secret_config_dirs(request: pytest.FixtureRequest, home: Path) -> list[Path]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -515,9 +515,10 @@ def _sweep_session_leftovers(basetemp: Path | None) -> int:
     agent's worktree. Without a basetemp there is nothing safe to scope to and
     the net does nothing at all.
 
-    Returns the number of config dirs that still had a LIVE broker, which is the
+    Returns the number of candidates this net actually STOPPED, which is the
     count worth reporting: candidates that were already clean are the expected
-    case and say nothing.
+    case and say nothing, and a candidate the sweep declined to stop was never
+    reclaimed.
     """
     if not _broker_daemon_is_available():
         return 0
@@ -526,20 +527,60 @@ def _sweep_session_leftovers(basetemp: Path | None) -> int:
         return 0
     try:
         from local_operator.secrets import client
+        from local_operator.secrets.protocol import socket_path
     except Exception:  # noqa: BLE001 — a net that cannot load is simply absent
         return 0
 
-    # `is_running` is the cheap question and the same one `_stop_brokers_in`
-    # asks; counting first is what makes the reported number "reclaimed" rather
-    # than merely "considered".
-    live = []
+    # The `socket_path(...).exists()` guard first, exactly as `_stop_brokers_in`
+    # writes it twelve lines of code below: this candidate list is almost
+    # entirely socket-less — measured at `pytest_sessionfinish` for
+    # `tests/unit/secrets` alone, 784 recorded roots from 261 tests — and the
+    # guard costs 7.4us against 199.4us for the protocol round trip (27x). Same
+    # question, so the same cheap route to answering it.
+    live: list[Path] = []
     for candidate in candidates:
-        with suppress(Exception):
+        try:
+            if not socket_path(candidate).exists():
+                continue
             if client.is_running(candidate):
                 live.append(candidate)
-    if live:
-        _stop_brokers_in(live)
-    return len(live)
+        except client.BrokerIncompatible:
+            # A version-skewed daemon is LIVE and refusing, which `is_running`
+            # re-raises rather than laundering into "unreachable". Swallowing it
+            # here would hide exactly the leak this net exists to report AND skip
+            # the one stop route that works on a skewed broker: `_stop_brokers_in`
+            # asks `broker_status`, which synthesises a pid from the version
+            # refusal precisely so a daemon that answers nothing else can still be
+            # stopped. So it is a candidate like any other.
+            live.append(candidate)
+        except Exception:  # noqa: BLE001 — cleanup never fails a test
+            continue
+    if not live:
+        return 0
+    _stop_brokers_in(live)
+    # What was actually STOPPED, never what was merely considered.
+    # `_stop_brokers_in` is free to decline a candidate it is then handed — most
+    # notably its third refusal, `pid == os.getpid()`, the in-process broker shape
+    # that once took the xdist worker down with it — and `len(live)` would then
+    # report a broker as reclaimed while it is still running. Re-asking the same
+    # cheap question after the stop is what makes the number match the message.
+    return sum(1 for candidate in live if not _broker_is_still_up(candidate))
+
+
+def _broker_is_still_up(candidate: Path) -> bool:
+    """Did the net's stop attempt leave ``candidate``'s broker answering?
+
+    Conservative in the only direction that is honest: any failure to get an
+    answer counts as STILL UP, so the net never claims a reclaim it could not
+    observe. `is_running` deliberately re-raises `BrokerIncompatible`, and a
+    skewed daemon that survived the stop is not a reclaim either.
+    """
+    from local_operator.secrets import client
+
+    try:
+        return client.is_running(candidate)
+    except Exception:  # noqa: BLE001 — an unanswerable question is not a reclaim
+        return True
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ import logging
 import os
 import shutil
 import signal
+import sys
 import time
 from collections.abc import Iterator
 from contextlib import suppress
@@ -407,8 +408,158 @@ def pytest_runtest_call(item: pytest.Item) -> Iterator[None]:
     try:
         yield
     finally:
-        item.stash[_SWEEP_ROOT_KEY] = _temp_roots(item)
+        roots = _temp_roots(item)
+        item.stash[_SWEEP_ROOT_KEY] = roots
+        _record_for_session_sweep(roots)
         _reap_brokers_of_this_test(item)
+
+
+#: Config dirs this worker's tests could have started a broker under, kept for
+#: the session-end net below. A module-level set rather than a stash entry
+#: because the net runs after every item's stash is out of reach, and a plain
+#: set of paths is ~100 bytes per entry for a suite that creates a few thousand.
+_SESSION_SWEEP_ROOTS: set[Path] = set()
+
+#: This session's ``basetemp``, captured by the fixture below.
+#:
+#: Captured through the PUBLIC ``tmp_path_factory`` fixture rather than read off
+#: ``config._tmp_path_factory`` at session end: that attribute is private (and
+#: pyright rejects it), and building a second ``TempPathFactory`` from the config
+#: would allocate a DIFFERENT basetemp than the one the tests actually used,
+#: which would make the net walk an empty directory and silently reclaim nothing.
+_SESSION_BASETEMP: Path | None = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _capture_session_basetemp(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Record this session's basetemp for the session-end broker net.
+
+    Session-scoped and autouse so it is resolved once per worker, at the first
+    test, and costs nothing thereafter; ``getbasetemp()`` is what the factory has
+    already computed for ``tmp_path``, so this creates no directory of its own.
+    """
+    global _SESSION_BASETEMP
+    with suppress(Exception):
+        _SESSION_BASETEMP = tmp_path_factory.getbasetemp().resolve()
+
+
+def _record_for_session_sweep(roots: tuple[Path, ...]) -> None:
+    """Remember this test's temp roots for the session-end net, scoped to basetemp.
+
+    THE BASETEMP FILTER IS THE SAFETY PROPERTY, and it is the same one the
+    per-test sweep relies on: a path is recorded only when it lies under this
+    run's own ``basetemp``, so the net can never reach the operator's real
+    ``~/.local-operator`` or another agent's worktree — exactly the processes
+    `stop_secret_brokers_started_by_this_test` documents it must not touch. The
+    isolated HOME is deliberately NOT recorded: `isolate_environment` may point
+    it outside basetemp, and the per-test reap already covers it while it exists.
+    """
+    base = _SESSION_BASETEMP
+    if base is None:
+        return
+    for root in roots:
+        with suppress(ValueError, OSError):
+            if root.resolve().is_relative_to(base):
+                _SESSION_SWEEP_ROOTS.add(root)
+
+
+def _session_sweep_candidates(basetemp: Path | None) -> list[Path]:
+    """Config dirs under ``basetemp`` that a session-end sweep should ask about.
+
+    Two sources, because neither alone is complete:
+
+    * the roots recorded per test, which is the only way to name a directory
+      pytest has since RECLAIMED — a fallback-layout socket outlives its config
+      dir, so the name is still enough to reach the daemon (see `_temp_roots`);
+    * a walk of ``basetemp`` for ``secrets/`` directories, which is the only way
+      to see a config dir that never belonged to any test's ``tmp_path`` at all.
+      A module- or session-scoped fixture takes its directory from
+      ``tmp_path_factory.mktemp``, so it appears in NO test's ``tmp_path`` and no
+      per-test record can contain it. Measured: a broker started in a
+      module-scoped fixture's teardown survived a full inner run.
+
+    ``secrets/`` is the marker because it is what the store actually creates
+    (`keys.secrets_dir`), so the walk names config dirs rather than guessing at
+    directory shapes — the same argument `_secret_config_dirs` records for not
+    hardcoding a list of known layouts. The walk runs ONCE per session, not per
+    test, which is what keeps it affordable.
+    """
+    candidates = set(_SESSION_SWEEP_ROOTS)
+    _SESSION_SWEEP_ROOTS.clear()
+    if basetemp is not None:
+        with suppress(Exception):
+            from local_operator.secrets.keys import SECRETS_DIRNAME
+
+            for marker in basetemp.rglob(SECRETS_DIRNAME):
+                with suppress(OSError):
+                    if marker.is_dir():
+                        candidates.add(marker.parent)
+    return sorted(candidates)
+
+
+def _sweep_session_leftovers(basetemp: Path | None) -> int:
+    """Stop every leftover broker under ``basetemp``; return how many were live.
+
+    **Belt and braces, not the primary mechanism.** The call-phase reap is what
+    stops brokers in practice, and the per-test teardown sweep covers a
+    function-scoped finaliser that restarts one. This exists for what neither can
+    structurally see: a broker whose config dir was never a test's ``tmp_path``
+    (see `_session_sweep_candidates`). Issue #958 asked for a net that also
+    *reports what it reclaimed*, so a non-zero count here is a signal that some
+    path leaks past the per-test reap and should be traced, rather than a number
+    quietly absorbed.
+
+    THE BASETEMP SCOPE IS THE SAFETY PROPERTY, and it is the same one the
+    per-test sweep rests on: every candidate lies under this run's own basetemp,
+    so this can never reach the operator's real ``~/.local-operator`` or another
+    agent's worktree. Without a basetemp there is nothing safe to scope to and
+    the net does nothing at all.
+
+    Returns the number of config dirs that still had a LIVE broker, which is the
+    count worth reporting: candidates that were already clean are the expected
+    case and say nothing.
+    """
+    if not _broker_daemon_is_available():
+        return 0
+    candidates = _session_sweep_candidates(basetemp)
+    if not candidates:
+        return 0
+    try:
+        from local_operator.secrets import client
+    except Exception:  # noqa: BLE001 — a net that cannot load is simply absent
+        return 0
+
+    # `is_running` is the cheap question and the same one `_stop_brokers_in`
+    # asks; counting first is what makes the reported number "reclaimed" rather
+    # than merely "considered".
+    live = []
+    for candidate in candidates:
+        with suppress(Exception):
+            if client.is_running(candidate):
+                live.append(candidate)
+    if live:
+        _stop_brokers_in(live)
+    return len(live)
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    """Run the session-end broker net and say what it reclaimed.
+
+    Written to ``sys.stderr`` rather than through the terminal reporter: under
+    ``-n auto`` this hook runs in each xdist WORKER, which has no reporter
+    plugin, and the worker's stderr is what ends up in the CI log where an
+    orphaned-process report is actually read. Silent at zero — the expected
+    outcome must not add a line to every run.
+    """
+    del session
+    with suppress(Exception):
+        reclaimed = _sweep_session_leftovers(_SESSION_BASETEMP)
+        if reclaimed:
+            print(
+                f"[broker-sweep] session-end net reclaimed {reclaimed} live broker(s) "
+                "the per-test reap did not stop; see tests/conftest.py",
+                file=sys.stderr,
+            )
 
 
 def _broker_daemon_is_available() -> bool:

--- a/tests/unit/secrets/test_broker_sweep.py
+++ b/tests/unit/secrets/test_broker_sweep.py
@@ -797,3 +797,98 @@ def test_the_net_hands_a_version_skewed_broker_to_the_sweep_and_counts_it(
     finally:
         _cleanup_planted_socket(candidate)
     assert stopped == [candidate], "the skewed candidate never reached the sweep"
+
+
+def test_the_sweep_survives_a_skewed_probe_and_never_assumes_the_broker_died(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refusal in the post-SIGTERM wait loop cannot escape cleanup.
+
+    `_stop_brokers_in` waits for the daemon to stop ANSWERING, and the bare
+    `client.is_running` it used to call there RAISES for the one daemon that is
+    still there to refuse: `is_running` re-raises `BrokerIncompatible` on purpose
+    (a version-skewed broker is live), and such a daemon is very likely still
+    listening on the first poll after the signal. Because the call-phase reap runs
+    inside `finally` for every test, that refusal failed an unrelated passing test
+    — the same class of defect the net's `BrokerIncompatible` handling closes, one
+    call site over. The loop now asks `_broker_is_still_up`, which reads any
+    failure to answer as STILL UP, so the wait stays bounded and the broker's fate
+    is never assumed: the net's count refuses to call a broker it could not
+    confirm stopped "reclaimed".
+
+    A real process that IGNORES `SIGTERM` (and records that it received it) stands
+    in for the daemon the sweep cannot confirm dead, so both halves are pinned: the
+    sweep must not raise, and the count must be 0 rather than a broker assumed
+    dead. Only the probe and `broker_status` are patched. The test costs the wait
+    loop's own bound (~5s), which is the behaviour under test.
+    """
+    candidate = tmp_path / "config"
+    candidate.mkdir()
+    _plant_socket(candidate)
+    marker = tmp_path / "sigterm-received"
+    ready = tmp_path / "sigterm-handled"
+    # The handler is what makes the signal observable rather than merely deliverable,
+    # and it is also why this daemon survives: a bare ignore would prove delivery no
+    # better but leave the process alive for the same reason. The `ready` file is not
+    # decoration — without it the TEST can signal a child that has not installed the
+    # handler yet, and a default-action SIGTERM would kill it and turn the count into
+    # a spurious 1.
+    daemon = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import os, signal, time\n"
+            "ready = os.environ['LO958_READY']\n"
+            "marker = os.environ['LO958_SIGTERM_MARKER']\n"
+            "signal.signal(signal.SIGTERM, lambda *_: open(marker, 'w').write('SIGTERM'))\n"
+            "open(ready, 'w').write('ready')\n"
+            "time.sleep(60)\n",
+        ],
+        env={
+            **os.environ,
+            "LO958_SIGTERM_MARKER": str(marker),
+            "LO958_READY": str(ready),
+        },
+    )
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and not ready.exists():
+        time.sleep(0.05)
+    assert ready.exists(), "the stand-in daemon never installed its SIGTERM handler"
+
+    def skewed(base: Path | None = None) -> bool:
+        if daemon.poll() is None:
+            raise client.BrokerIncompatible(
+                "the broker speaks protocol 0", pid=daemon.pid, protocol=0
+            )
+        return False
+
+    monkeypatch.setattr("tests.conftest._SESSION_SWEEP_ROOTS", {candidate})
+    monkeypatch.setattr(client, "is_running", skewed)
+    monkeypatch.setattr(
+        client, "broker_status", lambda base=None: {"pid": daemon.pid, "incompatible": True}
+    )
+    started = time.monotonic()
+    try:
+        # Before the wait loop was fixed this raised BrokerIncompatible straight out
+        # of the reap — an error in whatever test was running, not a suppressed
+        # cleanup.
+        reclaimed = _sweep_session_leftovers(tmp_path)
+        waited = time.monotonic() - started
+        assert reclaimed == 0, (
+            "the net counted a broker it could not confirm stopped — an unanswerable "
+            "probe reads as STILL UP, never as a reclaim"
+        )
+        assert waited >= 1.0, (
+            f"the wait loop returned after {waited:.2f}s: it must wait out its bound "
+            "for a daemon that never answers, not declare it stopped"
+        )
+        assert marker.exists(), (
+            "the sweep never signalled the daemon: the refusal above must come from a "
+            "stop that was actually attempted"
+        )
+        assert daemon.poll() is None, "the stand-in daemon was expected to survive SIGTERM"
+    finally:
+        _cleanup_planted_socket(candidate)
+        with suppress(OSError):
+            daemon.kill()
+        daemon.wait(timeout=5)

--- a/tests/unit/secrets/test_broker_sweep.py
+++ b/tests/unit/secrets/test_broker_sweep.py
@@ -710,7 +710,9 @@ def test_the_net_asks_the_protocol_only_about_a_candidate_that_has_a_socket(
 
     monkeypatch.setattr("tests.conftest._SESSION_SWEEP_ROOTS", {with_socket, without_socket})
     monkeypatch.setattr(client, "is_running", probe)
-    monkeypatch.setattr("tests.conftest._stop_brokers_in", lambda candidates: None)
+    monkeypatch.setattr(
+        "tests.conftest._stop_brokers_in", lambda candidates: set()
+    )  # the contract under test is its return: the candidates it stopped
     try:
         assert _sweep_session_leftovers(tmp_path) == 0
     finally:
@@ -729,25 +731,45 @@ def test_the_net_reports_only_the_brokers_it_actually_stopped(
     """The reported count is what was STOPPED, not what was considered.
 
     `_stop_brokers_in` refuses three shapes and the third — `pid == os.getpid()`,
-    the in-process `broker` fixture's shape — leaves the broker running, so a
-    count taken from the liveness probe alone reports a broker as reclaimed while
-    it is still there. This drives the REAL refusal through the real
-    `_stop_brokers_in` rather than stubbing the stop, so the test fails if either
-    the refusal or the re-check after it goes away.
+    the in-process `broker` fixture's shape — leaves the broker running, so a count
+    derived from the liveness probe alone reports a broker as reclaimed while it is
+    still there. This drives the REAL refusal through the real `_stop_brokers_in`
+    rather than stubbing the stop, so the test fails if either the refusal or the
+    count's source goes away.
+
+    **The candidate is a DEEP config dir on purpose** (`_deep_config_dir` asserts the
+    `$TMPDIR` fallback layout was chosen, which is the layout a real pytest
+    candidate takes — its in-directory socket path is ~145 bytes against the
+    103-byte limit). That matters because the sweep's runtime-dir removal is
+    unconditional and on this layout it deletes the socket of a broker it DECLINED
+    to signal, so a count taken from a probe afterwards is blind: no socket, read as
+    "reaped". The probe below therefore models what `is_running` actually does on
+    that layout — it answers False once the socket file is gone — instead of
+    returning a constant, because a constant answers the same way whether or not the
+    socket was destroyed and so cannot observe this defect at all.
     """
-    candidate = tmp_path / "config"
-    candidate.mkdir()
+    candidate = _deep_config_dir(tmp_path)
     _plant_socket(candidate)
+    # `is_running` answers by connecting to `socket_path(candidate)`, and on this
+    # layout that path stops existing when the runtime dir is removed — including for
+    # a candidate the sweep only declined.
+    monkeypatch.setattr(client, "is_running", lambda base=None: socket_path(candidate).exists())
     monkeypatch.setattr("tests.conftest._SESSION_SWEEP_ROOTS", {candidate})
-    monkeypatch.setattr(client, "is_running", lambda base=None: True)
     # The in-process broker shape: `broker_status` reports THIS process's pid, so
-    # the sweep refuses to signal it and the daemon is still answering afterwards.
+    # the sweep refuses to signal it and the daemon is still alive afterwards.
     monkeypatch.setattr(client, "broker_status", lambda base=None: {"pid": os.getpid()})
     try:
         assert client.is_running(candidate), "the planted socket was not seen as live"
         assert _sweep_session_leftovers(tmp_path) == 0, (
             "the net reported a broker as reclaimed that `_stop_brokers_in` refused "
             "to stop; the count must be what was stopped, not what was considered"
+        )
+        # The trap was genuinely live, so the assertion above is not vacuous: the
+        # sweep removed the socket's parent, which is exactly what a probe taken
+        # afterwards cannot see past.
+        assert not _runtime_fallback_dir(secrets_dir(candidate)).exists(), (
+            "the sweep did not remove the fallback runtime dir, so this test never "
+            "exercised the removal that blinds a later probe"
         )
     finally:
         _cleanup_planted_socket(candidate)
@@ -781,9 +803,10 @@ def test_the_net_hands_a_version_skewed_broker_to_the_sweep_and_counts_it(
             raise client.BrokerIncompatible("the broker speaks protocol 0", pid=4242, protocol=0)
         return False
 
-    def stop(candidates: list[Path]) -> None:
+    def stop(candidates: list[Path]) -> set[Path]:
         stopped.extend(candidates)
         state["up"] = False  # a stop that worked takes the daemon away
+        return set(candidates)  # ...and that is what the net counts
 
     monkeypatch.setattr("tests.conftest._SESSION_SWEEP_ROOTS", {candidate})
     monkeypatch.setattr(client, "is_running", probe)
@@ -821,6 +844,15 @@ def test_the_sweep_survives_a_skewed_probe_and_never_assumes_the_broker_died(
     sweep must not raise, and the count must be 0 rather than a broker assumed
     dead. Only the probe and `broker_status` are patched. The test costs the wait
     loop's own bound (~5s), which is the behaviour under test.
+
+    **Baseline note, so the obvious A/B is not misread (R2-2).** Against `512d5c0f8`
+    — the head this fix is on — it fails with `BrokerIncompatible` escaping the
+    reap, which IS the defect. Against `dc725c88a`, the head the other tests are
+    A/B'd against, it fails on a DIFFERENT assertion, `the wait loop returned after
+    0.00s`: at that tree R1-3's `suppress(Exception)` drops the skewed candidate
+    before it ever reaches the stop loop, so nothing is signalled and the escape
+    cannot happen. Both are failures for a stated reason, but only `512d5c0f8`
+    isolates this one — do not read the `dc725c88a` result as an unrelated error.
     """
     candidate = tmp_path / "config"
     candidate.mkdir()

--- a/tests/unit/secrets/test_broker_sweep.py
+++ b/tests/unit/secrets/test_broker_sweep.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import os
 import shutil
 import signal
+import subprocess
+import sys
 import tempfile
 import time
 from contextlib import suppress
@@ -374,3 +376,243 @@ def test_the_candidates_keep_paths_whose_directories_are_already_gone(
         "broker would never be reaped"
     )
     assert not gone.exists(), "the test's premise: the directories are gone by teardown"
+
+
+def _run_nested_pytest(
+    tmp_path: Path, body: str, *, extra_argv: tuple[str, ...] = ()
+) -> subprocess.CompletedProcess[str]:
+    """Run one test file under a REAL nested pytest that loads this repo's conftest.
+
+    The end-to-end tests below cannot be expressed in-process: what they pin is
+    pytest's own FINALISATION ORDER — ``tmp_path`` is torn down before an autouse
+    fixture declared in ``tests/conftest.py``, because that fixture is set up
+    first and finalisers run in reverse — and a test cannot observe its own
+    teardown. A nested run can: the inner test records what it started, the outer
+    one reads the record after the inner session has finished tearing down.
+
+    ``pytest_plugins = ["tests.conftest"]`` rather than a copy of the fixture:
+    the subject is the SHIPPED conftest, so anything that reproduces it here
+    would pass while the real one leaked — which is precisely the failure issue
+    #958 describes. ``-n0`` keeps the inner session single-process so the pid the
+    inner test writes is the broker's parent-visible one, and ``-p
+    no:cacheprovider`` keeps the inner run from writing a cache into the repo.
+
+    **``tmp_path_retention_policy = "failed"`` is load-bearing, not inherited.**
+    A nested run given its own ``-c`` ini does NOT pick up the root
+    ``pyproject.toml``, and that setting is the entire precondition for the bug:
+    under it, `tmp_path`'s own finaliser REMOVES the directory when the test
+    passed, before an autouse fixture declared in ``tests/conftest.py`` is
+    finalised — so a teardown-time walk finds nothing. Verified both ways here:
+    with the default policy the directory still exists at teardown and a
+    teardown-only sweep would have worked, which would have made this test pass
+    against the very code it is meant to catch.
+    """
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / "conftest.py").write_text('pytest_plugins = ["tests.conftest"]\n')
+    (inner / "test_inner.py").write_text(body)
+    # Mirrors the root `pyproject.toml`'s `[tool.pytest.ini_options]` for the two
+    # settings this reproduction depends on. `-c` below points the inner run at
+    # it, which also stops it inheriting the root `addopts` (`-n auto`).
+    (inner / "pytest.ini").write_text(
+        "[pytest]\ntmp_path_retention_policy = failed\ntmp_path_retention_count = 3\n"
+    )
+    repo_root = Path(__file__).resolve().parents[3]
+    environment = dict(os.environ)
+    # The inner interpreter must import BOTH `local_operator` and `tests.conftest`
+    # from this worktree — see AGENTS.md on a subprocess resolving the root
+    # checkout's copy when it is launched with the wrong path.
+    environment["PYTHONPATH"] = str(repo_root)
+    environment["LO958_RECORD"] = str(tmp_path / "record.txt")
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(inner / "test_inner.py"),
+            "-q",
+            "-n0",
+            "-p",
+            "no:cacheprovider",
+            "-c",
+            str(inner / "pytest.ini"),
+            f"--basetemp={tmp_path / 'inner-basetemp'}",
+            *extra_argv,
+        ],
+        cwd=repo_root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+#: The inner test for the end-to-end case: start a real broker under the config
+#: dir the test itself uses, and record its pid for the outer test to check.
+_INNER_STARTS_A_BROKER = '''
+import os
+from pathlib import Path
+
+from local_operator.secrets import client
+
+
+def test_starts_a_broker(tmp_path, monkeypatch):
+    """Stands in for every test that touches the store: it leaves a broker up."""
+    base = tmp_path / "config"
+    base.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(base))
+    assert client.ensure_broker(base), "the broker never came up"
+    pid = (client.broker_status(base) or {}).get("pid")
+    assert isinstance(pid, int), "no pid to hand to the outer test"
+    Path(os.environ["LO958_RECORD"]).write_text(f"{pid}\\n{base}")
+'''
+
+
+def test_a_broker_a_test_started_is_dead_once_that_test_has_torn_down(tmp_path: Path) -> None:
+    """The end-to-end regression guard for issue #958, at the level that broke.
+
+    Every other test in this file drives `_stop_brokers_in` or the candidate list
+    DIRECTLY, which is why the leak survived them all: the helper was correct and
+    the sweep still reaped nothing, because the candidate list it was given at
+    teardown had already collapsed to the default-config-dir entry. The bug lived
+    in the ORDERING, so only a test that submits to the real ordering can catch a
+    regression of it.
+
+    Fails against the pre-#985 conftest (candidate discovery at teardown only)
+    and passes with the call-phase reap; that A/B is in the PR for #958.
+
+    Asserted through `_wait_gone` rather than a bare `pid_alive` for the reason
+    that helper documents, and it matters MORE here: the sweep waits for the
+    daemon to stop ANSWERING, which happens as it closes its listener — a step
+    before it exits — so the broker is reliably still a process for a moment
+    after the inner pytest returns (measured on this machine: alive at t+0s,
+    gone by t+0.25s). A bare probe would flap on that scheduling. The bounded
+    wait still separates the two outcomes the test is about, because a LEAKED
+    broker does not exit at all: it idles for 30 minutes.
+    """
+    result = _run_nested_pytest(tmp_path, _INNER_STARTS_A_BROKER)
+    assert result.returncode == 0, f"the inner run failed:\n{result.stdout}\n{result.stderr}"
+
+    record = (tmp_path / "record.txt").read_text().splitlines()
+    pid, base = int(record[0]), Path(record[1])
+    try:
+        assert _wait_gone(pid), (
+            f"broker {pid} for {base} outlived the test that started it — the sweep "
+            "saw no candidate naming this test's config dir (issue #958)"
+        )
+    finally:
+        _kill_pid(pid)
+
+
+#: The inner test for the session-end net: a MODULE-SCOPED fixture starts a
+#: broker in its teardown, under a directory from ``tmp_path_factory``. That
+#: directory is in no test's ``tmp_path``, so no per-test record can name it and
+#: the module finaliser runs after the last test's function-scoped sweep — the
+#: one shape neither per-test mechanism can reach. Verified to leak without the
+#: net: the broker was still alive a second after the inner run returned.
+_INNER_STARTS_A_BROKER_AT_TEARDOWN = """
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator.secrets import client
+
+
+@pytest.fixture(scope="module")
+def module_scoped_store(tmp_path_factory):
+    base = tmp_path_factory.mktemp("modcfg")
+    yield base
+    # Module teardown: after the last test's function-scoped autouse sweep, in a
+    # directory that was never any test's tmp_path. Only the session-end net
+    # sees this one.
+    assert client.ensure_broker(base)
+    pid = (client.broker_status(base) or {}).get("pid")
+    Path(os.environ["LO958_RECORD"]).write_text(f"{pid}\\n{base}")
+
+
+def test_touches_the_store(module_scoped_store, monkeypatch):
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(module_scoped_store))
+"""
+
+
+def test_the_session_end_net_reaps_a_broker_started_after_the_per_test_reap(
+    tmp_path: Path,
+) -> None:
+    """The case neither per-test mechanism can see, and the count the net reports.
+
+    A module-scoped fixture's directory comes from ``tmp_path_factory`` and so
+    belongs to no test's ``tmp_path``: no per-test record can name it, and its
+    finaliser runs after the last function-scoped sweep. That is a structural
+    gap rather than a bug in the per-test reap, and it is what
+    `pytest_sessionfinish` covers.
+
+    Issue #958 asked for the net to REPORT what it reclaimed, so a leak past the
+    per-test reap stays visible instead of being silently absorbed; the reported
+    count is asserted for that reason rather than as decoration.
+    """
+    result = _run_nested_pytest(tmp_path, _INNER_STARTS_A_BROKER_AT_TEARDOWN)
+    assert result.returncode == 0, f"the inner run failed:\n{result.stdout}\n{result.stderr}"
+
+    record = (tmp_path / "record.txt").read_text().splitlines()
+    pid, base = int(record[0]), Path(record[1])
+    try:
+        assert _wait_gone(pid), (
+            f"broker {pid} for {base} survived the session it was started in — the "
+            "session-end net did not reach it"
+        )
+        assert "[broker-sweep] session-end net reclaimed 1 live broker" in result.stderr, (
+            "the net reaped the broker but reported nothing, so a suite leaking "
+            f"past the per-test reap would look clean:\n{result.stderr}"
+        )
+    finally:
+        _kill_pid(pid)
+
+
+def test_a_spawned_broker_names_itself_in_the_process_listing(config_root: Path) -> None:
+    """Issue #958's open question: the branded child in a teardown listing.
+
+    Every pre-#954 CI teardown listed a bare ``Local Operator`` child and nothing
+    said what it was. It was this: `_spawn_broker` launches ``[sys.executable,
+    "-m", ...]``, and in any process that has been through
+    `procname.reexec_branded` — every real ``lop`` launch — ``sys.executable`` IS
+    the branded hardlink, so the broker inherited the product name alone.
+
+    Asserted on ``argv``, deliberately, because that is the axis a teardown dump
+    reads and the only one that survives: Linux ``comm`` truncates at 15 bytes,
+    so ``Local Operator`` and every labelled form are indistinguishable there.
+    The argv is read back from the REAL spawned process rather than from
+    `_broker_argv0`, so a label that never reaches the child fails this.
+
+    The branded-``sys.executable`` precondition is macOS-only (a branded image is
+    only planted there — `procname.branded_link_path` returns None elsewhere), so
+    this test pins the part that holds EVERYWHERE: the label reaches the child's
+    argv whatever the image is. The branded-parent capture is in the PR for #958.
+    """
+    pid = _start(config_root)
+    try:
+        listing = subprocess.run(
+            ["ps", "-o", "args=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout.strip()
+        assert "[secret broker]" in listing, (
+            f"a spawned broker is unidentifiable in `ps`: {listing!r} — this is the "
+            "unexplained branded child of issue #958"
+        )
+        # The digest ties the row to the socket directory on disk, which is what
+        # makes the label actionable rather than merely decorative; and it is a
+        # digest and not the path because argv is world-readable.
+        digest = _runtime_fallback_dir(secrets_dir(config_root)).name.rsplit("-", 1)[-1]
+        assert f"store={digest}" in listing, (
+            f"the label does not name this broker's store: {listing!r}; expected the "
+            f"digest {digest} that also names its runtime directory"
+        )
+        assert "local_operator.secrets.brokerd" in listing, (
+            "the module must stay in argv: it is how the issue's reopen condition "
+            f"('argv is not -m local_operator.secrets.brokerd') is checked: {listing!r}"
+        )
+    finally:
+        _kill(config_root)
+        _kill_pid(pid)

--- a/tests/unit/secrets/test_broker_sweep.py
+++ b/tests/unit/secrets/test_broker_sweep.py
@@ -591,8 +591,14 @@ def test_a_spawned_broker_names_itself_in_the_process_listing(config_root: Path)
     """
     pid = _start(config_root)
     try:
+        # ``-ww`` is REQUIRED, and CI proved it: with stdout not a tty, Linux `ps`
+        # falls back to an 80-column screen width and CUTS the row, which took
+        # the 3.12 shard red on `... -m local_operator.secrets.brok`. The label
+        # was intact; the instrument was not. Anything reading this row in a
+        # teardown dump needs the same flag (or `/proc/<pid>/cmdline`), which is
+        # worth knowing for the issue this test belongs to.
         listing = subprocess.run(
-            ["ps", "-o", "args=", "-p", str(pid)],
+            ["ps", "-ww", "-o", "args=", "-p", str(pid)],
             capture_output=True,
             text=True,
             timeout=30,
@@ -609,6 +615,9 @@ def test_a_spawned_broker_names_itself_in_the_process_listing(config_root: Path)
             f"the label does not name this broker's store: {listing!r}; expected the "
             f"digest {digest} that also names its runtime directory"
         )
+        # Last, because it is the furthest right and so the first casualty of a
+        # truncating reader — the failure above. The module must stay in argv:
+        # it is how the issue's own reopen condition is checked.
         assert "local_operator.secrets.brokerd" in listing, (
             "the module must stay in argv: it is how the issue's reopen condition "
             f"('argv is not -m local_operator.secrets.brokerd') is checked: {listing!r}"

--- a/tests/unit/secrets/test_broker_sweep.py
+++ b/tests/unit/secrets/test_broker_sweep.py
@@ -33,7 +33,12 @@ from local_operator.secrets import client
 from local_operator.secrets.keys import secrets_dir
 from local_operator.secrets.protocol import _runtime_fallback_dir, socket_path
 from local_operator.session.runtime.registry import pid_alive
-from tests.conftest import _SWEEP_ROOT_KEY, _secret_config_dirs, _stop_brokers_in
+from tests.conftest import (
+    _SWEEP_ROOT_KEY,
+    _secret_config_dirs,
+    _stop_brokers_in,
+    _sweep_session_leftovers,
+)
 
 
 def _start(base: Path) -> int:
@@ -87,6 +92,35 @@ def _deep_config_dir(tmp_path: Path) -> Path:
         deep
     ), "the construction failed: this config dir took the in-directory layout"
     return deep
+
+
+def _plant_socket(base: Path) -> Path:
+    """Put a plain file where ``base``'s broker socket would be.
+
+    For the tests whose subject is the net's CHEAP PRE-CHECK rather than a real
+    daemon: the guard is `socket_path(...).exists()`, and which layout
+    `socket_path` picks is a property of the machine's tmp depth (see
+    `_uses_the_fallback_socket`), so the file is planted at whatever
+    `socket_path` returns rather than at a path these tests guess. A plain file is
+    enough for the guard, and it keeps the test from depending on a daemon being
+    up.
+    """
+    path = socket_path(base)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    return path
+
+
+def _cleanup_planted_socket(base: Path) -> None:
+    """Remove what `_plant_socket` created, in whichever layout it used.
+
+    The fallback runtime directory is derived from the config dir's NAME and is
+    the sweep's to remove; taking it here as well is what stops a mis-targeted
+    plant from leaving a runtime dir behind on the developer's machine.
+    """
+    with suppress(Exception):
+        socket_path(base).unlink(missing_ok=True)
+        shutil.rmtree(_runtime_fallback_dir(secrets_dir(base)), ignore_errors=True)
 
 
 def _wait_gone(pid: int, timeout: float = 5.0) -> bool:
@@ -478,8 +512,32 @@ def test_a_broker_a_test_started_is_dead_once_that_test_has_torn_down(tmp_path: 
     in the ORDERING, so only a test that submits to the real ordering can catch a
     regression of it.
 
-    Fails against the pre-#985 conftest (candidate discovery at teardown only)
-    and passes with the call-phase reap; that A/B is in the PR for #958.
+    **What this test actually discriminates, corrected in round 1.** It fails
+    only when the call-phase work is absent ENTIRELY — the `_SWEEP_ROOT_KEY` stash
+    that the teardown sweep reads (the "recording") and the call-phase reap
+    together. Verified three ways against this head: with the stash and the
+    recording kept but the reap removed, it PASSES; with all three removed it
+    FAILS (`assert False / _wait_gone`). The stash alone is sufficient here,
+    because this inner test's config dir takes the ``$TMPDIR`` fallback socket
+    layout: its in-directory socket path is well past `MAX_SOCKET_PATH` (103
+    bytes, `secrets/protocol.py`) on every runner — measured 174 bytes here, 126
+    on a Linux runner by that path's arithmetic — so a fallback socket survives
+    ``tmp_path``'s reclaim and the recorded PATH is what lets the teardown sweep
+    still reach the daemon. The call-phase REAP is therefore not what this test
+    pins; it is an end-to-end guard that the reap survives that reclaim, not a
+    falsifier of the pre-#985 ordering on its own. No A/B against the pre-#985
+    tree is possible for it either: `3295042b0^` cannot even collect this file
+    (``ImportError: cannot import name '_SWEEP_ROOT_KEY'``, a symbol that
+    postdates it).
+
+    The two tests that DO discriminate the change are
+    `test_a_spawned_broker_names_itself_in_the_process_listing` and
+    `test_the_session_end_net_reaps_a_broker_started_after_the_per_test_reap`;
+    both fail on the PR's base for their stated reasons.
+
+    A change to the inner test's nesting depth could move this config dir back to
+    the in-directory layout and so change what this test proves — that is the
+    reason this layout fact is written down rather than left implicit.
 
     Asserted through `_wait_gone` rather than a bare `pid_alive` for the reason
     that helper documents, and it matters MORE here: the sweep waits for the
@@ -625,3 +683,117 @@ def test_a_spawned_broker_names_itself_in_the_process_listing(config_root: Path)
     finally:
         _kill(config_root)
         _kill_pid(pid)
+
+
+def test_the_net_asks_the_protocol_only_about_a_candidate_that_has_a_socket(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The net's cheap pre-check, pinned so the protocol round trip cannot creep back.
+
+    The candidate list at `pytest_sessionfinish` is almost entirely socket-less —
+    measured for `tests/unit/secrets` alone, 784 recorded roots from 261 tests —
+    and asking each one with a protocol round trip measured 199.4us against 7.4us
+    for the `socket_path(...).exists()` guard `_stop_brokers_in` already writes
+    twelve lines away. This pins the BEHAVIOUR rather than the timing: a candidate
+    with no socket on disk is never asked the expensive question.
+    """
+    with_socket = tmp_path / "has-socket"
+    without_socket = tmp_path / "no-socket"
+    with_socket.mkdir()
+    without_socket.mkdir()
+    _plant_socket(with_socket)
+    asked: list[Path | None] = []
+
+    def probe(base: Path | None = None) -> bool:
+        asked.append(base)
+        return False
+
+    monkeypatch.setattr("tests.conftest._SESSION_SWEEP_ROOTS", {with_socket, without_socket})
+    monkeypatch.setattr(client, "is_running", probe)
+    monkeypatch.setattr("tests.conftest._stop_brokers_in", lambda candidates: None)
+    try:
+        assert _sweep_session_leftovers(tmp_path) == 0
+    finally:
+        _cleanup_planted_socket(with_socket)
+        _cleanup_planted_socket(without_socket)
+    assert asked == [with_socket], (
+        f"the net asked the protocol about {asked!r}; only a candidate with a socket "
+        "on disk can be a broker, and `socket_path(...).exists()` is the cheap way "
+        "to know — the same guard `_stop_brokers_in` uses"
+    )
+
+
+def test_the_net_reports_only_the_brokers_it_actually_stopped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported count is what was STOPPED, not what was considered.
+
+    `_stop_brokers_in` refuses three shapes and the third — `pid == os.getpid()`,
+    the in-process `broker` fixture's shape — leaves the broker running, so a
+    count taken from the liveness probe alone reports a broker as reclaimed while
+    it is still there. This drives the REAL refusal through the real
+    `_stop_brokers_in` rather than stubbing the stop, so the test fails if either
+    the refusal or the re-check after it goes away.
+    """
+    candidate = tmp_path / "config"
+    candidate.mkdir()
+    _plant_socket(candidate)
+    monkeypatch.setattr("tests.conftest._SESSION_SWEEP_ROOTS", {candidate})
+    monkeypatch.setattr(client, "is_running", lambda base=None: True)
+    # The in-process broker shape: `broker_status` reports THIS process's pid, so
+    # the sweep refuses to signal it and the daemon is still answering afterwards.
+    monkeypatch.setattr(client, "broker_status", lambda base=None: {"pid": os.getpid()})
+    try:
+        assert client.is_running(candidate), "the planted socket was not seen as live"
+        assert _sweep_session_leftovers(tmp_path) == 0, (
+            "the net reported a broker as reclaimed that `_stop_brokers_in` refused "
+            "to stop; the count must be what was stopped, not what was considered"
+        )
+    finally:
+        _cleanup_planted_socket(candidate)
+
+
+def test_the_net_hands_a_version_skewed_broker_to_the_sweep_and_counts_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A version-skewed broker is stopped and reported, not silently dropped.
+
+    `is_running` re-raises `BrokerIncompatible` on purpose — a version-mismatched
+    broker IS listening, and answering False would launder "live but unusable"
+    into "unreachable" — so a net that suppresses that exception drops the skewed
+    candidate out of `live` entirely: not stopped, and invisible in the count, on
+    exactly the axis this net exists to make visible. It must instead be handed to
+    `_stop_brokers_in`, which can still stop it because `broker_status` synthesises
+    a pid from the version refusal.
+
+    The stopper is recorded rather than run: the real one waits on `is_running`,
+    which re-raises on every poll while a stand-in daemon is still answering, so
+    driving a live one through it would make this test race rather than assert.
+    """
+    candidate = tmp_path / "config"
+    candidate.mkdir()
+    _plant_socket(candidate)
+    state = {"up": True}
+    stopped: list[Path] = []
+
+    def probe(base: Path | None = None) -> bool:
+        if state["up"]:
+            raise client.BrokerIncompatible("the broker speaks protocol 0", pid=4242, protocol=0)
+        return False
+
+    def stop(candidates: list[Path]) -> None:
+        stopped.extend(candidates)
+        state["up"] = False  # a stop that worked takes the daemon away
+
+    monkeypatch.setattr("tests.conftest._SESSION_SWEEP_ROOTS", {candidate})
+    monkeypatch.setattr(client, "is_running", probe)
+    monkeypatch.setattr("tests.conftest._stop_brokers_in", stop)
+    try:
+        assert _sweep_session_leftovers(tmp_path) == 1, (
+            "the net neither stopped nor reported a version-skewed broker: "
+            "`is_running` re-raises BrokerIncompatible so it is not laundered into "
+            "'unreachable', and the net must not swallow it back"
+        )
+    finally:
+        _cleanup_planted_socket(candidate)
+    assert stopped == [candidate], "the skewed candidate never reached the sweep"


### PR DESCRIPTION
# PR Description

## Summary of Changes

Closes the two halves of #958 that were still genuinely open, and states plainly
which half was not.

**Item 1 of the brief — "the per-test broker sweep is a silent no-op" — is
already fixed on `main` and this PR does not re-fix it.** It landed in **#985**
(`3295042b0` + `e66d4a99c`, merged 2026-09-12T01:46Z), which is the follow-up
PR the issue author committed to and which the issue thread never recorded.
That diagnosis reproduces only against a checkout that predates it:
`git merge-base --is-ancestor e66d4a99c <checkout-HEAD>` answers **no** for a
tree at `60273bb79`, where `grep -c pytest_runtest_call tests/conftest.py` is
`0`. A/B on this branch's worktree, same command both ways, is below.

What remained, and what this PR does:

1. **The orphan's identity — the question the issue explicitly left open.**
2. **A session-end net** for the one leak shape no per-test mechanism can see.
3. **Three regression tests.** Two fail against this branch's base for their stated
   reasons (verified again in round 1, independently, by both gates); the third is
   an end-to-end guard whose falsification claim did not hold and was corrected in
   round 1 — see §4.

---

## 1. The bare `Local Operator` child was the secret broker, spawned by a branded parent

`client._spawn_broker` launches `[sys.executable, "-m", "local_operator.secrets.brokerd"]`.
In any process that has been through `procname.reexec_branded` — every real `lop`
launch — `sys.executable` **is** the branded hardlink, so the broker inherited the
product name with nothing to say what it was. That is exactly the fingerprint in
every pre-#954 teardown. On Linux `comm` truncates at 15 bytes, so `Local Operator`
and any labelled form are indistinguishable *there*, which is why the label had to
go on **argv**, the axis a teardown dump reads.

This settles the author's retraction ("nothing brands the broker"): that assumed a
plain venv interpreter, which holds only until a parent re-execs.

### Raw `ps` line, before and after — a broker spawned from a branded parent

A throwaway probe re-execs itself through the branded hardlink (so `sys.executable`
IS the brand, reproducing the pre-#954 shape deliberately), then calls the real
`_spawn_broker` under an isolated `HOME` + config dir.

```
parent sys.executable: /Users/damian/workspace/repos/lo-958/.venv/bin/Local Operator
```

**Before** (`origin/main`) — captured live on this machine; this row is the
operator's own running broker, started by a branded `lop`, and it is the issue's
unexplained child verbatim:

```
$ ps -Ao pid,ppid,command | grep brokerd
99301     1 /Users/damian/.local/share/uv/tools/local-operator/bin/Local Operator -m local_operator.secrets.brokerd
```

**After** (this branch), same probe, same listing:

```
PS: 48517 48509 Local Operator [secret broker] store=fb9e8320ff1b -m local_operator.secrets.brokerd
```

The module stays in argv, so the issue's own reopen condition ("a branded child
whose argv is not `-m local_operator.secrets.brokerd`") remains checkable.

**The digest is not decoration.** It is the same derivation
`protocol._runtime_fallback_dir` uses for the socket directory, so a row in `ps`
maps to a directory on disk:

```
$ .venv/bin/python -c "...; print(_broker_argv0(base)); print(_runtime_fallback_dir(secrets_dir(base)).name)"
argv0 : Local Operator [secret broker] store=0ee2063947fd
rtdir : lop-secrets-501-0ee2063947fd
```

It is a **digest and not the config dir** because argv is world-readable and a
config dir can name a user, a project or a customer — the rule already written
above the `LABEL_*` block.

`brokerd` also sets its own `comm` on Linux (`prctl` does not survive an exec).
Both paths degrade to today's exact behaviour on any failure: a daemon must never
fail to start over its own decoration. Nothing matches the broker by argv
(`grep -rn brokerd` finds only the spawn site and the module itself), so the
relabel cannot break a lookup. `should_reexec` / `is_own_launch` are untouched —
neither reads argv[0] of a child, and the broker is not a `lop` launch.

Release: patch — the secret broker now names itself in process listings, and session teardown reports and stops the brokers no per-test sweep can see.

---

## 2. The session-end net, and the gap it actually covers

The per-test reap from #985 is what stops brokers in practice. I checked the shape
the brief suggested (a broker restarted by a *function-scoped* fixture finaliser)
and it is **already covered** — the autouse sweep is set up first and so finalised
last. The real gap is one directory further out:

> A **module- or session-scoped** fixture takes its directory from
> `tmp_path_factory.mktemp`. It is in **no test's `tmp_path`**, so no per-test
> record can name it, and its finaliser runs after the last function-scoped sweep.

Measured: a broker started in a module-scoped fixture's teardown was **still alive
a second after the inner run returned**. `pytest_sessionfinish` now walks the
session basetemp for `secrets/` markers (the marker the store itself creates),
stops what is still live, and **reports the count**:

```
[broker-sweep] session-end net reclaimed 1 live broker(s) the per-test reap did not stop; see tests/conftest.py
```

Reporting is the point — a leak past the per-test reap stays visible instead of
being absorbed. Silent at zero, so a clean run gains no line.

**Safety.** Every candidate must lie under this run's own `basetemp`, which is the
same property the per-test sweep rests on: it can never reach the operator's real
`~/.local-operator` or another worktree. Basetemp is captured through the **public**
`tmp_path_factory` fixture, not `config._tmp_path_factory` — building a second
`TempPathFactory` would allocate a *different* basetemp and the net would walk an
empty directory and silently reclaim nothing. Verified in round 1: a broker started
under a config dir outside every basetemp survived a 49-test session untouched, and
a symlink planted out of basetemp to a directory holding a `secrets/` marker was
never a candidate at all, because `rglob` does not follow symlinks. A look-alike
cannot be reaped either: both the net's liveness gate and `_stop_brokers_in`'s
`broker_status` require a real protocol answer, so a directory with a `secrets/`
marker and a plain file at the socket path is never signalled.

**Broader than the module-scoped shape written up here**, confirmed in round 1: the
net also catches a **session**-scoped fixture's teardown (`pytest_sessionfinish` runs
after session fixtures are finalised) and works with **no explicit `--basetemp`**;
under `-n 2` it fires per worker, on each worker's own basetemp subdirectory, and
stays silent at zero. `pytest_sessionfinish` runs in the xdist worker, which is why
the report goes to stderr rather than through a reporter that is not there.

**Round-1 corrections to the net itself, all three in `tests/conftest.py`:**

- The reported count is what the stop path **confirmed stopped**, not what it
  considered and not a re-probe afterwards. `_stop_brokers_in` now returns the
  candidates it actually signalled whose daemon stopped answering inside the wait
  bound, and the net reports that set. The confirmation has to be taken there, while
  the socket still exists: that function removes every candidate's fallback runtime
  dir unconditionally — including the ones it declined to signal, and on the layout
  a real pytest candidate takes (in-directory socket path ~145 bytes against the
  103-byte limit) that directory **is the socket's parent** — so a probe taken after
  it returns answers "no socket file" for a broker that is still alive. That was
  round 2's R2-1: the first version of this fix re-probed afterwards and reported a
  live broker as reclaimed on exactly that layout. A declined candidate
  (`pid <= 0`, `pid == os.getpid()`), a candidate with no socket, and an
  unconfirmable stop are all absent from the set, and none of them is assumed dead.
- `BrokerIncompatible` is no longer swallowed. `is_running` re-raises it on purpose
  (a version-mismatched broker is live; answering `False` would launder "live but
  unusable" into "unreachable"), so the net's `suppress(Exception)` dropped such a
  candidate entirely: neither reaped nor reported, on exactly the axis this net
  exists to make visible. It is handled explicitly, and `_stop_brokers_in` can
  stop it because `broker_status` synthesises a pid from the version refusal.
- The net asks `socket_path(...).exists()` before the protocol round trip — the same
  cheap guard `_stop_brokers_in` writes twelve lines away. The candidate list is
  almost entirely socket-less (784 recorded roots from `tests/unit/secrets` alone)
  and the guard measured 7.4us against 199.4us.
- **A pre-existing hole in the same function family is closed here rather than
deferred** (found while remediating the finding above, and fixed because it is small
  and lives in the function this PR already changes): `_stop_brokers_in`'s
  post-`SIGTERM` wait loop called `client.is_running` bare, which **re-raises**
  `BrokerIncompatible` for a version-skewed daemon — and such a daemon is very
  likely still listening on the first poll after the signal. The call-phase reap
  runs inside `finally` for every test, so that refusal was an error in whatever
  passing test was running, not a suppressed cleanup. The loop now asks
  `_broker_is_still_up`, so the wait stays bounded and nothing assumes the daemon
  died; the count re-asks before reporting a reclaim.

Each of those is pinned by a new test that fails against the head it fixes for its
stated reason (`3 failed` on `dc725c88a`; the wait-loop test `1 failed` with
`BrokerIncompatible` escaping on `512d5c0f8`, `14 passed` here).

---

## 3. Measurement evidence

Census = live `brokerd` pids whose `LOCAL_OPERATOR_CONFIG_DIR` is under a pytest
basetemp, taken as a **pid-set delta** (before/after `comm -13`) because this
machine carried pre-existing leaked brokers from diagnostic runs on a stale
checkout. Those strays are **not part of any measured number**: the delta is what a
run ADDED, and each cell is one before/after pair taken around that run alone. As of
the round-1 review the machine carries **3** `brokerd` processes, all legitimately
owned (the operator's `~/.local-operator`, a diagnostics run's, and a peer
worktree's basetemp) — none of them this suite's, and none of them a result of this
branch. Command, run identically in every cell:

```sh
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest <target> -q   # default addopts → xdist
```

| tree | target | result | leaked |
|---|---|---|---|
| `tests/conftest.py` reverted to `3295042b0^` (pre-#985) | `test_cli.py` | `39 passed` | **27** |
| `origin/main` (494ad221d) | `test_cli.py` | `39 passed` | **0** |
| `origin/main` | `test_agent_surfaces.py` | `46 passed` | **0** |
| **this branch** | `test_cli.py` | `39 passed` | **0** |
| **this branch** | `test_agent_surfaces.py` | `46 passed` | **0** |
| **this branch** | whole `tests/unit` | `19132 passed, 18 skipped` | **0** |

The 27 reproduces the issue's measured +27 exactly, and it reproduces **only**
against the pre-#985 conftest. So the ~22-27 → 0 improvement the brief asked me to
demonstrate is real, but it is #985's, not this PR's; this PR holds the line at 0
and covers the shape #985 could not see.

---

## 4. Regression tests — two fail against the code before this change; one claim corrected in round 1

All three are in `tests/unit/secrets/test_broker_sweep.py`. The existing tests in
that file drive `_stop_brokers_in` and the candidate list *directly*, which is
precisely why the original leak survived all of them: the helper was correct and
the sweep still reaped nothing. The bug lived in the **ordering**, so the new
end-to-end test submits to the real ordering by running a **real nested pytest**
against the shipped conftest (`pytest_plugins = ["tests.conftest"]`) — a test
cannot observe its own teardown.

**`tmp_path_retention_policy = "failed"` is load-bearing and is restated in the
inner ini.** A nested run given its own `-c` does not inherit the root
`pyproject.toml`, and that setting is the entire precondition: under it `tmp_path`'s
finaliser removes the directory *before* an autouse fixture declared in
`tests/conftest.py` is finalised. I verified both ways — with the default policy the
directory still exists at teardown, and the test then **passes against the very code
it must catch**. That near-miss is why it is pinned and commented.

| test | neutered tree | result |
|---|---|---|
| `test_a_spawned_broker_names_itself_in_the_process_listing` | `client.py` at `origin/main` (the PR's base) | **FAIL** — `assert '[secret broker]' in '/Users/…/.venv/bin/python -m local_operator.secrets.brokerd'` |
| `test_the_session_end_net_reaps_a_broker_started_after_the_per_test_reap` | net disabled (i.e. `main` today) | **FAIL** — `assert False / _wait_gone(18517)` |
| all three | this branch | **PASS** (`13 passed` for the whole file) |

**The third test's claim was wrong and is corrected (round 1, R1-1 / QA Q-3).**
`test_a_broker_a_test_started_is_dead_once_that_test_has_torn_down` does **not**
fail against the pre-#985 tree; both gates re-derived that independently and I
re-derived it here. The reason, now written into its docstring: that inner test's
config dir takes the **`$TMPDIR` fallback socket layout** — its in-directory socket
path is 174 bytes here and 126 on a Linux runner, both past `MAX_SOCKET_PATH`
(103) — so the socket **outlives** `tmp_path`'s reclaim and the *recorded path*
alone is enough for the teardown sweep to reach the daemon. Measured on this head:
with the call-phase stash and recording kept but the reap removed it **PASSES**;
with all of the call-phase work removed it **FAILS** (`assert False /
_wait_gone(69915)`). So it fails only when the whole call-phase mechanism is
gone, and it is an end-to-end guard that the reap survives pytest's reclaim rather
than a falsifier of the pre-#985 ordering on its own. No A/B against the true
pre-#985 tree is possible for it in any case: `3295042b0^` cannot even collect this
file (`ImportError: cannot import name '_SWEEP_ROOT_KEY'`). A future change to the
inner test's nesting depth could move it to the in-directory layout and silently
change what it proves, which is why the layout fact is now written down.

The two tests that DO discriminate the change are named at the top of the table,
and both fail against the PR's base for their stated reasons — not for an unrelated
error.

Assertions go through the file's own `_wait_gone` rather than a bare `pid_alive`:
the sweep waits for the daemon to stop *answering*, which happens as it closes its
listener — a step before it exits. Measured here: alive at t+0s, gone by t+0.25s. A
bare probe flaps on that scheduling, and the bounded wait still separates the two
outcomes, because a **leaked** broker does not exit at all (it idles 30 minutes).

The branding test asserts on **argv**, not `comm`, for the truncation reason above,
and reads the argv back from the **really spawned process**, so a label that never
reaches the child fails it. It pins the part that holds on every platform (the label
reaches argv whatever the image is); the branded-`sys.executable` precondition is
macOS-only, since `procname.branded_link_path` returns `None` elsewhere — the
branded-parent capture is in §1 above and is noted in the test's docstring.

---

## CI caught one thing my local run could not: `ps` truncates at 80 columns on Linux

The first push went red on `test (3.12, 2)` — and it was my own new test, which is
the outcome a regression test is supposed to have when it is pointed at a real
difference:

```
E  AssertionError: the module must stay in argv: ...
   'Local Operator [secret broker] store=57d52245abbc -m local_operator.secrets.brok'
```

Cut at **exactly 80 characters**. The label was intact; the **instrument** truncated
it. Linux `ps` falls back to an 80-column screen width when stdout is not a tty,
which is every CI invocation — and every teardown dump this label exists to make
readable. Fixed with `ps -ww` in the test (`dc725c88a`), not by shortening the label.

It also surfaced a property worth keeping, now documented on `LABEL_BROKER`: the
label is **ordered for a truncating reader**. Identity and store digest sit at the
front, so an 80-column cut still reads `Local Operator [secret broker]
store=<digest>` and only the module — which a reader can infer — is lost. The full
row is **83 characters**, so the 80-column cut lands exactly inside the module
(`…-m local_operator.secrets.brok`) and takes nothing else; verified in round 1
against a real spawned broker, not reconstructed. A reader that needs the whole
line uses `ps -ww` or `/proc/<pid>/cmdline`.

I could not have found this locally: macOS `ps` does not truncate this way, and
there is no Docker on this machine, so Linux argv rendering is an axis only CI can
exercise. Stating that plainly rather than implying I verified both platforms.

---

## What this does NOT cover

- **A `timeout-minutes` SIGKILL of the whole job skips every in-process cleanup.**
  `SIGKILL` cannot be handled, so neither the per-test reap, the teardown sweep nor
  `pytest_sessionfinish` runs, and a detached broker started before the kill
  survives it. That is acceptable on a hosted runner because the runner VM is
  destroyed with the job, so the survivor has a lifetime measured in seconds and
  holds a key for a config dir that is about to cease to exist. It is *not*
  harmless on a developer machine, which is why the broker now self-identifies:
  the survivor of such a kill can be found and explained from `ps` alone, which was
  the whole complaint in #958.
- **The hang half of #958 is not addressed** and I found no evidence it exists —
  consistent with the issue's own comment 2 (four re-runs of shard 1's real file
  list, all `rc=0`).
- **Pre-existing leaked brokers on the operator's machine are left alone**, by the
  manager's instruction; they predate this branch and are a separate cleanup. The
  round-1 review found **3** `brokerd` processes on the machine, all legitimately
  owned (the operator's `~/.local-operator`, a diagnostics run's, and a peer
  worktree's basetemp). This line earlier read "54", a snapshot taken while a
  diagnostics backlog was live; the count is not stable and the pre-existing strays
  were never part of any measured number here — §3's census is a per-run pid-set
  **delta**, computed before/after each run, so a stray that was already running
  cancels out of every cell.
- `pyproject.toml` is untouched — no version bump.

## Testing

Gates run exactly as CI, whole tree, in this worktree's own venv
(`.venv/bin/python -c "import local_operator"` resolves to this worktree):

| gate | result |
|---|---|
| `flake8 local_operator tests` | clean (`rc=0`) |
| `black==26.1.0 --check .` | `1257 files would be left unchanged` |
| `isort==5.13.2 --check .` | clean |
| `pyright` (pinned 1.1.411, venv active) | `0 errors, 0 warnings` |
| `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` | **`19132 passed, 18 skipped in 1703.76s`** |

**CI on head `dc725c88a`: all 16 checks green** — including `test (3.12, 0-4)`,
`filesystem-boundaries-windows` (the job that caught the first call-phase reap),
both `tui-e2e` jobs, `lint`, `type-check` and `version-bump-guard`.

**Remediation head `2f2c463dd`** (commits `512d5c0f8` + `334d3a53f` + `2f2c463dd`,
rounds 1–2) — bounded gates re-run in this worktree's venv, over the two changed
files plus the sibling suites the net touches:

| gate | result |
|---|---|
| `flake8 .` | clean (`rc=0`) |
| `black==26.1.0 --check` (changed files) | `2 files would be left unchanged` |
| `isort==5.13.2 --check-only` (changed files) | clean |
| `pyright` (pinned 1.1.411, venv active, whole tree) | `0 errors, 0 warnings, 0 informations` |
| `pytest tests/unit/secrets tests/unit/tools/test_group_reaper.py -q` | **`303 passed`** (was 299; +4 new tests) |
| `pytest tests/unit/secrets/test_broker_sweep.py -q -n 2` | `14 passed` |
| the 3 new net tests against `dc725c88a` (previous head, new test file copied in) | **`3 failed`**, each for its stated reason |
| the wait-loop test against `512d5c0f8` (its own previous head) | **`1 failed`** — `BrokerIncompatible: the broker speaks protocol 0` escaping the reap, in 0.38s |
| the count test against `334d3a53f` (its own previous head) | **`1 failed`** — `assert 1 == 0`: a declined broker reported as reclaimed on the fallback layout |
| real broker on the fallback layout, declined shape, before → after | `reclaimed: 1` (daemon alive) → `reclaimed: 0` (daemon alive) |

No whole-tree run on the remediation head by instruction: the host is shared and a
sibling session was mid-run, and the bounded scope plus the 16/16 CI on `dc725c88a`
covers it; the round-3 gates check this delta (`334d3a53f..2f2c463dd`).

Closes #958.



