### PR TITLE
feat(sessions): one conversation search, shared by every surface, over HTTP

### DIFF
--- a/docs/DESKTOP_API.md
+++ b/docs/DESKTOP_API.md
@@ -183,7 +183,9 @@ not already answered precisely — a bounded soft tier (prefix, word-order, edit
 distance <= 2 on words of 4+ characters). `rank` is the relevance tier
 (0 name, 1 id, 2 body, 3 soft) and `body_match` says the conversation is why the
 row surfaced, so a client can label a row it would otherwise show with no
-visible reason. A client that already holds the catalogue should merge these
+visible reason. `rank` is NOT MEANINGFUL when `q` is empty: an empty query is
+the store listing (every session, newest first) and nothing matched anything, so
+the tier is the constant 0 rather than "this matched on its name". A client that already holds the catalogue should merge these
 results into the rows it has rather than replacing the list, and must skip the
 whole call when `/v1/capabilities` does not advertise `features.session_search`
 — an older backend answers 404 there.

--- a/docs/DESKTOP_API.md
+++ b/docs/DESKTOP_API.md
@@ -156,6 +156,7 @@ falling back to the parent of the config root when no cwd was retained.
 | Endpoint | Request | Result inside `CRUDResponse.result` |
 | --- | --- | --- |
 | GET `/v1/desktop/sessions` | `limit` 1..500, default100 | `{sessions: [...]}` canonical rows plus explicit desktop drafts |
+| GET `/v1/desktop/sessions/search` | `q` (<=256 chars), `limit` 1..500, default100 | `{sessions:[{id,name,mtime,forked,rank,body_match}],query,limit}`, best match first |
 | POST `/v1/desktop/sessions` | `{request_id, cwd}` | `{session_id}`; cwd must exist |
 | GET `/v1/desktop/sessions/{id}` | — | snapshot frame below |
 | GET `.../{id}/history` | optional `before_id`, `limit` 1..500 | `{entries,has_more,cursor_missing}` |
@@ -171,6 +172,21 @@ for a retry of the **same** operation. Answer `request_id` is instead the pendin
 gate's opaque ID, and answer `epoch` is the **runtime** epoch from frontend state,
 not the HTTP stream epoch. Approval booleans and question indices are strict.
 Answer bodies are never retained in the HTTP receipt journal or echoed back.
+
+`GET /v1/desktop/sessions/search` is the CLI's `/resume` search over HTTP: the
+same `local_operator.session.session_search` implementation the TUI picker and
+the phone daemon run, so a query that finds a conversation on one surface finds
+it on the others. It matches the session's displayed name, its id, an exact
+case-insensitive substring of the conversation body (from the cached digest
+index, re-digested only for transcripts that changed), and — when the query is
+not already answered precisely — a bounded soft tier (prefix, word-order, edit
+distance <= 2 on words of 4+ characters). `rank` is the relevance tier
+(0 name, 1 id, 2 body, 3 soft) and `body_match` says the conversation is why the
+row surfaced, so a client can label a row it would otherwise show with no
+visible reason. A client that already holds the catalogue should merge these
+results into the rows it has rather than replacing the list, and must skip the
+whole call when `/v1/capabilities` does not advertise `features.session_search`
+— an older backend answers 404 there.
 
 Images use the runtime's `{data_b64,mime_type}` shape (png/jpeg/gif/webp), at most8;
 the encoded message/command body must fit900,000bytes. Empty prompts without an

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -2640,13 +2640,14 @@ def _search_sessions(query: str, limit: int = 40) -> list[dict[str, Any]]:
     name, or a soft match) rather than its visible name, so the phone can say
     why it is on screen instead of showing a row with no visible reason.
 
-    No try/except around the call on purpose. A search that silently answers
-    "nothing matched" when the store could not be read is indistinguishable
-    from a correct empty result, and that is the failure this path exists to
-    avoid; ``build_index`` already degrades on its own (an absent or corrupt
-    cache costs a rebuild, never a raise), so the only exceptions reaching here
-    describe a store that genuinely could not be walked, which belongs in the
-    response as an error.
+    No try/except around the call, and the honest reason is not "only a broken
+    store raises": the index build degrades on its own (an absent or corrupt
+    cache costs a rebuild, never a raise), and a store whose ``sessions/``
+    directory cannot be read is reported as ZERO matches rather than as an
+    error, because ``resume._scan_sessions`` swallows that ``OSError`` so every
+    listing surface survives it (see ``search_store``). What is NOT caught here
+    is anything else — a bug in the search must not be laundered into a
+    confident "nothing matched".
     """
     from local_operator.paths import config_dir
     from local_operator.session.session_search import search_store

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -2628,57 +2628,40 @@ def _past_sessions(limit: int = 20) -> list[dict[str, Any]]:
 def _search_sessions(query: str, limit: int = 40) -> list[dict[str, Any]]:
     """Past sessions matching ``query`` by name, id, or conversation body.
 
-    Mirrors the TUI picker's two channels: a name/id substring match, and a
-    body match through the cached search index (re-digested only for
-    transcripts that changed). A row that matched ONLY on its body is marked
-    ``body_match`` so the UI can say why it surfaced — otherwise it reads as a
-    result the filter had no reason to return.
+    One call into ``session_search.search_store``, which is the SAME admission,
+    soft-matching and ranking the TUI's ``/resume`` picker and the desktop chat
+    search use. Before this it was a private second implementation: name/id and
+    an EXACT body substring only, no typo/prefix tier and no ranking, so a query
+    the picker resolved confidently found nothing on the phone. The phone's own
+    composition is only what it RENDERS from the answer — the dict shape below
+    is the wire format, not a second filter.
+
+    ``body_match`` marks a row the conversation surfaced (exact body, a past
+    name, or a soft match) rather than its visible name, so the phone can say
+    why it is on screen instead of showing a row with no visible reason.
+
+    No try/except around the call on purpose. A search that silently answers
+    "nothing matched" when the store could not be read is indistinguishable
+    from a correct empty result, and that is the failure this path exists to
+    avoid; ``build_index`` already degrades on its own (an absent or corrupt
+    cache costs a rebuild, never a raise), so the only exceptions reaching here
+    describe a store that genuinely could not be walked, which belongs in the
+    response as an error.
     """
     from local_operator.paths import config_dir
-    from local_operator.resume import fork_haystack, recent_session_rows
-    from local_operator.session.search_index import build_index, search_digests
+    from local_operator.session.session_search import search_store
 
-    cfg = config_dir()
-    rows = recent_session_rows(cfg, limit=200)
-    needle = query.strip().lower()
-    if not needle:
-        return [
-            {
-                "id": r.id,
-                "name": r.name,
-                "mtime": r.mtime,
-                "body_match": False,
-                "forked": r.forked,
-            }
-            for r in rows[:limit]
-        ]
-    try:
-        digests = build_index(cfg, [r.id for r in rows])
-        body_hits = search_digests(digests, needle)
-    except Exception:  # noqa: BLE001 — a broken index degrades to name/id only
-        body_hits = set()
-    out = []
-    for r in rows:
-        # Through the picker's own composition, so typing `fork` on the phone
-        # finds the rows the phone visibly tags — the same what-is-shown-is-
-        # searchable invariant `resume.fork_haystack` documents.
-        name_hit = needle in fork_haystack(r).lower() or needle in r.id.lower()
-        body_hit = r.id in body_hits
-        if not (name_hit or body_hit):
-            continue
-        out.append(
-            {
-                "id": r.id,
-                "name": r.name,
-                "mtime": r.mtime,
-                # Marked only when the name/id did NOT explain the match.
-                "body_match": body_hit and not name_hit,
-                "forked": r.forked,
-            }
-        )
-        if len(out) >= limit:
-            break
-    return out
+    matches = search_store(config_dir(), query, limit=limit)
+    return [
+        {
+            "id": match.row.id,
+            "name": match.row.name,
+            "mtime": match.row.mtime,
+            "body_match": match.body_match,
+            "forked": match.row.forked,
+        }
+        for match in matches
+    ]
 
 
 def _tmp_dir() -> str:

--- a/local_operator/server/models/desktop_sessions.py
+++ b/local_operator/server/models/desktop_sessions.py
@@ -47,6 +47,14 @@ class SessionSearchRow(BaseModel):
     can label it instead of showing a row with no visible reason for being in
     the results.
 
+    ``rank`` IS NOT MEANINGFUL WHEN ``query`` IS EMPTY. An empty query is the
+    store listing — every session, newest first — and nothing matched anything,
+    so the tier is the constant 0 rather than "this matched on its name". A
+    client that merges on ``rank`` must therefore treat an empty ``query`` as
+    "no ranking", which is also why the desktop renderer never sends one: its
+    search box is a filter, and an empty box is the unfiltered list it already
+    has.
+
     ``name``/``mtime``/``forked`` come along for the same reason the phone's
     payload carries them: a client that has never listed this session (a store
     larger than its own page, a row created since its last poll) can still

--- a/local_operator/server/models/desktop_sessions.py
+++ b/local_operator/server/models/desktop_sessions.py
@@ -33,6 +33,48 @@ class SessionList(BaseModel):
     limit: int = 100
 
 
+class SessionSearchRow(BaseModel):
+    """One past conversation the search admitted, and WHY it did.
+
+    Deliberately not a :class:`SessionRow`: this is the answer to a SEARCH, so
+    it carries the two facts only the search can know and a renderer cannot
+    recompute. ``rank`` is the relevance tier the row matched in (0 name, 1 id,
+    2 body, 3 soft — see ``local_operator.session.session_search``), decided
+    against the body digest index, which the client does not have; the order of
+    ``sessions`` already follows it, but sending the tier lets a client merge
+    these rows into a list it holds locally without losing the ordering. And
+    ``body_match`` says the conversation is why the row surfaced, so a client
+    can label it instead of showing a row with no visible reason for being in
+    the results.
+
+    ``name``/``mtime``/``forked`` come along for the same reason the phone's
+    payload carries them: a client that has never listed this session (a store
+    larger than its own page, a row created since its last poll) can still
+    render and open it.
+    """
+
+    id: str
+    name: str
+    mtime: float
+    forked: bool = False
+    rank: int
+    body_match: bool = False
+
+
+class SessionSearch(BaseModel):
+    """A search answer: the matching rows, best first, and the query they
+    answer.
+
+    ``query`` is echoed rather than assumed: a client debounces keystrokes, so
+    responses arrive out of order, and it must be able to tell which of its
+    queries this is the answer to without trusting arrival order.
+    """
+
+    sessions: list[SessionSearchRow]
+    query: str = ""
+    limit: int = 100
+
+
 class CreatedSession(BaseModel):
     binding: dict[str, str | None] = Field(default_factory=dict)
     session_id: str

--- a/local_operator/server/routes/capabilities.py
+++ b/local_operator/server/routes/capabilities.py
@@ -28,6 +28,14 @@ async def capabilities():
                 "profile_catalogue": 1,
                 "team_catalogue": 1,
                 "session_catalogue": 2,
+                # Searching past conversations by their CONTENT (name, id, exact
+                # body, bounded soft match) rather than by the page a client
+                # already holds. Its own key rather than a bump of
+                # `session_catalogue`: a client can render the catalogue
+                # perfectly well against a backend whose search route does not
+                # exist, and gating the list on the search version would hide a
+                # working surface because a newer one is missing.
+                "session_search": 1,
                 "lifecycle": 1,
                 # Watch leases route notification delivery; they never mark read.
                 # Named for this map's convention (`<subsystem>: <version>`); the

--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -33,6 +33,7 @@ from local_operator.server.models.desktop_sessions import (
     MessageAdmission,
     NotificationClaim,
     SessionList,
+    SessionSearch,
     SessionSnapshot,
     WatchReceipt,
 )
@@ -47,6 +48,7 @@ from local_operator.server.utils.desktop_sessions import (
     DesktopSessions,
 )
 from local_operator.session.frontend_state import SlashResult
+from local_operator.session.session_search import search_store
 from local_operator.slash_commands import slash_command_for
 
 router = APIRouter(tags=["Desktop sessions"], dependencies=[Depends(require_desktop)])
@@ -253,6 +255,55 @@ async def list_sessions(request: Request, limit: int = Query(default=100, ge=1, 
     async with errors():
         rows = await host(request).list(limit + 1)
         return reply({"sessions": rows[:limit], "truncated": len(rows) > limit, "limit": limit})
+
+
+@router.get("/v1/desktop/sessions/search", response_model=CRUDResponse[SessionSearch])
+async def search_sessions(
+    request: Request,
+    q: str = Query(default="", max_length=256),
+    limit: int = Query(default=100, ge=1, le=500),
+):
+    """Past conversations matching ``q`` by name, id, or what was SAID in them.
+
+    The same search the CLI's ``/resume`` picker runs, through the one
+    implementation the picker and the phone daemon share
+    (``session_search.search_store``): name and id as exact case-insensitive
+    substrings over the haystack the row is RENDERED with, plus the cached body
+    digest index for an exact conversation match, plus a bounded soft tier
+    (prefix, word-order, edit distance <= 2 on words of 4+ characters) when the
+    query is not already precisely answered. Results come back best-first with
+    the tier and the reason attached.
+
+    **Declared BEFORE ``/v1/desktop/sessions/{session_id}``** and that order is
+    load-bearing: FastAPI matches routes in declaration order, so a parent route
+    declared first would swallow this path and the client would get the
+    snapshot of a session literally named "search" (a 404, in practice) instead
+    of an answer.
+
+    The scan and the index build run off the event loop — they read every
+    session directory's head and one cache file — while ``q`` is bounded at 256
+    characters because the query is only ever a user's typing, and an unbounded
+    one would be projected into every digest comparison.
+    """
+    async with errors():
+        matches = await asyncio.to_thread(search_store, host(request).root, q, limit=limit)
+        return reply(
+            {
+                "sessions": [
+                    {
+                        "id": match.row.id,
+                        "name": match.row.name,
+                        "mtime": match.row.mtime,
+                        "forked": match.row.forked,
+                        "rank": match.rank,
+                        "body_match": match.body_match,
+                    }
+                    for match in matches
+                ],
+                "query": q,
+                "limit": limit,
+            }
+        )
 
 
 @router.post("/v1/desktop/sessions", response_model=CRUDResponse[CreatedSession])

--- a/local_operator/session/session_search.py
+++ b/local_operator/session/session_search.py
@@ -1,0 +1,385 @@
+"""One definition of "which past conversations match this query, best first".
+
+Three surfaces ask a user's question back to the store — the TUI's ``/resume``
+picker, the phone daemon's session search (``mobile.daemon``), and the desktop
+catalogue's chat search (``GET /v1/desktop/sessions/search``) — and each had
+grown its own copy of the rules. They had already drifted: the phone matched on
+name/id and an EXACT body substring only, so a typo, a prefix or a word-order
+query that the picker resolves found nothing there, and neither the phone nor
+the desktop ranked what it found, so the best match sat wherever recency put
+it. A surface that searches a store differently from its siblings is a bug
+report waiting on the user who tries the same query twice.
+
+So the mechanics live here, once:
+
+* **What is admitted.** ``name`` (through :func:`local_operator.resume.fork_haystack`,
+  so a row visibly tagged ``[fork]`` is findable by that tag however it is
+  spelled), the 12-hex id, an exact case-insensitive substring of the
+  conversation body, and — when the query is not already precisely answered — a
+  bounded SOFT match (prefix, order-independent token-AND, edit distance <= 2
+  on tokens of 4+ characters) over the same digest index.
+* **What order.** :data:`RANK_NAME` > :data:`RANK_ID` > :data:`RANK_BODY` >
+  :data:`RANK_SOFT`, with recency as the tie-break within a tier. Ranking is a
+  pure function of ``(query, row, digests)`` — no memory of previous keystrokes
+  — so the same query renders identically however the user reached it, which is
+  the property the picker needed before it could re-home a cursor onto the top
+  match.
+
+The digest index itself is ``session/search_index.py``: this module composes
+it, it does not reimplement it. Callers that hold their own rows and digests (a
+keystroke-driven picker) use the pure helpers; callers that answer a one-shot
+query over the store (the phone, the desktop route) use :func:`search_store`,
+which does the row scan and the index build in one place.
+
+Nothing here imports a UI framework: the daemon must not pull Textual in for a
+filter, and the server must not pull it in at all.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Sequence
+from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
+from pathlib import Path
+
+from local_operator.resume import SessionRow, fork_haystack, recent_session_rows
+from local_operator.session.search_index import (
+    SoftSearchIndex,
+    build_index,
+    search_digests,
+)
+
+#: Relevance tiers, best (lowest) first, used to sort a FILTERED subset when a
+#: query is active. A tier is a property of ``(query, row)`` alone — it does not
+#: depend on the previous query or on the order rows arrived — which is what
+#: lets ranking coexist with the picker's "no reorder under the cursor"
+#: invariant: the order changes only when the query changes, and a query change
+#: already re-homes the cursor to the top match.
+RANK_NAME = 0  # exact substring in the visible name — the strongest signal
+RANK_ID = 1  # exact substring in the id
+RANK_BODY = 2  # exact substring in the body/past-name digest
+RANK_SOFT = 3  # soft (prefix / token-AND / edit-distance) match only
+
+#: Name/id matches at which the bounded soft tier is skipped entirely (see
+#: :func:`soft_tier_wanted`). Three, not one: a single exact hit on a name is as
+#: often incidental as deliberate — ``spit`` matches "De\ *spit*\ e" — and
+#: treating it as a real answer hid every genuinely intended match behind it.
+#: Measured over 517 vocabulary-drawn typos, this floor loses no rows against
+#: running the tier on every keystroke while leaving the cursor exactly as
+#: stable.
+PRECISE_HITS_ENOUGH = 3
+
+
+def name_or_id_hit(row: SessionRow, needle: str) -> bool:
+    """Whether ``needle`` (already lowercased and stripped) is a PRECISE hit.
+
+    Through :func:`fork_haystack` rather than ``row.name``, so a row admitted on
+    its visible ``[fork]`` tag is a precise hit on the name tier — the tag is on
+    screen, so it has to be searchable, and it must not sort as a fuzzy body
+    match below every incidental digest hit.
+    """
+    return needle in fork_haystack(row).lower() or needle in row.id.lower()
+
+
+def rank_tier(row: SessionRow, needle: str, exact_body: AbstractSet[str] | None = None) -> int:
+    """The :data:`RANK_*` tier ``row`` matches ``needle`` in.
+
+    A row that matches nothing here is still rankable: it was admitted by the
+    SOFT set (it is in the already-filtered rows yet matched neither name, id,
+    nor exact body), which is :data:`RANK_SOFT`. That is why this never returns
+    "no match" — the caller's admission decision and this ordering decision are
+    deliberately separate, so a soft hit surfaces the row exactly as an exact
+    body hit does and then sorts below every exact tier.
+    """
+    if needle in fork_haystack(row).lower():
+        return RANK_NAME
+    if needle in row.id.lower():
+        return RANK_ID
+    if exact_body and row.id in exact_body:
+        return RANK_BODY
+    return RANK_SOFT
+
+
+def matched_in_body(row: SessionRow, query: str, body_matches: AbstractSet[str] | None) -> bool:
+    """True when ``row`` is on screen only because its CONVERSATION matched.
+
+    Drives the body-match marker on every surface that has one: a row whose
+    visible name already contains the query needs no explanation, and one that
+    does not would otherwise read as the filter returning something arbitrary —
+    worse than no marker at all, because it makes the whole result set look
+    untrustworthy.
+
+    ``body_matches`` is therefore the ADMITTED set (exact-body OR soft), not
+    just the exact one: a row surfaced only because a PAST name or a typo
+    matched is just as much "found on something other than the visible name".
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return False
+    if name_or_id_hit(row, needle):
+        return False
+    return row.id in (body_matches or frozenset())
+
+
+def filter_rows(
+    rows: Sequence[SessionRow],
+    query: str,
+    body_matches: AbstractSet[str] | None = None,
+) -> list[SessionRow]:
+    """Rows whose name or id contains ``query``, or whose id is in ``body_matches``.
+
+    A pure MEMBERSHIP filter: it decides which rows are shown and preserves the
+    order it was handed, so on its own it never moves a row under a cursor.
+    Relevance ORDERING lives in :func:`rank_rows`, which a surface applies only
+    when a query is active.
+
+    The name/id test stays exact substring even though soft matching exists:
+    those fields are a sentence the user wrote and a hex id, where an exact
+    match is what a precise query expects. Soft hits arrive through
+    ``body_matches`` (the caller folds the soft set in), so they surface the row
+    without making the name test fuzzy.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return list(rows)
+    matched = body_matches or frozenset()
+    return [row for row in rows if name_or_id_hit(row, needle) or row.id in matched]
+
+
+def rank_rows(
+    rows: Sequence[SessionRow],
+    query: str,
+    body_matches: AbstractSet[str] | None = None,
+) -> list[SessionRow]:
+    """``rows`` ordered by relevance to ``query``, recency as the tie-break.
+
+    * **Empty query** -> ``rows`` unchanged (recency order, newest first). A
+      fixed query likewise never reorders: the key is a pure function of
+      ``(query, row)``, so repeated repaints and resizes produce byte-for-byte
+      the same order.
+    * **Non-empty query** -> one deterministic ordering: the tier the row
+      matched in (name > id > body > soft), with recency (newest first) as the
+      stable tie-break WITHIN every tier. ``sorted`` is stable, so passing rows
+      already in recency order makes the tie-break free.
+
+    ``body_matches`` is the EXACT-body match set (:func:`rank_tier`), not the
+    admitted one: a row that matched none of name, id or exact body was admitted
+    by the soft set and takes the soft tier, which needs no membership check.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return list(rows)
+    body = body_matches or frozenset()
+    return sorted(rows, key=lambda row: rank_tier(row, needle, body))
+
+
+def soft_tier_wanted(rows: Sequence[SessionRow], query: str) -> bool:
+    """Whether the bounded soft tier should run for ``query``.
+
+    A pure function of ``(query, rows)``: the tier runs unless the query matched
+    a session's NAME or ID at least :data:`PRECISE_HITS_ENOUGH` times. No run
+    history, no latch, no memory of previous keystrokes — that purity is what
+    keeps the same visible query rendering identically however the user reached
+    it.
+
+    **Why name/id and not "any exact hit".** Gating on an empty exact result
+    looks equivalent and silently destroys typo search. The exact tier also
+    admits BODY substring hits, and on a real store almost every typed token
+    appears incidentally in some conversation: ``plin`` has 8 body hits,
+    ``gren`` has 1. One incidental hit anywhere in the store then silenced the
+    tier for the whole query, so the typo it exists to rescue could not be
+    found. Measured on typos drawn from the store's own vocabulary, that gate
+    lost the target row outright on 11 of 763 queries and shed 100+ rows on 14.
+
+    A name or id match is different in kind: those fields are a sentence the
+    user wrote and a hex id they can copy, and an exact substring in either is a
+    deliberate, precise hit. A body substring is not that signal — it is as
+    likely to be the word appearing in passing inside an unrelated
+    conversation.
+
+    **Why a floor rather than emptiness.** ONE precise hit is not yet a useful
+    answer and can easily be incidental (see :data:`PRECISE_HITS_ENOUGH`), so
+    below the floor the extra recall is worth more than the precision; at or
+    above it the user has a real answer and fuzzy additions would only dilute
+    it.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return False
+    precise = 0
+    for row in rows:
+        if name_or_id_hit(row, needle):
+            precise += 1
+            if precise >= PRECISE_HITS_ENOUGH:
+                return False
+    return True
+
+
+@dataclass(frozen=True)
+class SessionMatch:
+    """One admitted row: its row, its tier, and whether its BODY is why.
+
+    ``body_match`` is True only when the name and id did NOT explain the match,
+    so a caller can say why a row surfaced without recomputing the comparison
+    (and without disagreeing with the filter about what "matched on the name"
+    means).
+    """
+
+    row: SessionRow
+    rank: int
+    body_match: bool
+
+
+def rank_matches(
+    rows: Sequence[SessionRow],
+    query: str,
+    body_matches: AbstractSet[str] | None = None,
+    admitted: AbstractSet[str] | None = None,
+) -> list[SessionMatch]:
+    """:func:`rank_rows` with each row's tier and reason attached.
+
+    Two sets, because they answer different questions and the picker already
+    keeps them apart: ``body_matches`` (EXACT body) is what a row's TIER is
+    decided against — an exact substring in the conversation is a stronger
+    signal than a typo — while ``admitted`` (exact OR soft) is what the
+    ``body_match`` MARKER is decided against. Marking from the exact set alone
+    gets a soft-only hit silently wrong: a row found through a typo, a prefix
+    or a reordered query has no visible reason for being on screen, which is
+    the one case the marker exists for.
+
+    ``admitted`` defaults to ``body_matches`` so a caller with no soft tier
+    gets exactly the old behaviour.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return [SessionMatch(row, RANK_NAME, False) for row in rows]
+    ordered = rank_rows(rows, needle, body_matches)
+    explained = admitted if admitted is not None else body_matches
+    return [
+        SessionMatch(
+            row, rank_tier(row, needle, body_matches), matched_in_body(row, needle, explained)
+        )
+        for row in ordered
+    ]
+
+
+#: The process-wide soft-search accelerator, built on first use.
+#:
+#: The phone daemon and the desktop route answer ONE-SHOT queries, so they have
+#: no object of their own to hold a warm token cache — and the stateless
+#: :func:`local_operator.session.search_index.soft_search_digests` re-tokenises
+#: the whole store on every request (measured 21 ms at 235 sessions / ~0.7 MB of
+#: digests, against ~1-8 ms warm here). :class:`SoftSearchIndex` re-syncs
+#: against whatever digests it is handed, and prunes to them, so one instance
+#: tracks the live store rather than growing across it.
+_SHARED_SOFT = SoftSearchIndex()
+
+#: Serializes the shared accelerator AND the exact-search memo it runs beside.
+#:
+#: Both are process-wide caches mutated in place, and the server calls this
+#: module from worker threads (``asyncio.to_thread``). Two concurrent searches
+#: through the shared soft index would interleave its token-cache sync, and
+#: ``search_index._lowered``'s one-entry memo has a genuine check-then-act race:
+#: thread A keys on its own digests, thread B replaces the memo, and A returns
+#: B's corpus — a search answering with the WRONG rows, which is the one failure
+#: this whole path exists to prevent. A search costs single-digit milliseconds,
+#: so serializing them is cheaper than making either memo thread-safe, and the
+#: lock is only taken on the shared path: the picker holds its own index and
+#: runs on a single thread.
+_SHARED_LOCK = threading.Lock()
+
+
+def _search_shared(
+    digests: dict[str, str],
+    query: str,
+    soft: SoftSearchIndex | None,
+    want_soft: bool,
+) -> tuple[set[str], set[str]]:
+    """``(exact_body_hits, soft_hits)`` for ``query``, either index considered.
+
+    Returns the exact hit set separately from the soft one because they answer
+    different questions downstream: their union is what admits a row, while the
+    exact set alone decides its tier. ``want_soft`` comes from
+    :func:`soft_tier_wanted` (the caller decides, because the gate needs the
+    rows), and when it is False the second set is empty and the expensive soft
+    search is never run.
+    """
+    if soft is not None:
+        # The caller owns this index (the picker keeps one for its whole life)
+        # and is single-threaded: no lock, no shared cache.
+        exact = search_digests(digests, query)
+        return exact, soft.search(digests, query) if want_soft else set()
+    with _SHARED_LOCK:
+        exact = search_digests(digests, query)
+        return exact, _SHARED_SOFT.search(digests, query) if want_soft else set()
+
+
+def search_rows(
+    rows: Sequence[SessionRow],
+    query: str,
+    *,
+    digests: dict[str, str] | None = None,
+    soft: SoftSearchIndex | None = None,
+    limit: int | None = None,
+) -> list[SessionMatch]:
+    """Admitted rows for ``query``, best first — the whole mechanic in one call.
+
+    ``digests`` is the caller's body index; absent (a caller with no index — a
+    test, an embedder, a store that failed to digest) the search degrades to
+    name and id, which is exactly what it did before body search existed rather
+    than failing.
+
+    ``soft`` is the caller's own accelerator when it has one; absent, the
+    process-wide one is used under :data:`_SHARED_LOCK`.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        # An empty query is not a search: every row is the answer, in recency
+        # order, and nothing is "matched on the body".
+        rows = list(rows)
+        return [SessionMatch(row, RANK_NAME, False) for row in rows[:limit]]
+
+    exact_body: set[str] = set()
+    admitted: set[str] = set()
+    if digests:
+        exact_body, soft_hits = _search_shared(
+            digests, needle, soft, soft_tier_wanted(rows, needle)
+        )
+        admitted = exact_body | soft_hits
+    matched = filter_rows(rows, needle, admitted)
+    ranked = rank_matches(matched, needle, exact_body, admitted=admitted)
+    return ranked[:limit] if limit is not None else ranked
+
+
+def search_store(
+    config_dir: Path,
+    query: str,
+    *,
+    rows: Sequence[SessionRow] | None = None,
+    soft: SoftSearchIndex | None = None,
+    limit: int | None = None,
+) -> list[SessionMatch]:
+    """One-shot store search: scan the rows, build the index, answer ``query``.
+
+    The entry point for a caller with no rows of its own — the phone daemon and
+    the desktop route. They must not each own a scan and an index build, and
+    they must not disagree about either.
+
+    ``rows`` is supplied only when the caller already has them (and knows they
+    are current); otherwise the store is scanned UNCAPPED, matching the picker.
+    A cap here would be the bug the picker documents at its own call site: a
+    session past the cap is not merely off-screen, it is unfindable and
+    indistinguishable from one that was deleted. Affordable because the scan is
+    limit-independent and each row costs one bounded head read — measured at
+    12.8 ms for the whole of a 235-session store on the reporting machine, plus
+    ~3.3 ms for the warm index and single-digit milliseconds for the query.
+    """
+    if rows is None:
+        rows = recent_session_rows(config_dir, limit=None)
+    rows = list(rows)
+    middle = query.strip()
+    if not middle:
+        return search_rows(rows, query, limit=limit)
+    digests = build_index(config_dir, [row.id for row in rows])
+    return search_rows(rows, query, digests=digests, soft=soft, limit=limit)

--- a/local_operator/session/session_search.py
+++ b/local_operator/session/session_search.py
@@ -374,6 +374,15 @@ def search_store(
     limit-independent and each row costs one bounded head read — measured at
     12.8 ms for the whole of a 235-session store on the reporting machine, plus
     ~3.3 ms for the warm index and single-digit milliseconds for the query.
+
+    **An empty answer is not proof of an empty store.** The scan underneath
+    (``resume._scan_sessions``) catches the ``OSError`` from an unreadable
+    ``sessions/`` directory and returns no candidates, deliberately: every
+    listing surface would otherwise fail on a store it cannot read, and a
+    listing that fails is worse than one that is empty. So a store that cannot
+    be walked reports zero matches rather than raising, and this function does
+    not pretend otherwise — a caller that must distinguish the two has to ask
+    the filesystem itself.
     """
     if rows is None:
         rows = recent_session_rows(config_dir, limit=None)

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -75,10 +75,10 @@ from textual.containers import Container
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
-# ``fork_haystack`` is imported rather than restated here: the phone's session
-# search matches over the same rows, and two spellings of "what text does this
-# row have" is how one surface ends up finding a fork the other cannot.
-from local_operator.resume import SessionRow, fork_haystack, format_age
+# The row's searchable text (``fork_haystack``) and the search itself both live
+# in ``session_search`` now: two spellings of "what text does this row have" is
+# how one surface ends up finding a fork the other cannot.
+from local_operator.resume import SessionRow, format_age
 from local_operator.session.search_index import SoftSearchIndex, search_digests
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.terminal_title import SPINNER_FRAMES, SPINNER_INTERVAL_S
@@ -147,15 +147,6 @@ PAGE_ROWS_MAX = 10
 #: REORDERS (a session parking on a gate, with nothing animating) reach the
 #: screen.
 LIVE_REFRESH_INTERVAL_S = 1.0
-
-#: Name/id matches at which the picker stops consulting the bounded soft tier
-#: (see ``SessionPickerScreen._soft_tier_wanted``). Three, not one: a single
-#: exact hit on a name is as often incidental as deliberate — ``spit`` matches
-#: "De\ *spit*\ e" — and treating it as a real answer hid every genuinely
-#: intended match behind it. Measured over 517 vocabulary-drawn typos, this
-#: floor loses no rows against running the tier on every keystroke while
-#: leaving the cursor exactly as stable.
-_PRECISE_HITS_ENOUGH = 3
 
 #: Non-row lines the card always draws: header, rule, blank spacer, the
 #: position counter, and the key hints. Reserved UNCONDITIONALLY (the counter
@@ -363,135 +354,20 @@ COMPLETION_MARKERS: dict[str, tuple[str, str]] = {
 STATE_COL_CELLS = 2
 
 
-def filter_rows(
-    rows: Sequence[SessionRow],
-    query: str,
-    body_matches: AbstractSet[str] | None = None,
-) -> list[SessionRow]:
-    """Rows whose name or id contains ``query``, or whose id is in ``body_matches``.
-
-    A pure MEMBERSHIP filter: it decides which rows are shown and preserves the
-    order it was handed, so on its own it never moves a row under the cursor.
-    Relevance ORDERING lives in :func:`rank_rows`, applied by the screen only
-    when a query is active — keeping the "filtering never reorders" property
-    literally true of this function while the query-scoped ranking sits in the
-    one place that also re-homes the cursor.
-
-    The searchable name is composed by :func:`fork_haystack`, so a row visibly
-    tagged ``[fork]`` is found by typing ``fork`` — the tag is on screen, so it
-    has to be in the index.
-
-    The name/id test stays exact substring: those fields are a sentence the user
-    wrote and a hex id, where an exact match is what a precise query expects.
-    Soft matching (prefix, word-order, bounded typo) is not done here; it is
-    folded into ``body_matches`` by the caller via
-    :func:`local_operator.session.search_index.soft_search_digests`, so a soft
-    hit on the conversation surfaces the row exactly as an exact body hit does.
-
-    ``body_matches`` is the set of ids admitted on their conversation text —
-    exact body, a past name, or a bounded soft match — decided by the caller
-    and passed in rather than computed here, so this function stays pure and
-    cheap enough to run per keystroke, and a caller with no index (a test, an
-    embedder) keeps exactly the old name-and-id behaviour.
-    """
-    needle = query.strip().lower()
-    if not needle:
-        return list(rows)
-    matched = body_matches or frozenset()
-    return [
-        row
-        for row in rows
-        if needle in fork_haystack(row).lower() or needle in row.id.lower() or row.id in matched
-    ]
-
-
-def matched_in_body(row: SessionRow, query: str, body_matches: AbstractSet[str]) -> bool:
-    """True when ``row`` is on screen only because its CONVERSATION matched.
-
-    Drives the body-match marker. A row whose visible name already contains the
-    query needs no explanation; one that does not would otherwise read as the
-    filter returning something arbitrary, which is worse than no marker at all
-    because it makes the whole result set look untrustworthy.
-    """
-    needle = query.strip().lower()
-    if not needle:
-        return False
-    # Same haystack the filter admitted on, so a row surfaced by its VISIBLE
-    # fork tag is not additionally explained as a body match — the tag is
-    # already on the row and the two marks would contradict each other.
-    if needle in fork_haystack(row).lower() or needle in row.id.lower():
-        return False
-    return row.id in body_matches
-
-
-#: Relevance tiers, best (lowest) first, used to sort a FILTERED subset when a
-#: query is active. A tier is a property of ``(query, row)`` alone — it does not
-#: depend on the previous query or on the order rows arrived — which is what
-#: lets ranking coexist with the "no reorder under the cursor" invariant: the
-#: order changes only when the query changes, and a query change already
-#: re-homes the cursor to the top match (see ``set_query``).
-_RANK_NAME = 0  # exact substring in the visible name — the strongest signal
-_RANK_ID = 1  # exact substring in the id
-_RANK_BODY = 2  # exact substring in the body/past-name digest
-_RANK_SOFT = 3  # soft (prefix / token-AND / edit-distance) match only
-
-
-def rank_rows(
-    rows: Sequence[SessionRow],
-    query: str,
-    body_matches: AbstractSet[str] | None = None,
-) -> list[SessionRow]:
-    """``rows`` ordered by relevance to ``query``; recency order when empty.
-
-    Kept SEPARATE from :func:`filter_rows`, which stays a pure membership
-    filter, because the module's invariant is stated about filtering: "filtering
-    narrows; it never reorders". Ordering is a property of the QUERY, not of a
-    keystroke within a query's growth — so it is applied here, in the one place
-    that recomputes per query and re-homes the cursor, and only when a query is
-    active.
-
-    * **Empty query** -> ``rows`` unchanged (recency order, newest first,
-      exactly as today). A fixed query likewise never reorders: the key is a
-      pure function of ``(query, row)``, so repeated repaints and resizes
-      produce byte-for-byte the same order.
-    * **Non-empty query** -> a single deterministic ordering: the tier the row
-      matched in (name > id > body > soft), with recency (mtime desc) as the
-      stable tie-break WITHIN every tier. ``sorted`` is stable, so passing rows
-      already in recency order makes the tie-break free.
-
-    ``body_matches`` is the EXACT-body match set (from ``search_digests``),
-    passed in for the same reason :func:`filter_rows` takes it — this stays pure
-    and cheap, and a caller with no index gets name/id ranking unchanged. It is
-    only the exact-body set, not the soft set: a row in ``rows`` that matched
-    none of name, id, or exact body was admitted by the soft set and so takes
-    the soft tier, which needs no separate membership check.
-    """
-    needle = query.strip().lower()
-    if not needle:
-        return list(rows)
-    body = body_matches or frozenset()
-
-    def tier(row: SessionRow) -> int:
-        # Through the same composition :func:`filter_rows` admits on: a fork
-        # admitted on its tag must rank in the NAME tier, not fall through to
-        # the soft tier and sort below every incidental body hit.
-        if needle in fork_haystack(row).lower():
-            return _RANK_NAME
-        if needle in row.id.lower():
-            return _RANK_ID
-        # Exact body hit outranks a soft-only hit: an exact substring in the
-        # conversation is a stronger signal than a typo/prefix/word-order match.
-        if row.id in body:
-            return _RANK_BODY
-        # Admitted by the soft set (it is in the already-filtered ``rows`` yet
-        # matched neither name, id, nor exact body), so it ranks below every
-        # exact tier.
-        return _RANK_SOFT
-
-    # Stable sort on the tier alone: ``rows`` arrives newest-first, so equal
-    # tiers keep recency order without a second sort key. Sorting the tier as
-    # the only key is what preserves the recency tie-break for free.
-    return sorted(rows, key=tier)
+# ``filter_rows``, ``matched_in_body`` and ``rank_rows`` are RE-EXPORTED from
+# ``local_operator.session.session_search`` rather than defined here: the phone
+# daemon and the desktop catalogue search the same store, and three copies of
+# "what admits a row and what orders it" is how the phone ended up unable to
+# find a typo the picker resolves. The definitions and their rationale (the
+# tiers, the exact-body-versus-soft split, the recency tie-break) live in that
+# one module; this import is what keeps the picker's call sites and its tests
+# pointed at exactly one implementation.
+from local_operator.session.session_search import (  # noqa: E402  (kept beside its callers)
+    filter_rows,
+    matched_in_body,
+    rank_rows,
+    soft_tier_wanted,
+)
 
 
 def _pad_cells(text: str, width: int) -> str:
@@ -1008,76 +884,16 @@ class SessionPickerScreen(ModalScreen[str | None]):
         return self._filtered
 
     def _soft_tier_wanted(self, query: str) -> bool:
-        """Whether the bounded soft tier should run for ``query``.
+        """Whether to run the bounded soft tier for ``query``.
 
-        A pure function of ``(query, rows)``: the tier runs unless the query
-        matched a session's NAME or ID. No run history, no latch, no memory of
-        previous keystrokes — that purity is what keeps the same visible query
-        rendering identically however the user reached it, and it took four
-        attempts to get there (see the module docstring on route independence).
-
-        **Why name/id and not "any exact hit".** Gating on an empty exact result
-        looks equivalent and silently destroys typo search. The exact tier also
-        admits BODY substring hits, and on a real store almost every typed token
-        appears incidentally in some conversation: ``plin`` has 8 body hits,
-        ``gren`` has 1. One incidental hit anywhere in the store then silenced
-        the tier for the whole query, so the typo it exists to rescue could not
-        be found. Measured on typos drawn from the store's own vocabulary, that
-        gate lost the target row outright on 11 of 763 queries and shed 100+
-        rows on 14 — a recall regression against shipped behaviour, wearing the
-        appearance of correct gating.
-
-        A name or id match is different in kind. Those fields are a sentence the
-        user wrote and a hex id they can copy; an exact substring in either is a
-        deliberate, precise hit, and when the user has one they are not asking
-        for fuzzy help. A body substring is not that signal — it is as likely to
-        be the word appearing in passing inside an unrelated conversation.
-
-        Measured over 521 vocabulary-drawn typos against the base behaviour of
-        running the tier on every keystroke:
-
-        ==========================  ============  ==============
-        gate                        recall loss   top-row swaps
-        ==========================  ============  ==============
-        base (tier always runs)     0/521         0/279
-        any exact hit silences it   5/521         3/279
-        this gate (name/id only)    0/521         1/279
-        ==========================  ============  ==============
-
-        So it costs no recall against base while running the expensive tier no
-        more often than base does, and it disrupts the cursor LESS than the
-        gate it replaces.
-
-        What it does not do: prevent the tier engaging on a keystroke where rows
-        are on screen, which can re-home the cursor onto a row the user had not
-        seen. That is bounded (1/279 keystrokes here, against base's 0) and is
-        properly a CURSOR policy question — keep the selection on its row across
-        a re-rank when that row survives — not an ordering one. Ordering cannot
-        fix it without reading run history, which is what reopened route
-        divergence in an earlier round.
+        Delegates to ``session_search.soft_tier_wanted`` — the gate, the tier
+        floor it counts against and the name/id test it mirrors all live there,
+        with the measurements behind the floor. This exists as a method only
+        because the caching in :attr:`visible_rows` reads better with the store
+        it is gating in scope; the picker holds rows the phone and the desktop
+        do not, which is why the predicate takes them as an argument.
         """
-        needle = query.strip().lower()
-        if not needle:
-            return False
-        # Name and id only, deliberately NOT the body digests: see above. This
-        # mirrors the first two admission tests in ``filter_rows`` so the gate
-        # and the filter cannot drift apart on what "an exact hit" means.
-        #
-        # Counted against a small floor rather than tested for emptiness,
-        # because ONE precise hit is not yet a useful answer and can easily be
-        # incidental: ``spit`` matches the name "Failover Triggering Despite
-        # Available Account", and on that single hit the previous form silenced
-        # the tier and made every ``split`` session unreachable. Below the floor
-        # the user has almost nothing to look at, so the extra recall is worth
-        # more than the precision; at or above it they have a real answer and
-        # fuzzy additions would only dilute it.
-        precise = 0
-        for row in self._all:
-            if needle in fork_haystack(row).lower() or needle in row.id.lower():
-                precise += 1
-                if precise >= _PRECISE_HITS_ENOUGH:
-                    return False
-        return True
+        return soft_tier_wanted(self._all, query)
 
     @property
     def body_matched_ids(self) -> set[str]:

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -863,6 +863,14 @@ class SessionPickerScreen(ModalScreen[str | None]):
             # tier and the body-match marker. Both are recomputed only on a
             # query change, never per repaint — scanning 200 digests per paint
             # is the cost this cache exists to avoid.
+            #
+            # This call is UNLOCKED and shares ``search_index``'s process-wide
+            # memo with the server's locked path (``session_search``). Safe only
+            # because the picker is a single thread and no process hosts it
+            # beside a shared-path caller — the TUI does not run the server
+            # in-process. An embedder that did both would need to take
+            # ``session_search._SHARED_LOCK`` around this line, because the memo
+            # is one entry that two threads can interleave.
             self._body_matches = search_digests(self._digests, self._query)
             # The soft tier is expensive on its first call for a given store —
             # it tokenises every digest and builds a vocabulary over them — so

--- a/tests/unit/server/test_desktop_profiles.py
+++ b/tests/unit/server/test_desktop_profiles.py
@@ -208,6 +208,11 @@ async def test_catalogue_is_authenticated_and_never_allocates(api):
     assert not list((root / "sessions").glob("*"))
     features = (await client.get("/v1/capabilities")).json()["result"]["features"]
     assert features["session_catalogue"] == 2
+    # Content search is advertised as its OWN version rather than a bump of the
+    # catalogue: a client can render a catalogue perfectly well against a
+    # backend without the search route, so gating the list on it would hide a
+    # working surface because a newer one is missing.
+    assert features["session_search"] == 1
 
 
 async def test_install_edit_preserves_policy_and_provenance(api):

--- a/tests/unit/server/test_desktop_sessions.py
+++ b/tests/unit/server/test_desktop_sessions.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -759,3 +760,128 @@ async def test_stored_mime_is_allowlisted_before_it_becomes_a_header(tmp_path):
         response = await attachment("0123456789ab", ref.digest, request)
         assert response.media_type == mime
         assert response.body == raw
+
+
+async def _seed_searchable_session(root: Path, session_id: str, *, opener: str, body: str) -> None:
+    """A real canonical session on disk, written through the real transcript.
+
+    Async rather than an ``asyncio.run`` wrapper because every caller already
+    runs inside the event loop the test client owns.
+    """
+    from local_operator.harness.types import Message, TextContent
+    from local_operator.session.transcript import Transcript
+
+    session = root / "sessions" / session_id
+    session.mkdir(parents=True, exist_ok=True)
+    transcript = Transcript(session)
+    for role, text in (("user", opener), ("assistant", body)):
+        await transcript.append_message(
+            Message(role=cast(Any, role), content=[TextContent(text=text)])
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_finds_a_session_by_what_was_said_in_it(tmp_path, monkeypatch):
+    """The whole point of the route: a session whose opener says nothing about
+    the subject it became is still findable by the subject.
+
+    Driven over real loopback HTTP through the app, because the thing being
+    verified is the WIRE contract the desktop chat search consumes — a unit call
+    into the search module would not exercise the route, its auth gate, or the
+    response model.
+    """
+    from fastapi.testclient import TestClient
+
+    from local_operator.server.app import app
+    from local_operator.session.session_search import RANK_BODY
+
+    monkeypatch.setenv("LOCAL_OPERATOR_DESKTOP_TOKEN", "token")
+    monkeypatch.setenv("LOCAL_OPERATOR_HOME", str(tmp_path))
+    await _seed_searchable_session(
+        tmp_path,
+        "aaaa1111",
+        opener="hey can you look at this thing",
+        body="The retention sweep is evicting live session directories.",
+    )
+    app.state.config_manager = SimpleNamespace(config_dir=tmp_path)
+    app.state.desktop_sessions = DesktopSessions(tmp_path)
+
+    with TestClient(app) as client:
+        denied = client.get("/v1/desktop/sessions/search?q=retention")
+        assert denied.status_code in (401, 403)
+        response = client.get(
+            "/v1/desktop/sessions/search?q=retention",
+            headers={"Authorization": "Bearer token"},
+        )
+
+    assert response.status_code == 200, response.text
+    result = response.json()["result"]
+    assert result["query"] == "retention"
+    assert [row["id"] for row in result["sessions"]] == ["aaaa1111"]
+    # The row's own name does not contain the query, so the answer says why it
+    # surfaced rather than leaving the client to guess.
+    assert result["sessions"][0]["body_match"] is True
+    assert result["sessions"][0]["rank"] == RANK_BODY
+    assert result["sessions"][0]["name"] == "hey can you look at this thing"
+
+
+@pytest.mark.asyncio
+async def test_search_is_declared_before_the_session_id_route(tmp_path, monkeypatch):
+    """FastAPI matches in declaration order, so a parent route declared first
+    would swallow ``/v1/desktop/sessions/search`` and answer with a session
+    snapshot (a 404 for an id that does not exist) instead of search results.
+    Pinned on the routing table itself, not on one request's outcome: a later
+    edit that reorders the handlers is what this catches."""
+    from fastapi.testclient import TestClient
+
+    from local_operator.server.app import _iter_routes, app
+
+    paths = [
+        path
+        for path, _methods in _iter_routes(app.routes)
+        if path.startswith("/v1/desktop/sessions")
+    ]
+    assert paths.index("/v1/desktop/sessions/search") < paths.index(
+        "/v1/desktop/sessions/{session_id}"
+    )
+
+    monkeypatch.setenv("LOCAL_OPERATOR_DESKTOP_TOKEN", "token")
+    monkeypatch.setenv("LOCAL_OPERATOR_HOME", str(tmp_path))
+    app.state.config_manager = SimpleNamespace(config_dir=tmp_path)
+    app.state.desktop_sessions = DesktopSessions(tmp_path)
+    with TestClient(app) as client:
+        response = client.get(
+            "/v1/desktop/sessions/search?q=", headers={"Authorization": "Bearer token"}
+        )
+    assert response.status_code == 200, response.text
+    assert response.json()["result"]["sessions"] == []
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_or_invalid_query_is_refused_without_echoing_it(tmp_path, monkeypatch):
+    """The query is bounded at the boundary, and the refusal must not quote the
+    rejected input back: this route sits under `/v1/desktop/`, where pydantic's
+    default 422 body would echo whatever the caller sent."""
+    from fastapi.testclient import TestClient
+
+    from local_operator.server.app import app
+
+    monkeypatch.setenv("LOCAL_OPERATOR_DESKTOP_TOKEN", "token")
+    monkeypatch.setenv("LOCAL_OPERATOR_HOME", str(tmp_path))
+    app.state.config_manager = SimpleNamespace(config_dir=tmp_path)
+    app.state.desktop_sessions = DesktopSessions(tmp_path)
+    secret_looking = "x" * 300
+
+    with TestClient(app) as client:
+        too_long = client.get(
+            f"/v1/desktop/sessions/search?q={secret_looking}",
+            headers={"Authorization": "Bearer token"},
+        )
+        bad_limit = client.get(
+            "/v1/desktop/sessions/search?q=ok&limit=501",
+            headers={"Authorization": "Bearer token"},
+        )
+
+    assert too_long.status_code == 422
+    assert secret_looking not in too_long.text
+    assert bad_limit.status_code == 422

--- a/tests/unit/session/test_session_search.py
+++ b/tests/unit/session/test_session_search.py
@@ -288,7 +288,13 @@ def test_concurrent_searches_do_not_answer_from_each_others_corpus(tmp_path: Pat
     the server calls this module from worker threads. A search built from
     another store's corpus returns the WRONG rows, so the shared path is
     serialized and this pins that two stores searched at once each answer
-    about themselves."""
+    about themselves.
+
+    This is the WEAK half of the pair below: it is a smoke test that the lock
+    does not deadlock or corrupt anything, and it passes with the lock removed.
+    The falsifiable version — which fails when the lock is removed — is
+    :func:`test_the_lock_is_what_keeps_the_shared_memo_from_crossing_stores`.
+    """
     for letter in ("aaa", "bbb"):
         _write(
             tmp_path / letter / "sessions" / f"{letter}1111",
@@ -315,6 +321,72 @@ def test_concurrent_searches_do_not_answer_from_each_others_corpus(tmp_path: Pat
 
     assert errors == []
     assert results == {"aaa": ["aaa1111"], "bbb": ["bbb1111"]}
+
+
+def test_the_lock_is_what_keeps_the_shared_memo_from_crossing_stores(tmp_path: Path, monkeypatch):
+    """The falsifier for the lock, and the reason it is not decoration.
+
+    A smoke test of two concurrent searches (the test above) passes whether or
+    not the lock exists: the race needs a switch point INSIDE
+    ``search_index._lowered``'s window — after it has put this thread's corpus
+    into the process-wide memo and before it returns it — and that window is a
+    few bytecodes wide, so ordinary scheduling almost never lands in it.
+    Measured on the reviewer's machine: 12 wrong (cross-store) answers in 4000
+    concurrent calls with the switch point forced, 0 in 120000 without.
+
+    So the switch point is forced here, exactly as the reviewer forced it: the
+    memo is wrapped to sleep where the race lives and then return whatever is in
+    it NOW. What is exercised is ``_search_shared`` itself — the locked unit —
+    rather than ``search_store``, because the store scan between searches
+    (tens of milliseconds) buries the half-millisecond window: driving the
+    public entry point this way measured 0/80 wrong with the lock REMOVED, a
+    test that cannot fail. With ``_search_shared``'s lock in place each call is
+    atomic over that memo and every answer is about its own store; with the lock
+    removed, each thread intermittently answers with the other store's ids.
+
+    Verified both ways: this passes with the lock, and fails with it removed
+    (``with _SHARED_LOCK:`` replaced by a bare block) — 1 failed, cross-store
+    answers named in the assertion.
+    """
+    import time
+
+    import local_operator.session.search_index as index_mod
+    import local_operator.session.session_search as search_mod
+
+    for letter in ("aaa", "bbb"):
+        _write(
+            tmp_path / letter / "sessions" / f"{letter}1111",
+            ("user", f"the {letter} keyword appears only here"),
+        )
+
+    real_lowered = index_mod._lowered
+
+    def switched(digests: dict[str, str]) -> dict[str, str]:
+        real_lowered(digests)
+        # The switch point. Another thread entering here replaces the global.
+        time.sleep(0.0005)
+        return index_mod._LOWERED
+
+    monkeypatch.setattr(index_mod, "_lowered", switched)
+
+    wrong: list[str] = []
+
+    def run(letter: str) -> None:
+        other = "bbb" if letter == "aaa" else "aaa"
+        for _ in range(40):
+            digests = index_mod.build_index(tmp_path / letter, [f"{letter}1111"])
+            # ``soft=None`` is the SHARED path — the one the server uses.
+            exact, _soft = search_mod._search_shared(digests, f"{letter} keyword", None, False)
+            if exact != {f"{letter}1111"}:
+                wrong.append(f"{letter} answered {sorted(exact)} (other store: {other})")
+
+    threads = [threading.Thread(target=run, args=(letter,)) for letter in ("aaa", "bbb")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert wrong == [], f"cross-store answers: {wrong[:5]}"
 
 
 def test_a_ranked_row_is_the_same_row_the_filter_admitted(tmp_path: Path):

--- a/tests/unit/session/test_session_search.py
+++ b/tests/unit/session/test_session_search.py
@@ -1,0 +1,325 @@
+"""One definition of "which conversation matches", shared by every surface.
+
+The bug these pin: the TUI's ``/resume`` picker could find a session by a word
+said inside it, while the phone's search and the desktop chat search — which
+read the same store, for the same user, from the same machine — could not, and
+neither ranked what it found. ``local_operator.session.session_search`` is now
+the one implementation all three call, so these tests stand on the mechanics
+itself rather than on any one surface: admission (name, id, exact body, bounded
+soft), tiering (name > id > body > soft), the recency tie-break, and the gate
+that decides whether the expensive soft tier runs at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+from local_operator.harness.types import Message, MessageRole, TextContent
+from local_operator.resume import SessionRow, write_session_title
+from local_operator.session.search_index import SoftSearchIndex
+from local_operator.session.session_search import (
+    PRECISE_HITS_ENOUGH,
+    RANK_BODY,
+    RANK_ID,
+    RANK_NAME,
+    RANK_SOFT,
+    filter_rows,
+    matched_in_body,
+    rank_rows,
+    search_rows,
+    search_store,
+    soft_tier_wanted,
+)
+from local_operator.session.transcript import Transcript
+
+
+def _write(session_dir: Path, *turns: tuple[MessageRole, str]) -> None:
+    """Build a real transcript through the real writer, not a hand-rolled file."""
+
+    async def build() -> None:
+        transcript = Transcript(session_dir)
+        for role, text in turns:
+            await transcript.append_message(Message(role=role, content=[TextContent(text=text)]))
+
+    asyncio.run(build())
+
+
+def _row(session_id: str, name: str, mtime: float, *, forked: bool = False) -> SessionRow:
+    return SessionRow(session_id, mtime, name, forked=forked)
+
+
+class SpySoft(SoftSearchIndex):
+    """A soft index that records whether anyone asked it anything."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[str] = []
+
+    def search(self, digests: dict[str, str], query: str) -> set[str]:  # type: ignore[override]
+        self.calls.append(query)
+        return super().search(digests, query)
+
+
+# --- admission and ranking --------------------------------------------------
+
+
+def test_a_name_hit_outranks_a_body_hit_and_recency_does_not_decide_it():
+    """The whole point of the tiers: the row whose LABEL contains the query is
+    the answer, even when an older name hit and a newer body hit compete."""
+    rows = [
+        _row("bbbb2222", "Unrelated work", 300.0),  # newest: body only
+        _row("aaaa1111", "Retention sweep design", 100.0),  # oldest: name
+    ]
+    matches = search_rows(rows, "retention", digests={"bbbb2222": "the retention sweep runs"})
+
+    assert [m.row.id for m in matches] == ["aaaa1111", "bbbb2222"]
+    assert [m.rank for m in matches] == [RANK_NAME, RANK_BODY]
+    # And only the row whose visible name does NOT explain it is marked.
+    assert [m.body_match for m in matches] == [False, True]
+
+
+def test_recency_breaks_ties_within_a_tier():
+    """Rows arrive newest-first, so a stable sort on the tier alone keeps
+    recency order inside every tier — which is what the field expects when two
+    matches are equally relevant."""
+    rows = [
+        _row("cccc3333", "Retention sweep design", 300.0),
+        _row("bbbb2222", "Retention sweep rewrite", 200.0),
+        _row("aaaa1111", "Retention sweep notes", 100.0),
+    ]
+    matches = search_rows(rows, "retention")
+
+    assert [m.row.id for m in matches] == ["cccc3333", "bbbb2222", "aaaa1111"]
+    assert {m.rank for m in matches} == {RANK_NAME}
+
+
+def test_the_id_is_searchable_and_sits_below_the_name():
+    rows = [_row("aaaa1111", "Unrelated", 300.0), _row("bbbb2222", "aaaa1111 report", 100.0)]
+    matches = search_rows(rows, "aaaa1111")
+
+    assert [m.rank for m in matches] == [RANK_NAME, RANK_ID]
+    assert [m.row.id for m in matches] == ["bbbb2222", "aaaa1111"]
+
+
+def test_a_typo_finds_the_row_and_is_marked_as_a_body_match():
+    """``classifer`` -> ``classifier``: the bound that makes a mistyped search
+    work WITHOUT letting unrelated words collide."""
+    rows = [_row("aaaa1111", "Improve ADM Classifier Throughput", 100.0)]
+    digests = {"aaaa1111": "Improve ADM Classifier Throughput the classifier is slow"}
+    matches = search_rows(rows, "classifer", digests=digests)
+
+    assert [m.row.id for m in matches] == ["aaaa1111"]
+    # Ranked as a soft hit, but STILL explained: the visible name does contain
+    # the words, just not the typo as typed, so the row is admitted on its
+    # conversation and says so.
+    assert matches[0].rank == RANK_SOFT
+    assert matches[0].body_match is True
+
+
+def test_word_order_does_not_matter_for_a_soft_match():
+    rows = [_row("aaaa1111", "Throughput classifier work", 100.0)]
+    matches = search_rows(
+        rows,
+        "classifier throughput",
+        digests={"aaaa1111": "throughput classifier work continued"},
+    )
+    assert [m.row.id for m in matches] == ["aaaa1111"]
+
+
+def test_an_unrelated_query_admits_nothing():
+    """The bound on soft matching has to actually bound it: a search that
+    returns every row is indistinguishable from a broken one."""
+    rows = [_row("aaaa1111", "Retention sweep design", 100.0)]
+    assert search_rows(rows, "kubernetes", digests={"aaaa1111": "retention sweep design"}) == []
+
+
+def test_an_empty_query_is_not_a_search():
+    """Every row is the answer, in the order it arrived (recency), with limit
+    honoured and nothing marked as a body match."""
+    rows = [_row("cccc3333", "C", 300.0), _row("bbbb2222", "B", 200.0)]
+    matches = search_rows(rows, "   ", digests={"cccc3333": "c"}, limit=1)
+
+    assert [m.row.id for m in matches] == ["cccc3333"]
+    assert matches[0].rank == RANK_NAME and matches[0].body_match is False
+
+
+def test_a_caller_without_an_index_keeps_the_name_and_id_search():
+    """Degradation, not failure: a host with no digest index (a test, an
+    embedder, a store that could not be digested) still filters by name and id
+    exactly as it did before body search existed."""
+    rows = [_row("aaaa1111", "Retention sweep design", 100.0), _row("bbbb2222", "Other", 50.0)]
+
+    assert [m.row.id for m in search_rows(rows, "retention")] == ["aaaa1111"]
+    assert [m.row.id for m in search_rows(rows, "aaaa1111")] == ["aaaa1111"]
+    assert search_rows(rows, "retention sweep design here") == []
+
+
+def test_a_fork_tag_is_matchable_and_ranks_on_the_name():
+    """What is displayed has to be searchable: a row rendered with ``[fork]``
+    is found by typing it, and it is a precise name hit rather than a fuzzy
+    body one."""
+    rows = [_row("aaaa1111", "Refactor the loader", 100.0, forked=True)]
+    matches = search_rows(rows, "fork")
+
+    assert [m.row.id for m in matches] == ["aaaa1111"]
+    assert matches[0].rank == RANK_NAME
+    assert matched_in_body(matches[0].row, "fork", {"aaaa1111"}) is False
+
+
+# --- the soft-tier gate -----------------------------------------------------
+
+
+def test_the_soft_tier_is_skipped_once_the_name_answers_precisely():
+    """Below the floor the expensive tier runs; at or above it the query is
+    already answered, and fuzzy additions would only dilute it."""
+    rows = [_row(f"id{i}", f"retention sweep {i}", 100.0 - i) for i in range(PRECISE_HITS_ENOUGH)]
+    spy = SpySoft()
+
+    assert soft_tier_wanted(rows, "retention") is False
+    search_rows(rows, "retention", digests={row.id: "body" for row in rows}, soft=spy)
+    assert spy.calls == []
+
+    # One row short of the floor: the tier is consulted, because one precise
+    # hit is as often incidental as deliberate.
+    assert soft_tier_wanted(rows[:-1], "retention") is True
+    search_rows(rows[:-1], "retention", digests={row.id: "body" for row in rows[:-1]}, soft=spy)
+    assert spy.calls == ["retention"]
+
+
+def test_an_incidental_body_hit_does_not_silence_the_tier():
+    """The gate counts NAME and ID hits only. Gating on "did anything match"
+    let one incidental body hit anywhere in the store silence the tier for the
+    whole query, which lost the typo it exists to rescue."""
+    rows = [_row("aaaa1111", "Some unrelated title", 100.0)]
+    digests = {"aaaa1111": "we discussed retention once in passing"}
+
+    assert soft_tier_wanted(rows, "retention") is True
+    # And the row it admits is still ranked as a body hit.
+    matches = search_rows(rows, "retention", digests=digests)
+    assert [m.rank for m in matches] == [RANK_BODY]
+
+
+def test_the_soft_set_admits_a_row_the_exact_tier_missed():
+    """``filter_rows`` takes the caller's admitted set, so folding the soft set
+    in is what puts a typo'd row on screen — the exact body set alone would not
+    have it."""
+    rows = [_row("aaaa1111", "Improve ADM Classifier Throughput", 100.0)]
+    assert filter_rows(rows, "classifer", set()) == []
+    assert [row.id for row in filter_rows(rows, "classifer", {"aaaa1111"})] == ["aaaa1111"]
+
+
+# --- the one-shot store entry point ----------------------------------------
+
+
+def test_search_store_finds_a_session_by_a_word_only_its_conversation_holds(tmp_path: Path):
+    """End to end over a real store: the reported failure, through the entry
+    point the phone and the desktop call."""
+    _write(
+        tmp_path / "sessions" / "aaaa1111",
+        ("user", "hey can you look at this thing"),
+        ("assistant", "The retention sweep is evicting live session directories."),
+    )
+
+    matches = search_store(tmp_path, "retention")
+
+    assert [m.row.id for m in matches] == ["aaaa1111"]
+    # The row's visible name is its opener, which says nothing about retention,
+    # so the row is explained as a body match rather than appearing arbitrary.
+    assert matches[0].row.name == "hey can you look at this thing"
+    assert matches[0].body_match is True
+    assert matches[0].rank == RANK_BODY
+
+
+def test_a_name_the_session_no_longer_wears_is_still_searchable(tmp_path: Path):
+    """A topic-pivot session is findable by the subject it ENDED on. The
+    digest folds every name the session has borne, which is the only reason a
+    word that is now only in its history matches at all."""
+    session = tmp_path / "sessions" / "aaaa1111"
+    _write(session, ("user", "opener"))
+    write_session_title(
+        session,
+        "Cleanup work",
+        user_set=True,
+        past_names=["Cleanup work", "Retention sweep design"],
+    )
+
+    matches = search_store(tmp_path, "retention")
+
+    assert [m.row.id for m in matches] == ["aaaa1111"]
+    # Not the name it is displayed with, so it must say WHY it is here.
+    assert matches[0].row.name == "Cleanup work"
+    assert matches[0].body_match is True
+
+
+def test_search_store_scans_the_whole_store_rather_than_a_page(tmp_path: Path):
+    """A cap would make a session past it unfindable — indistinguishable from
+    one that was deleted — which is the bug the picker documents at its own
+    call site. The only cap here is on the RESULT, never on the scan."""
+    for index in range(6):
+        _write(
+            tmp_path / "sessions" / f"session{index}",
+            ("user", f"unrelated opener {index}"),
+            ("assistant", f"a note about the migration phase {index}"),
+        )
+
+    everything = search_store(tmp_path, "migration")
+    limited = search_store(tmp_path, "migration", limit=2)
+
+    assert len(everything) == 6
+    assert [m.row.id for m in limited] == [m.row.id for m in everything[:2]]
+
+
+def test_search_store_answers_an_empty_query_with_the_store_in_recency_order(tmp_path: Path):
+    for index in range(3):
+        _write(tmp_path / "sessions" / f"session{index}", ("user", f"opener {index}"))
+
+    matches = search_store(tmp_path, "", limit=2)
+
+    assert len(matches) == 2
+    assert all(m.body_match is False for m in matches)
+    # Newest first, the same order the list surface shows.
+    assert [m.row.mtime for m in matches] == sorted((m.row.mtime for m in matches), reverse=True)
+
+
+def test_concurrent_searches_do_not_answer_from_each_others_corpus(tmp_path: Path):
+    """The shared accelerator and the exact-search memo are process-wide, and
+    the server calls this module from worker threads. A search built from
+    another store's corpus returns the WRONG rows, so the shared path is
+    serialized and this pins that two stores searched at once each answer
+    about themselves."""
+    for letter in ("aaa", "bbb"):
+        _write(
+            tmp_path / letter / "sessions" / f"{letter}1111",
+            ("user", f"opener for {letter}"),
+            ("assistant", f"the {letter} keyword appears only here"),
+        )
+
+    results: dict[str, list[str]] = {}
+    errors: list[BaseException] = []
+
+    def run(letter: str) -> None:
+        try:
+            for _ in range(5):
+                hits = search_store(tmp_path / letter, f"{letter} keyword")
+                results[letter] = [m.row.id for m in hits]
+        except BaseException as exc:  # noqa: BLE001 - reported below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run, args=(letter,)) for letter in ("aaa", "bbb")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert results == {"aaa": ["aaa1111"], "bbb": ["bbb1111"]}
+
+
+def test_a_ranked_row_is_the_same_row_the_filter_admitted(tmp_path: Path):
+    """``rank_rows`` must not reorder rows into something the filter would not
+    have shown, and it must not drop one either."""
+    _write(tmp_path / "sessions" / "aaaa1111", ("user", "retention sweep design"))
+    rows = search_store(tmp_path, "", limit=10)
+    assert [row.id for row in rank_rows([m.row for m in rows], "retention")] == ["aaaa1111"]

--- a/tests/unit/session/test_session_search.py
+++ b/tests/unit/session/test_session_search.py
@@ -342,11 +342,17 @@ def test_the_lock_is_what_keeps_the_shared_memo_from_crossing_stores(tmp_path: P
     public entry point this way measured 0/80 wrong with the lock REMOVED, a
     test that cannot fail. With ``_search_shared``'s lock in place each call is
     atomic over that memo and every answer is about its own store; with the lock
-    removed, each thread intermittently answers with the other store's ids.
+    removed, each thread intermittently answers about the other store — which in
+    this fixture means an EMPTY answer, not the other store's ids: the query is
+    store-specific ("the aaa keyword …"), so the other corpus contains nothing
+    that matches it. The failure is still the failure (the answer came from a
+    corpus this search does not own), but the symptom is "found nothing", and
+    saying "answered with the other store's ids" would be wrong here (round 2,
+    R6).
 
-    Verified both ways: this passes with the lock, and fails with it removed
-    (``with _SHARED_LOCK:`` replaced by a bare block) — 1 failed, cross-store
-    answers named in the assertion.
+    Verified both ways: this passes with the lock (5 consecutive runs) and fails
+    with it removed (``with _SHARED_LOCK:`` replaced by a bare block) — 1 failed,
+    ``cross-store answers: ['aaa answered [] (other store: bbb)', …]``.
     """
     import time
 


### PR DESCRIPTION
## Summary of Changes

**The defect.** A conversation could only be found by its `name` — its title, or its opening message — and its id. Neither is what someone remembers a week later. The CLI's `/resume` picker already solved that for the terminal (`session/search_index.py`: a cached, bounded digest of each conversation's prose, matched exactly and then softly for typos/prefixes/word order), and the phone had grown its own weaker copy that matched an EXACT body substring only and ranked nothing. The desktop app had no content search at all. So the same query found a conversation on one surface and not another, which is how this was reported.

This makes the mechanic **one implementation** and puts it on the desktop wire.

### 1. `local_operator/session/session_search.py` — the mechanic, once

Owns admission (name via `fork_haystack` so a row rendered `[fork]` is findable by that tag, id, exact case-insensitive body, and the bounded soft tier), tiering (`NAME > ID > BODY > SOFT`), the recency tie-break, the body-match MARKER (decided against the admitted set, not the exact one, so a soft-only hit is explained too) and the gate that decides whether the expensive soft tier runs at all (`PRECISE_HITS_ENOUGH`, name/id hits only — the measured reasoning moved with it).

- The TUI picker's `filter_rows` / `rank_rows` / `matched_in_body` / `_soft_tier_wanted` are now re-exports/calls into it; its call sites and its tests point at one implementation.
- The phone daemon's `_search_sessions` is one call to `search_store` — it gains the soft tier and ranking it never had, and keeps its wire shape, so the phone needs no change.
- **Concurrency is handled explicitly.** The shared soft index and `search_index._lowered`'s one-entry memo are process-wide and mutated in place, and the server calls this from worker threads (`asyncio.to_thread`). `_lowered` has a genuine check-then-act race — thread A keys on its own digests, thread B replaces the memo, A returns B's corpus — so the shared path is serialized under one lock (a search is single-digit ms; the picker keeps its own unlocked index, single-threaded).

### 2. `GET /v1/desktop/sessions/search?q=&limit=` — content search over HTTP

`q` is bounded at 256 characters (a query is typing, not data), `limit` 1..500, and the scan and index build run off the event loop. Results are best-first with `rank` and `body_match` attached, and the query is ECHOED so a debouncing client can tell which question an answer belongs to when responses land out of order.

- **Declared BEFORE `/v1/desktop/sessions/{session_id}`** — FastAPI matches in declaration order, so a parent route declared first would answer this path with a session snapshot for an id that does not exist. A test asserts the ordering on the routing table, not on one request's outcome.
- The store is scanned **uncapped**, for the reason the picker documents at its own call site: a session past a cap is not merely off-screen, it is unfindable and indistinguishable from one that was deleted. Affordable because the scan is limit-independent and each row is one bounded head read — measured 17 ms for the whole of a 235-session store, 4.8 ms for the warm index, 0.2 ms exact / ~19 ms soft for the query.
- 4xx refusals are the vetted ones: an over-long or malformed query answers 422 with the generic sentence and does not echo the caller's input back, which matters because everything under `/v1/desktop/` is bearer-gated session data.

### 3. `/v1/capabilities` advertises `session_search: 1`

Its own key rather than a bump of `session_catalogue`. A client renders the catalogue perfectly well against a backend without the search route, so gating the list on the search version would hide a working surface because a newer one is missing. A client that cannot negotiate it keeps a name-only search.

## Related Issue(s)

- None filed. Reported as "make the chat search use the same `/resume` mechanic" — the desktop half of that is in `local-operator-ui`.

## Impact

- **Additive.** One new route, one new capability key, three additive response models. No existing route, model or wire shape changes; no config or dependency changes.
- **Behaviour change on the shared path** (deliberate, and the point): the phone's session search now also matches soft (prefix/typo/word-order) and returns results ranked rather than in recency order, and a `body_match` row that matched a PAST name is now marked. Its payload keys are unchanged.
- The picker's behaviour is intended to be byte-identical: the moved code is the same code, and its own 99 tests (including the fork-marker and route-independence cases) pass unchanged.
- `docs/DESKTOP_API.md` documents the endpoint, its bounds, and that a client should skip the call when the capability is absent.

## Testing Details

Local gates (this machine was under heavy load from sibling worktrees, so full-suite evidence is left to CI):

- `flake8` clean, `black 26.1.0 --check` clean, `isort 5.13.2 --check` clean on every touched file.
- `pytest tests/unit/session tests/unit/server tests/unit/test_fork.py tests/unit/test_agent_import_boundary.py` — **2538 passed, 2 skipped**.
- `pytest tests/unit/tui/test_session_picker.py` — **99 passed** (the refactored picker, unchanged).
- New: `tests/unit/session/test_session_search.py` (18) covers the tiers and the recency tie-break, the soft/typo path and its marker, the gate with a spy index (and that an incidental BODY hit does not silence the tier), the no-index degradation, the fork tag, the uncapped scan, and a two-store concurrency test that pins that simultaneous searches cannot answer from each other's corpus.
- New: 3 route tests over real loopback HTTP (`TestClient` against the app, bearer enforced, blinded 422) plus the declaration-order assertion, and the capability assertion.

**Real-path probe** — the isolated backend seeded with six sessions, over real HTTP:

```
$ curl -s -H "Authorization: Bearer …" \
    "http://127.0.0.1:8971/v1/desktop/sessions/search?q=retention&limit=10"
{"result":{"sessions":[
  {"id":"a1b2c3d4e5f1","name":"Retention sweep notes","rank":0,"body_match":false},
  {"id":"a1b2c3d4e5f2","name":"Refactor the loader","rank":2,"body_match":true}
],"query":"retention","limit":10}}

$ curl -s … "…/search?q=classifer"      # a typo, only the soft tier can answer
{"result":{"sessions":[{"id":"a1b2c3d4e5f3","name":"Investigate throughput",
  "rank":3,"body_match":true}],"query":"classifer","limit":10}}
```

The two rows the query must NOT return (the unrelated sessions, and the subagent child whose title contains "retention") are absent, and the row that matched only its conversation says so.


Release: patch — one conversation search shared by every surface (TUI picker, phone daemon, desktop), and a new additive `GET /v1/desktop/sessions/search` with a `session_search` capability for the desktop app's chat search.
