### PR TITLE
chore(release): bump version to 0.54.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.25"
+version = "0.54.26"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window bump, post-v0.54.25. Owner session pid: 4316.

One commit, one file, one line: `pyproject.toml` 0.54.25 → 0.54.26. Rebased onto the merged window head, so the diff against `main` is exactly that line.

Window (derived from commits — `git log v0.54.25..origin/main`, never a `--merges` scan — and re-derived again immediately before tagging):
- #1013 — `revert(tui)`: removes the tool-row padding #1006 landed against the wrong repository (the report was about local-operator-ui's chat transcript, not this TUI's). Merge `a71cf2cfd`.

`git diff v0.54.25..origin/main -- pyproject.toml` is empty, so no other PR consumed this number.

**PATCH** bump: a single revert; nothing clears the minor step-function bar. Gate on #1013: agent review rounds 1-2 terminal, QA rounds 1-2 (round 1 raised one major — the revert had dropped a test-only flake guard, revealed by 2/27 failures on a loaded host, remediated and re-verified with a discriminating canary), CI 17/17 at the merged head.