### PR TITLE
fix(mobile): open a conversation with its subagents collapsed, and keep every ask option reachable

### DIFF
--- a/local_operator/mobile/web/src/components/pending-card.tsx
+++ b/local_operator/mobile/web/src/components/pending-card.tsx
@@ -16,17 +16,37 @@
  * column's foot is clipped with no way to scroll to it. An uncapped card
  * therefore did not merely look bad — a 10-option ask measured 1426px against
  * an 844px viewport, so the last four options and the composer were off screen
- * and unreachable by any gesture. Two guards, the same idiom the todos panel
- * and the sheet use: the card is capped at ~60% of the viewport, and its BODY
- * is a `lo-scroll` scroller, so a long question and a long option list are
- * reached by scrolling inside the card while the composer stays put and the
- * transcript keeps the rest of the column.
+ * and unreachable by any gesture.
  *
- * 60dvh rather than the panels' 40dvh because a question awaiting an answer
- * outranks a task list (branding §7), and rather than a fixed pixel height
- * because the bound has to hold on every phone, not on the one it was measured
- * on. The cap applies to every variant — options, free-text/secret, and the
- * approval's approve/deny pair — because all three overflow the same column.
+ * THREE regions, and which region a thing lives in is the whole contract:
+ *
+ *   meta row   shrink-0, pinned ABOVE the scroller
+ *   body       min-h-0 flex-1 `lo-scroll` — title, detail, options
+ *   controls   shrink-0, pinned BELOW the scroller — and the error line
+ *
+ * The split is what review round 1 bought. Putting the whole body in one
+ * scroller (the first shape of this fix) capped the card correctly and then
+ * let the DECISION scroll out of reach: an approval with a long detail arrived
+ * with `approve` showing 30 of its 44px at 390x844 and 0 of 44px — invisible —
+ * at 360x780, where the uncapped card before it had shown both buttons whole
+ * (U2/Q1). The stale-tap error landed ~26px below the fold for the same reason,
+ * so a refused tap greyed every option out and explained nothing (U3). Content
+ * may scroll; the control that answers the card may not. A long option list can
+ * still cost one gesture to reach its foot — that is inherent to a list longer
+ * than the card — but the thing the user must press never does.
+ *
+ * The title stays INSIDE the scroller with the detail, deliberately: on a phone
+ * a paragraph-length question can outgrow the cap on its own, and pinning it
+ * would rebuild the same unreachable tail the cap exists to prevent. Only the
+ * one-line meta row is pinned, which cannot outgrow anything and is what keeps
+ * the card legible as a decision at the moment of the decision (D2).
+ *
+ * The cap is a fraction of the COLUMN, not of the dynamic viewport — see
+ * `lib/column.ts` for why those are different numbers the moment a keyboard
+ * opens, and for the 360x780 measurement where a `60dvh` card put `send` under
+ * the column's clipped foot (C1/U1). It applies to every variant — options,
+ * free-text/secret, and the approval's approve/deny pair — because all three
+ * overflow the same column.
  *
  * Transient card state (`busy`/`error`/`remember`/free-text draft) lives in
  * component-local `useState`, so it MUST NOT survive from one question to the
@@ -40,9 +60,10 @@
  * this component, because a component cannot key itself; that is why there is
  * no per-field remount key here.
  */
-import { useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { sendCommand } from "../api";
 import { cn } from "../lib/cn";
+import { PENDING_CARD_FRACTION, columnCap } from "../lib/column";
 import type { PendingRequest } from "../types";
 
 /** Turn a raw command error into copy a phone user can act on. The daemon and
@@ -89,6 +110,36 @@ export function PendingCard({
 	const [freeText, setFreeText] = useState("");
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState("");
+
+	/* Whether the body has content below the fold, which drives the bottom fade
+	   (U4). Derived by measurement rather than from the content, because whether
+	   the card overflows depends on the cap, the keyboard and the option count at
+	   once — a 3-option ask does not overflow and must not wear the cue. Measured
+	   on scroll, on resize (the keyboard changes the cap), and on content change
+	   via ResizeObserver, since none of those fire the others. */
+	const scrollerRef = useRef<HTMLDivElement>(null);
+	const [moreBelow, setMoreBelow] = useState(false);
+	const syncOverflow = useCallback(() => {
+		const el = scrollerRef.current;
+		if (!el) return;
+		/* 4px of slack: sub-pixel layout leaves a fraction of a pixel at the true
+		   bottom, which would otherwise keep the fade painted on a fully-read
+		   card and teach the user to distrust it. */
+		setMoreBelow(el.scrollHeight - el.scrollTop - el.clientHeight > 4);
+	}, []);
+	useLayoutEffect(syncOverflow);
+	useEffect(() => {
+		const el = scrollerRef.current;
+		if (!el || typeof ResizeObserver === "undefined") return;
+		const ro = new ResizeObserver(syncOverflow);
+		ro.observe(el);
+		for (const child of Array.from(el.children)) ro.observe(child);
+		window.addEventListener("resize", syncOverflow);
+		return () => {
+			ro.disconnect();
+			window.removeEventListener("resize", syncOverflow);
+		};
+	}, [syncOverflow]);
 
 	const answer = async (fn: () => Promise<unknown>) => {
 		if (busy) return;
@@ -141,50 +192,142 @@ export function PendingCard({
 	   error line sits under buttons that still look live (D7). */
 	const inert = busy || error !== "";
 
+	const optionCount = pending.kind === "approval" ? 0 : pending.options.length;
+
 	return (
 		/* `shrink-0` keeps the card at its content height (up to the cap) rather
 		   than letting the column squeeze it toward nothing when the transcript is
-		   long; `max-h-[60dvh]` is what stops it taking the whole column. The
-		   padding stays on this element so the scrollbar rides the card's inner
-		   edge instead of overlapping the accent border. */
-		<div className="border-accent bg-accent-wash mx-2 flex max-h-[60dvh] shrink-0 flex-col rounded-md border p-2.5">
-			{/* The scroller is the whole card body, question included: on a phone a
-			   paragraph-length question can outgrow the cap on its own, so pinning
-			   it above the scroller would reintroduce the same unreachable tail it
-			   is meant to prevent. `min-h-0` is required — a flex child defaults to
-			   `min-height: auto` and would refuse to shrink below its content,
-			   which is precisely how the card grew past the viewport. */}
-			<div className="lo-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
-			<div className="flex flex-col gap-0.5">
-				<span className="flex items-center justify-between text-meta text-accent">
-					<span>
-						{pending.kind === "approval"
-							? "approval needed"
-							: pending.secret
-								? "secret requested"
-								: "question"}
-					</span>
-					{multiQuestion ? (
-						<span className="font-mono text-mono-sm text-ink-dim">
-							Question {pending.question_index + 1} of{" "}
-							{pending.question_total}
-						</span>
-					) : count > 1 ? (
-						<span className="font-mono text-mono-sm text-ink-dim">
-							1 of {count}
-						</span>
+		   long; the cap is what stops it taking the whole column. The padding
+		   stays on this element so the scrollbar rides the card's inner edge
+		   instead of overlapping the accent border.
+
+		   `data-testid` rather than the accent border class as the test handle:
+		   `border-accent` is also applied by the composer on drag-over and by the
+		   new-session screen on selection, so a class selector picks the wrong
+		   node the first time one of those states renders alongside a card (C5). */
+		<div
+			data-testid="pending-card"
+			style={columnCap(PENDING_CARD_FRACTION)}
+			className="border-accent bg-accent-wash mx-2 flex shrink-0 flex-col rounded-md border p-2.5"
+		>
+			{/* PINNED meta row (D2). One line, fixed height, cannot outgrow
+			    anything — so pinning it costs no reachability while keeping the
+			    card legible as a decision at the moment of the decision. Scrolled
+			    to the option the user means to tap, 0% of the kind label and 0% of
+			    the counter were still on screen; a card that says nothing about
+			    what is being asked is a bare list of buttons.
+
+			    The option total rides here too (U4): the cap trades first-glance
+			    information (6 visible options of 10 became 3 at 390x844) for a
+			    bounded card, and stating the count is the one affordance that
+			    costs no vertical space at all. */}
+			<span className="flex shrink-0 items-center justify-between text-meta text-accent">
+				<span>
+					{pending.kind === "approval"
+						? "approval needed"
+						: pending.secret
+							? "secret requested"
+							: "question"}
+					{optionCount > 0 ? (
+						<span className="text-ink-dim"> · {optionCount} options</span>
 					) : null}
 				</span>
-				<span className="text-body font-medium">{pending.title}</span>
-				{pending.detail ? (
-					<p className="text-body-sm text-ink-muted whitespace-pre-wrap">
-						{pending.detail}
-					</p>
+				{multiQuestion ? (
+					<span className="font-mono text-mono-sm text-ink-dim">
+						Question {pending.question_index + 1} of{" "}
+						{pending.question_total}
+					</span>
+				) : count > 1 ? (
+					<span className="font-mono text-mono-sm text-ink-dim">
+						1 of {count}
+					</span>
+				) : null}
+			</span>
+
+			{/* SCROLLING content: the title, the detail, and the option list.
+			    The title rides inside rather than pinned beside the meta row on
+			    purpose — on a phone a paragraph-length question outgrows the cap
+			    by itself, and pinning it would rebuild the unreachable tail the
+			    cap exists to prevent. `min-h-0` is required: a flex child defaults
+			    to `min-height: auto` and would refuse to shrink below its content,
+			    which is precisely how the card grew past the viewport.
+
+			    `overflow-x-hidden` + `break-words` are the backstop the
+			    transcript's scroller documents for the same reason (C7): option
+			    labels and descriptions are arbitrary agent-supplied strings, and
+			    one long unbroken token would otherwise scroll the card sideways. */}
+			<div
+				ref={scrollerRef}
+				onScroll={syncOverflow}
+				className={cn(
+					"lo-scroll mt-1 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden break-words",
+					/* The one static cue that the card scrolls (U4). The overlay
+					   scrollbar has zero layout width and paints nothing at rest,
+					   so before this the only hint was a half-clipped row — absent
+					   entirely on the approval card, where the clipped thing is a
+					   button. A bottom fade steals no row and reads at arm's
+					   length; it is removed the moment the foot is reached so a
+					   fully-read card does not look truncated. */
+					moreBelow && "lo-fade-b",
+				)}
+			>
+				<div className="flex flex-col gap-0.5">
+					<span className="text-body font-medium">{pending.title}</span>
+					{pending.detail ? (
+						<p className="text-body-sm text-ink-muted whitespace-pre-wrap">
+							{pending.detail}
+						</p>
+					) : null}
+				</div>
+
+				{optionCount > 0 ? (
+					<div className="flex flex-col gap-2">
+						{pending.options.map((opt) => (
+							<button
+								key={opt.label}
+								type="button"
+								disabled={inert}
+								onClick={() => answerAsk(opt.label)}
+								/* Accent-tinted left edge + elevated fill so an option
+								   reads as a tap target, not a static label or a text
+								   field (D2). Disabled dims (D3/D4) — including while an
+								   error is shown, so a stale option stops reading as
+								   live under the message (D7). */
+								className={cn(
+									"flex min-h-11 flex-col justify-center rounded-sm border border-l-2 border-control border-l-accent bg-elevated px-3 py-2 text-left active:bg-accent-wash disabled:opacity-50",
+								)}
+							>
+								<span className="text-body-sm font-medium text-ink">
+									{opt.label}
+								</span>
+								{opt.description ? (
+									<span className="text-body-sm text-ink-muted">
+										{opt.description}
+									</span>
+								) : null}
+							</button>
+						))}
+					</div>
 				) : null}
 			</div>
 
+			{/* PINNED controls (U2/Q1) and the error line (U3), `shrink-0` and
+			    OUTSIDE the scroller. The option list above may cost a gesture to
+			    reach its foot — inherent to a list longer than the card — but the
+			    control that answers the card may not. Inside the scroller, an
+			    approval with a long detail arrived with `approve` showing 30 of
+			    44px at 390x844 and 0 of 44px at 360x780, and the stale-tap error
+			    landed ~26px below the fold because it is appended below wherever
+			    the user is standing.
+
+			    `pr-1.5` keeps the rows clear of the overlay scrollbar's paint band
+			    (D3): the thumb has no layout width, so it painted over the right
+			    edge of `deny` and `send` at `gapToContentEdge = 0`. Only the
+			    control rows carry it — over prose the overlay behaviour is the
+			    app-wide `lo-scroll` idiom and was ruled acceptable, and a gutter
+			    would cost 4px of line length on every card at 360px. */}
 			{pending.kind === "approval" ? (
-				<>
+				<div className="mt-2 flex shrink-0 flex-col gap-2 pr-1.5">
 					<label className="flex min-h-11 items-center gap-2 text-body-sm text-ink-muted select-none">
 						<input
 							type="checkbox"
@@ -212,37 +355,9 @@ export function PendingCard({
 							{busy ? "…" : "deny"}
 						</button>
 					</div>
-				</>
-			) : pending.options.length > 0 ? (
-				<div className="flex flex-col gap-2">
-					{pending.options.map((opt) => (
-						<button
-							key={opt.label}
-							type="button"
-							disabled={inert}
-							onClick={() => answerAsk(opt.label)}
-							/* Accent-tinted left edge + elevated fill so an option
-							   reads as a tap target, not a static label or a text
-							   field (D2). Disabled dims (D3/D4) — including while an
-							   error is shown, so a stale option stops reading as
-							   live under the message (D7). */
-							className={cn(
-								"flex min-h-11 flex-col justify-center rounded-sm border border-l-2 border-control border-l-accent bg-elevated px-3 py-2 text-left active:bg-accent-wash disabled:opacity-50",
-							)}
-						>
-							<span className="text-body-sm font-medium text-ink">
-								{opt.label}
-							</span>
-							{opt.description ? (
-								<span className="text-body-sm text-ink-muted">
-									{opt.description}
-								</span>
-							) : null}
-						</button>
-					))}
 				</div>
-			) : (
-				<div className="flex flex-col gap-1">
+			) : optionCount === 0 ? (
+				<div className="mt-2 flex shrink-0 flex-col gap-1 pr-1.5">
 					<div className="flex gap-2">
 						<input
 							/* No per-field remount key needed: the whole card is keyed
@@ -277,10 +392,11 @@ export function PendingCard({
 						</p>
 					) : null}
 				</div>
-			)}
+			) : null}
 
-			{error ? <p className="text-body-sm text-danger">{error}</p> : null}
-			</div>
+			{error ? (
+				<p className="mt-1 shrink-0 pr-1.5 text-body-sm text-danger">{error}</p>
+			) : null}
 		</div>
 	);
 }

--- a/local_operator/mobile/web/src/components/pending-card.tsx
+++ b/local_operator/mobile/web/src/components/pending-card.tsx
@@ -10,6 +10,24 @@
  * "Question N of M" header and re-renders the next question after each answer
  * (U1).
  *
+ * The card is an UNSHRINKABLE sibling of the transcript inside the session
+ * column, which is `h-dvh overflow-hidden` (screens/session-view.tsx): whatever
+ * height the card claims is taken off the transcript, and anything past the
+ * column's foot is clipped with no way to scroll to it. An uncapped card
+ * therefore did not merely look bad — a 10-option ask measured 1426px against
+ * an 844px viewport, so the last four options and the composer were off screen
+ * and unreachable by any gesture. Two guards, the same idiom the todos panel
+ * and the sheet use: the card is capped at ~60% of the viewport, and its BODY
+ * is a `lo-scroll` scroller, so a long question and a long option list are
+ * reached by scrolling inside the card while the composer stays put and the
+ * transcript keeps the rest of the column.
+ *
+ * 60dvh rather than the panels' 40dvh because a question awaiting an answer
+ * outranks a task list (branding §7), and rather than a fixed pixel height
+ * because the bound has to hold on every phone, not on the one it was measured
+ * on. The cap applies to every variant — options, free-text/secret, and the
+ * approval's approve/deny pair — because all three overflow the same column.
+ *
  * Transient card state (`busy`/`error`/`remember`/free-text draft) lives in
  * component-local `useState`, so it MUST NOT survive from one question to the
  * next: a stale `busy` leaves the next question's options disabled and
@@ -124,7 +142,19 @@ export function PendingCard({
 	const inert = busy || error !== "";
 
 	return (
-		<div className="border-accent bg-accent-wash mx-2 flex flex-col gap-2 rounded-md border p-2.5">
+		/* `shrink-0` keeps the card at its content height (up to the cap) rather
+		   than letting the column squeeze it toward nothing when the transcript is
+		   long; `max-h-[60dvh]` is what stops it taking the whole column. The
+		   padding stays on this element so the scrollbar rides the card's inner
+		   edge instead of overlapping the accent border. */
+		<div className="border-accent bg-accent-wash mx-2 flex max-h-[60dvh] shrink-0 flex-col rounded-md border p-2.5">
+			{/* The scroller is the whole card body, question included: on a phone a
+			   paragraph-length question can outgrow the cap on its own, so pinning
+			   it above the scroller would reintroduce the same unreachable tail it
+			   is meant to prevent. `min-h-0` is required — a flex child defaults to
+			   `min-height: auto` and would refuse to shrink below its content,
+			   which is precisely how the card grew past the viewport. */}
+			<div className="lo-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
 			<div className="flex flex-col gap-0.5">
 				<span className="flex items-center justify-between text-meta text-accent">
 					<span>
@@ -250,6 +280,7 @@ export function PendingCard({
 			)}
 
 			{error ? <p className="text-body-sm text-danger">{error}</p> : null}
+			</div>
 		</div>
 	);
 }

--- a/local_operator/mobile/web/src/components/pending-card.tsx
+++ b/local_operator/mobile/web/src/components/pending-card.tsx
@@ -357,7 +357,28 @@ export function PendingCard({
 					</div>
 				</div>
 			) : optionCount === 0 ? (
-				<div className="mt-2 flex shrink-0 flex-col gap-1 pr-1.5">
+				/* Same footer rhythm as the approval above (design D5), which is
+				   the variant that had one: `gap-2` between a grounding non-control
+				   row and the controls, and the card's own `p-2.5` as the only
+				   thing below them. Measured before this, the two cards' footers
+				   sat on different ground — the approval's controls opened 60px
+				   below the scroller with the `remember` row between, while the
+				   secret's input sat 8px under text that scrolls beneath it with
+				   nothing between, and its reassurance line hanging BELOW the
+				   controls made the card bottom-heavy at 32.4px against the
+				   approval's 11px.
+
+				   The reassurance line is what grounds this footer, so it moves
+				   ABOVE the input rather than a hairline being added beside it: a
+				   second divider idiom next to the approval's row is the
+				   competing-patterns bug, and a warning about a credential is one
+				   a user should read BEFORE pasting it, not after. */
+				<div className="mt-2 flex shrink-0 flex-col gap-2 pr-1.5">
+					{pending.secret ? (
+						<p className="text-meta text-ink-dim">
+							secret — sent directly, not shown in the transcript
+						</p>
+					) : null}
 					<div className="flex gap-2">
 						<input
 							/* No per-field remount key needed: the whole card is keyed
@@ -386,11 +407,6 @@ export function PendingCard({
 							{busy ? "…" : "send"}
 						</button>
 					</div>
-					{pending.secret ? (
-						<p className="text-meta text-ink-dim">
-							secret — sent directly, not shown in the transcript
-						</p>
-					) : null}
 				</div>
 			) : null}
 

--- a/local_operator/mobile/web/src/components/subagents-panel.tsx
+++ b/local_operator/mobile/web/src/components/subagents-panel.tsx
@@ -14,8 +14,17 @@
  * The previous default was `running > 0`, which made "a subagent is working"
  * — the normal state of a coordinating session — the trigger for covering the
  * screen. The count in the header carries that signal without the cost.
+ *
+ * The header carries FAILURES as well as the running count, which the glyphs
+ * used to carry on their own. Collapsing by default is right, but it hid the
+ * one status a user must not miss: 3 of 22 agents failed rendered exactly like
+ * a healthy fan-out, `subagents 1/22 running`, with no ✗ anywhere on screen and
+ * the word "failed" absent from the page (U5). `· 3 failed` in `text-danger`
+ * restores that at a glance and costs no vertical space.
  */
+import { useRef } from "react";
 import { cn } from "../lib/cn";
+import { PANEL_FRACTION, columnCap } from "../lib/column";
 import { formatElapsed } from "../lib/format";
 import { navigate } from "../router";
 import type { SubagentRow } from "../types";
@@ -86,20 +95,31 @@ export function AgentRoster({
 	sessionId,
 	subagents,
 	parentJobId,
-	collapsible = false,
 	embedded = false,
 	label = "subagents",
+	forceCollapsed = false,
 }: {
 	sessionId: string;
 	subagents: SubagentRow[];
 	parentJobId: string | null;
-	collapsible?: boolean;
 	embedded?: boolean;
 	label?: string;
+	/** Collapse and refuse to expand while something needs a decision — see
+	    the session view's panel-budget comment (D1). */
+	forceCollapsed?: boolean;
 }) {
 	const direct = subagents.filter((agent) => agent.parent_job_id === parentJobId);
+	/* The body's own scroll offset, kept OUTSIDE the collapsed body. `Disclosure`
+	   unmounts its children, so a user who scrolled to row 21, collapsed the
+	   panel to read the conversation and re-expanded was returned to row 1 with
+	   22 rows to re-scroll (U6). A ref, not state: restoring it must not repaint,
+	   and it is per mounted roster rather than per session, which is the right
+	   lifetime — a route change should not resurrect a stale offset. */
+	const scrollTopRef = useRef(0);
+	const bodyRef = useRef<HTMLDivElement>(null);
 	if (direct.length === 0) return null;
 	const running = direct.filter((agent) => agent.status === "running").length;
+	const failed = direct.filter((agent) => agent.status === "failed").length;
 	const rows = (
 		<div className="flex w-full flex-col gap-1 pb-2">
 			{direct.map((agent) => (
@@ -107,32 +127,52 @@ export function AgentRoster({
 			))}
 		</div>
 	);
-	/* The non-collapsible roster is always the whole point of the surface
-	   hosting it, so it is left uncapped: a nested scroller inside a page that
-	   already scrolls is the two-competing-patterns bug the Disclosure docstring
-	   warns about. The cap belongs where the roster is a SECONDARY panel above a
-	   transcript, which is exactly the collapsible case below. */
-	if (!collapsible) return <section className={cn("border-t border-hairline", embedded ? "pt-1" : "px-3")}>{rows}</section>;
 	return (
 		<Disclosure
 			/* Collapsed by default, including when agents are running: see the
 			   module docstring. `running > 0` opened the roster on arrival for
 			   every coordinating session. */
 			defaultOpen={false}
-			className="border-t border-hairline px-3"
+			forceClosed={forceCollapsed}
+			className={cn(
+				"border-t border-hairline",
+				/* `min-h-0` so this panel can give space back to the column
+				   instead of pushing a sibling past its clipped foot (D1). */
+				"min-h-0",
+				embedded ? "pt-1" : "px-3",
+			)}
 			header={
 				<span className="text-body-sm text-ink-muted">
 				{label}{" "}
 					<span className="font-mono text-mono-sm text-ink-dim">
 						{running}/{direct.length} running
 					</span>
+					{failed > 0 ? (
+						<span className="font-mono text-mono-sm text-danger">
+							{" "}· {failed} failed
+						</span>
+					) : null}
 				</span>
 			}
 		>
-			{/* Capped to ~40% of the viewport and scrolls internally, the same
+			{/* Capped to a fraction of the COLUMN and scrolls internally, the same
 			   bound the todos panel uses: a 22-row roster can never crowd out the
-			   messages, even fully expanded. */}
-			<div className="lo-scroll max-h-[40dvh] overflow-y-auto">{rows}</div>
+			   messages, even fully expanded. Column units rather than `dvh` — see
+			   `lib/column.ts`; the two diverge while the keyboard is open, and a cap
+			   that does not tighten with the column is not a cap. */}
+			<div
+				ref={(el) => {
+					bodyRef.current = el;
+					if (el) el.scrollTop = scrollTopRef.current;
+				}}
+				onScroll={() => {
+					scrollTopRef.current = bodyRef.current?.scrollTop ?? 0;
+				}}
+				style={columnCap(PANEL_FRACTION)}
+				className="lo-scroll overflow-y-auto"
+			>
+				{rows}
+			</div>
 		</Disclosure>
 	);
 }
@@ -141,16 +181,18 @@ export function AgentRoster({
 export function SubagentsPanel({
 	subagents,
 	pid = "",
+	forceCollapsed = false,
 }: {
 	subagents: SubagentRow[];
 	pid?: string;
+	forceCollapsed?: boolean;
 }) {
 	return (
 		<AgentRoster
 			sessionId={pid}
 			subagents={subagents}
 			parentJobId={null}
-			collapsible
+			forceCollapsed={forceCollapsed}
 		/>
 	);
 }

--- a/local_operator/mobile/web/src/components/subagents-panel.tsx
+++ b/local_operator/mobile/web/src/components/subagents-panel.tsx
@@ -28,7 +28,7 @@ import { PANEL_FRACTION, columnCap } from "../lib/column";
 import { formatElapsed } from "../lib/format";
 import { navigate } from "../router";
 import type { SubagentRow } from "../types";
-import { Disclosure } from "./ui/disclosure";
+import { Disclosure, HELD_DIM } from "./ui/disclosure";
 
 export const AGENT_GLYPH: Record<SubagentRow["status"], string> = {
 	running: "⟳",
@@ -143,9 +143,19 @@ export function AgentRoster({
 			)}
 			header={
 				<span className="text-body-sm text-ink-muted">
-				{label}{" "}
-					<span className="font-mono text-mono-sm text-ink-dim">
-						{running}/{direct.length} running
+					{/* The held-shut dim is applied per PART, and the failure count
+					    is deliberately a SIBLING of the dimmed span rather than a
+					    child of it: opacity composites the whole subtree, so a dim
+					    any higher takes the count with it — 7.08:1 down to 3.30:1,
+					    measured from the painted frame (design D4). The label and
+					    running count may fade, because a pending card already
+					    implies the roster is held; a failed fan-out may not, and it
+					    matters most while a decision is waiting. */}
+					<span className={cn(forceCollapsed && HELD_DIM)}>
+						{label}{" "}
+						<span className="font-mono text-mono-sm text-ink-dim">
+							{running}/{direct.length} running
+						</span>
 					</span>
 					{failed > 0 ? (
 						<span className="font-mono text-mono-sm text-danger">

--- a/local_operator/mobile/web/src/components/subagents-panel.tsx
+++ b/local_operator/mobile/web/src/components/subagents-panel.tsx
@@ -142,7 +142,29 @@ export function AgentRoster({
 				embedded ? "pt-1" : "px-3",
 			)}
 			header={
-				<span className="text-body-sm text-ink-muted">
+				/* A FLEX line, not inline text, so the row has an explicit order of
+				   who yields first. Held shut, this row carries three claims on one
+				   44px line — label + running count, the failure count, and the
+				   `· answer first` hint — and at 360px wide (a supported viewport)
+				   they add up to within ~6px of the width. Something has to give. As
+				   inline text nothing could: `truncate` needs a block box to clip, so
+				   the label just wrapped, and the LAST inline content — the danger
+				   count — was what broke across two lines at a two-digit count
+				   (`· 10 failed`), the one glyph U5 and D4 exist to protect. Flex lets
+				   the label absorb the pressure instead.
+
+				   `relative` restores the PAINT ORDER that inline text got for free.
+				   Below the viewport ladder the column is height-starved, this panel's
+				   container collapses to ~12px and the pending card — a LATER sibling —
+				   overlaps the row. As inline content the header always drew above that
+				   card's background, because CSS paints in-flow block backgrounds before
+				   inline content. Flex blockifies these children and moves them into the
+				   block phase, where tree order decides and the later card wins:
+				   measured at 320x568, the count went to 0 painted danger-red pixels
+				   while keeping its box. Positioning lifts the row back above in-flow
+				   block backgrounds; no z-index, since paint phase is the whole
+				   problem. */
+				<span className="relative flex min-w-0 items-baseline gap-1 text-body-sm text-ink-muted">
 					{/* The held-shut dim is applied per PART, and the failure count
 					    is deliberately a SIBLING of the dimmed span rather than a
 					    child of it: opacity composites the whole subtree, so a dim
@@ -150,16 +172,25 @@ export function AgentRoster({
 					    measured from the painted frame (design D4). The label and
 					    running count may fade, because a pending card already
 					    implies the roster is held; a failed fan-out may not, and it
-					    matters most while a decision is waiting. */}
-					<span className={cn(forceCollapsed && HELD_DIM)}>
+					    matters most while a decision is waiting.
+
+					    `min-w-0 truncate` makes the label the span that YIELDS: it is
+					    the only one here that degrades gracefully, because a clipped
+					    label still reads and the tail it loses is recoverable by
+					    opening the panel. This is the mechanism the hint's `shrink-0`
+					    in `disclosure.tsx` already assumes exists. */}
+					<span className={cn("min-w-0 truncate", forceCollapsed && HELD_DIM)}>
 						{label}{" "}
 						<span className="font-mono text-mono-sm text-ink-dim">
 							{running}/{direct.length} running
 						</span>
 					</span>
 					{failed > 0 ? (
-						<span className="font-mono text-mono-sm text-danger">
-							{" "}· {failed} failed
+						/* `shrink-0 whitespace-nowrap`: the count is the row's least
+						   expendable token, so it neither shrinks nor breaks between
+						   `10` and `failed`. Undimmed at 7.08:1 per D4. */
+						<span className="shrink-0 font-mono text-mono-sm whitespace-nowrap text-danger">
+							· {failed} failed
 						</span>
 					) : null}
 				</span>

--- a/local_operator/mobile/web/src/components/subagents-panel.tsx
+++ b/local_operator/mobile/web/src/components/subagents-panel.tsx
@@ -1,3 +1,20 @@
+/**
+ * Subagent roster: collapsible, one line per agent, shared by the session
+ * screen's root roster and every descendant roster on the agent screen.
+ *
+ * Same phone constraint the todos panel documents, and the same two guards.
+ * The roster sits ABOVE the transcript in the session column, so a roster
+ * expanded on arrival pushes the conversation off the top: a real session with
+ * `subagents 1/22 running` painted 22 rows and left the transcript a 16px
+ * sliver with the composer off screen entirely. It therefore starts COLLAPSED
+ * (the header's `n/m running` count is the at-a-glance signal; tap to work the
+ * list) and its expanded body is capped to ~40% of the viewport with internal
+ * scrolling, so even a long fan-out can never crowd out the messages.
+ *
+ * The previous default was `running > 0`, which made "a subagent is working"
+ * — the normal state of a coordinating session — the trigger for covering the
+ * screen. The count in the header carries that signal without the cost.
+ */
 import { cn } from "../lib/cn";
 import { formatElapsed } from "../lib/format";
 import { navigate } from "../router";
@@ -90,10 +107,18 @@ export function AgentRoster({
 			))}
 		</div>
 	);
+	/* The non-collapsible roster is always the whole point of the surface
+	   hosting it, so it is left uncapped: a nested scroller inside a page that
+	   already scrolls is the two-competing-patterns bug the Disclosure docstring
+	   warns about. The cap belongs where the roster is a SECONDARY panel above a
+	   transcript, which is exactly the collapsible case below. */
 	if (!collapsible) return <section className={cn("border-t border-hairline", embedded ? "pt-1" : "px-3")}>{rows}</section>;
 	return (
 		<Disclosure
-			defaultOpen={running > 0}
+			/* Collapsed by default, including when agents are running: see the
+			   module docstring. `running > 0` opened the roster on arrival for
+			   every coordinating session. */
+			defaultOpen={false}
 			className="border-t border-hairline px-3"
 			header={
 				<span className="text-body-sm text-ink-muted">
@@ -104,7 +129,10 @@ export function AgentRoster({
 				</span>
 			}
 		>
-			{rows}
+			{/* Capped to ~40% of the viewport and scrolls internally, the same
+			   bound the todos panel uses: a 22-row roster can never crowd out the
+			   messages, even fully expanded. */}
+			<div className="lo-scroll max-h-[40dvh] overflow-y-auto">{rows}</div>
 		</Disclosure>
 	);
 }

--- a/local_operator/mobile/web/src/components/todos-panel.tsx
+++ b/local_operator/mobile/web/src/components/todos-panel.tsx
@@ -16,6 +16,7 @@
  * pre-phase flat list, matching the TUI's `_IMPLICIT_PHASE` rule.
  */
 import { cn } from "../lib/cn";
+import { PANEL_FRACTION, columnCap } from "../lib/column";
 import type { TodoItem, TodoPhase } from "../types";
 import { Disclosure } from "./ui/disclosure";
 
@@ -72,9 +73,13 @@ function TodoRow({ t }: { t: TodoItem }) {
 export function TodosPanel({
 	todos,
 	embedded = false,
+	forceCollapsed = false,
 }: {
 	todos: TodoPhase[];
 	embedded?: boolean;
+	/** Held shut while something needs a decision — see the session view's
+	    panel-budget comment (D1). A task list does not outrank a question. */
+	forceCollapsed?: boolean;
 }) {
 	const items = todos.flatMap((p) => p.items);
 	const done = items.filter((t) => CLOSED.has(t.status)).length;
@@ -89,7 +94,14 @@ export function TodosPanel({
 			   screen. The header's count is the at-a-glance signal; tap to work
 			   the list. */
 			defaultOpen={false}
-			className={cn("border-t border-hairline", embedded ? "pt-1" : "px-4")}
+			forceClosed={forceCollapsed}
+			className={cn(
+				"border-t border-hairline",
+				/* `min-h-0` so this panel can give space back to the column rather
+				   than pushing a sibling past its clipped foot (D1). */
+				"min-h-0",
+				embedded ? "pt-1" : "px-4",
+			)}
 			header={
 				<span className="text-body-sm text-ink-muted">
 					tasks{" "}
@@ -99,9 +111,15 @@ export function TodosPanel({
 				</span>
 			}
 		>
-			{/* Capped to ~40% of the viewport and scrolls internally: a long
-			   list can never crowd out the messages, even fully expanded. */}
-			<div className="lo-scroll flex max-h-[40dvh] flex-col gap-1 overflow-y-auto pb-2">
+			{/* Capped to a fraction of the COLUMN and scrolls internally: a long
+			   list can never crowd out the messages, even fully expanded. Column
+			   units rather than `dvh` — see `lib/column.ts`; the two diverge while
+			   the keyboard is open, and a cap that does not tighten with the column
+			   is not a cap. */}
+			<div
+				style={columnCap(PANEL_FRACTION)}
+				className="lo-scroll flex flex-col gap-1 overflow-y-auto pb-2"
+			>
 				{headerless
 					? todos[0].items.map((t, i) => (
 							/* pl-5 aligns items with the panel gutter, same as

--- a/local_operator/mobile/web/src/components/todos-panel.tsx
+++ b/local_operator/mobile/web/src/components/todos-panel.tsx
@@ -106,16 +106,28 @@ export function TodosPanel({
 				/* Dimmed here rather than on the Disclosure's button — see HELD_DIM.
 				   This panel has nothing that must stay at full contrast while held,
 				   but it takes the dim the same way the roster does so the two held
-				   headers read as one state rather than two treatments. */
-				<span
+				   headers read as one state rather than two treatments.
+
+					  `min-w-0 truncate` for the same reason the roster's label carries
+						 it: held shut, this row also gains the `· answer first` hint, and
+						 the hint is `shrink-0`. The label must therefore be the span that
+					  yields, or the row wraps onto a second line and spends a row of a
+				   budget measured in rows. `truncate` needs a box to clip, which an
+					  inline span does not have — hence the flex line, and `relative`
+					   with it: flex blockifies these children, which drops them out of
+						  the inline paint phase that kept a header above an overlapping
+						 later sibling's background. See the roster's fuller note. */
+						<span
 					className={cn(
-						"text-body-sm text-ink-muted",
+						"relative flex min-w-0 items-baseline gap-1 text-body-sm text-ink-muted",
 						forceCollapsed && HELD_DIM,
 					)}
 				>
-					tasks{" "}
-					<span className="font-mono text-mono-sm text-ink-dim">
-						{done}/{items.length}
+					<span className="min-w-0 truncate">
+						tasks{" "}
+						<span className="font-mono text-mono-sm text-ink-dim">
+							{done}/{items.length}
+						</span>
 					</span>
 				</span>
 			}

--- a/local_operator/mobile/web/src/components/todos-panel.tsx
+++ b/local_operator/mobile/web/src/components/todos-panel.tsx
@@ -18,7 +18,7 @@
 import { cn } from "../lib/cn";
 import { PANEL_FRACTION, columnCap } from "../lib/column";
 import type { TodoItem, TodoPhase } from "../types";
-import { Disclosure } from "./ui/disclosure";
+import { Disclosure, HELD_DIM } from "./ui/disclosure";
 
 const GLYPH: Record<TodoItem["status"], string> = {
 	pending: "☐",
@@ -103,7 +103,16 @@ export function TodosPanel({
 				embedded ? "pt-1" : "px-4",
 			)}
 			header={
-				<span className="text-body-sm text-ink-muted">
+				/* Dimmed here rather than on the Disclosure's button — see HELD_DIM.
+				   This panel has nothing that must stay at full contrast while held,
+				   but it takes the dim the same way the roster does so the two held
+				   headers read as one state rather than two treatments. */
+				<span
+					className={cn(
+						"text-body-sm text-ink-muted",
+						forceCollapsed && HELD_DIM,
+					)}
+				>
 					tasks{" "}
 					<span className="font-mono text-mono-sm text-ink-dim">
 						{done}/{items.length}

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -342,6 +342,31 @@ export function Transcript({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [growthSignal]);
 
+	/* Follow the tail when the SCROLLER ITSELF is resized, not just when content
+	   arrives. The effect above triggers on new content, and a container that
+	   shrinks under stationary content is not new content — so expanding a panel
+	   beside the transcript silently cost the live tail: the scroller went from
+	   612px to 274px and the newest messages slid 156px below the fold with no
+	   scroll of the user's own, visible rows going [0..5] → [0..3] (U6).
+	   Collapsing the panel restored it, which made "close the thing you opened"
+	   the only way back to the conversation.
+
+	   A ResizeObserver here rather than a callback from each panel: the panels
+	   are one cause among several (the pending card claiming its space, the
+	   working line appearing, the keyboard re-pinning the column), and a
+	   per-caller notification fixes whichever cause someone remembered to wire.
+	   Gated on `pinnedRef` exactly like the content path, so a user reading
+	   history is never yanked to the bottom by a resize either. */
+	useEffect(() => {
+		const el = scrollRef.current;
+		if (!el || typeof ResizeObserver === "undefined") return;
+		const ro = new ResizeObserver(() => {
+			if (pinnedRef.current) el.scrollTop = el.scrollHeight;
+		});
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, []);
+
 	/* Prepending older rows must NOT move the viewport: capture the scroll
 	   offset relative to the top of the OLD content, then restore it after the
 	   prepend so the row the user was reading stays put. */

--- a/local_operator/mobile/web/src/components/ui/disclosure.tsx
+++ b/local_operator/mobile/web/src/components/ui/disclosure.tsx
@@ -3,6 +3,11 @@
  * competing patterns is a bug). The chevron SWAPS between right and down
  * glyphs; it never rotates, because a rotating chevron animates a pixel
  * shape that was designed to point one way.
+ *
+ * `forceClosed` is part of this one idiom on purpose. The session column needs
+ * its panels shut while a request is pending, and the alternative — a second
+ * collapse mechanism beside this one, or lifting every panel's open state into
+ * the screen — is exactly the competing-patterns bug above.
  */
 import { useState, type ReactNode } from "react";
 import { cn } from "../../lib/cn";
@@ -22,33 +27,46 @@ export function Disclosure({
 	header,
 	children,
 	defaultOpen = false,
+	forceClosed = false,
 	className,
 	headerClassName,
 }: {
 	header: ReactNode;
 	children: ReactNode;
 	defaultOpen?: boolean;
+	/** Hold the panel shut regardless of its own state. The one caller is the
+	    session column while a request is pending (see session-view): a panel
+	    that expands beside a decision card pushes the decision off a column
+	    that cannot scroll. The panel's own state is preserved rather than
+	    reset, so answering the question returns the user to what they opened. */
+	forceClosed?: boolean;
 	className?: string;
 	headerClassName?: string;
 }) {
 	const [open, setOpen] = useState(defaultOpen);
+	const shown = open && !forceClosed;
 	return (
 		<div className={className}>
 			<button
 				type="button"
-				aria-expanded={open}
-				onClick={() => setOpen(!open)}
+				aria-expanded={shown}
+				disabled={forceClosed}
+				onClick={() => setOpen(!shown)}
 				className={cn(
 					/* The compact label stays unchanged while the hit box matches the
 					   navigation controls users alternate with on a phone. */
 					"flex min-h-11 w-full items-center gap-1 text-left select-none",
+					/* Held shut reads as inert rather than broken: the count stays
+					   legible, the chevron stops inviting a tap that would do
+					   nothing. */
+					forceClosed && "opacity-60",
 					headerClassName,
 				)}
 			>
-				<Chevron open={open} />
+				<Chevron open={shown} />
 				{header}
 			</button>
-			{open ? children : null}
+			{shown ? children : null}
 		</div>
 	);
 }

--- a/local_operator/mobile/web/src/components/ui/disclosure.tsx
+++ b/local_operator/mobile/web/src/components/ui/disclosure.tsx
@@ -12,6 +12,25 @@
 import { useState, type ReactNode } from "react";
 import { cn } from "../../lib/cn";
 
+/**
+ * The dim that says "held shut, not broken" — applied per PART, never to the
+ * header button as a whole.
+ *
+ * It began on the button and cannot stay there. `opacity` composites the whole
+ * subtree and a descendant cannot undo it, so a blanket dim also dims the
+ * roster's failure count: measured from the painted frame at 3.30:1 against the
+ * card's background where the undimmed count is 7.08:1 (design D4). A failed
+ * fan-out matters most in exactly the state that dimmed it — the user is being
+ * asked for a decision. WCAG's inactive-control exemption does cover a
+ * `disabled` header, so this is not a conformance defect; it is the dim taxing
+ * the one glyph U5 exists to surface.
+ *
+ * Each header therefore opts its own parts in, and anything that must stay
+ * legible while held simply does not carry it. That is the only thing that
+ * works given how opacity composites.
+ */
+export const HELD_DIM = "opacity-60";
+
 export function Chevron({ open, className }: { open: boolean; className?: string }) {
 	return (
 		<span
@@ -38,7 +57,10 @@ export function Disclosure({
 	    session column while a request is pending (see session-view): a panel
 	    that expands beside a decision card pushes the decision off a column
 	    that cannot scroll. The panel's own state is preserved rather than
-	    reset, so answering the question returns the user to what they opened. */
+	    reset, so answering the question returns the user to what they opened.
+
+	    The header it renders must stay readable while held — see HELD_DIM: the
+	    dim is applied by each header to its own parts, not to this button. */
 	forceClosed?: boolean;
 	className?: string;
 	headerClassName?: string;
@@ -51,20 +73,34 @@ export function Disclosure({
 				type="button"
 				aria-expanded={shown}
 				disabled={forceClosed}
+				/* Dimmed-and-inert is the same vocabulary this product uses for
+				   "busy", so a tap that does nothing reads as a fault rather than
+				   as a rule (UX U8). The rule is stated in the header itself
+				   rather than in a `title` alone, because a phone has no hover and
+				   a long-press on a disabled control surfaces nothing. */
+				title={
+					forceClosed
+						? "Held shut while a question is waiting — answer it to reopen this panel."
+						: undefined
+				}
 				onClick={() => setOpen(!shown)}
 				className={cn(
 					/* The compact label stays unchanged while the hit box matches the
 					   navigation controls users alternate with on a phone. */
 					"flex min-h-11 w-full items-center gap-1 text-left select-none",
-					/* Held shut reads as inert rather than broken: the count stays
-					   legible, the chevron stops inviting a tap that would do
-					   nothing. */
-					forceClosed && "opacity-60",
 					headerClassName,
 				)}
 			>
-				<Chevron open={shown} />
+				{/* The chevron stops inviting a tap that would do nothing. */}
+				<Chevron open={shown} className={cn(forceClosed && HELD_DIM)} />
 				{header}
+				{forceClosed ? (
+					/* Says why it is inert, in the row itself, at no vertical cost.
+					   `shrink-0` so a long panel label truncates before this does —
+					   the panel budget this state enforces is measured in rows, so
+					   the explanation must not wrap the header onto a second one. */
+					<span className="shrink-0 text-meta text-ink-dim">· answer first</span>
+				) : null}
 			</button>
 			{shown ? children : null}
 		</div>

--- a/local_operator/mobile/web/src/lib/column.ts
+++ b/local_operator/mobile/web/src/lib/column.ts
@@ -1,0 +1,53 @@
+/**
+ * The session column's height budget — the one place the phone's bounded
+ * regions agree on what they are bounded BY.
+ *
+ * Every capped region in the session column (the pending card, the todos and
+ * subagent panels) has to be measured against that column, and `dvh` is not
+ * that column. `screens/session-view.tsx` pins the column to
+ * `visualViewport.height` in px so the composer stays above the iOS keyboard,
+ * while `dvh` follows the DYNAMIC viewport — and a virtual keyboard is an
+ * overlay, so it shrinks the first and leaves the second alone (`index.html`
+ * sets no `interactive-widget`, so the spec default `resizes-visual` applies).
+ * The two agree only while no keyboard is open.
+ *
+ * That divergence is not theoretical. A `60dvh` card stayed 468px tall inside a
+ * column that had fallen to 480px on a 360x780 phone with a 300px keyboard, and
+ * `send` — the only way to submit a free-text or secret answer — went under the
+ * column's clipped foot (the column is `overflow-hidden`) with no gesture that
+ * recovered it. Same arithmetic at 390x844 with a 260px keyboard.
+ *
+ * So the caps are written against `--lo-vvh`, which the session view publishes
+ * from the SAME `visualViewport` handler that pins the column — one number, one
+ * writer, so a cap cannot drift from the box it bounds. `100dvh` is the
+ * fallback for a browser without `visualViewport` and for a surface outside the
+ * column, which is the pre-pin behaviour rather than a new one.
+ *
+ * These are inline styles rather than Tailwind arbitrary values on purpose.
+ * The fraction is a layout contract shared by three components, so it belongs
+ * in one named constant instead of being retyped as a class string in each —
+ * and a class string is also unassertable: the vitest layer runs under
+ * happy-dom with no stylesheet, so `getComputedStyle` on a Tailwind class
+ * returns "". A round-1 review shipped a broken cap past four assertions that
+ * only compared class names. An inline style resolves, so a cap that stops
+ * tracking the column fails a test.
+ */
+
+/** The custom property the session view publishes its pinned height as. */
+export const COLUMN_HEIGHT_VAR = "--lo-vvh";
+
+/**
+ * A question awaiting an answer outranks a task list (branding §7), so the
+ * card may claim more of the column than the panels beside it. Fractions
+ * rather than pixels because the bound has to hold on every phone, not on the
+ * one it was measured on.
+ */
+export const PENDING_CARD_FRACTION = 0.6;
+export const PANEL_FRACTION = 0.4;
+
+/** `max-height` in column units — see the module docstring for why not `dvh`. */
+export function columnCap(fraction: number): { maxHeight: string } {
+	return {
+		maxHeight: `calc(var(${COLUMN_HEIGHT_VAR}, 100dvh) * ${fraction})`,
+	};
+}

--- a/local_operator/mobile/web/src/screens/agent-view.tsx
+++ b/local_operator/mobile/web/src/screens/agent-view.tsx
@@ -266,7 +266,6 @@ function ConversationTail({
 						sessionId={sessionId}
 						subagents={projection.subagents}
 						parentJobId={detail.job_id}
-						collapsible
 						embedded
 						label="child agents"
 					/>

--- a/local_operator/mobile/web/src/screens/session-view.tsx
+++ b/local_operator/mobile/web/src/screens/session-view.tsx
@@ -9,6 +9,18 @@
  * viewport shrinks and the root element is re-pinned to its height. This
  * works around iOS Safari's habit of scrolling the page instead of
  * shrinking the layout when `interactive-widget` is not honoured.
+ *
+ * That pin is also why the column publishes `--lo-vvh`. Every bounded region
+ * inside it (the ask card, the todos and subagent panels) has to be measured
+ * against THIS column, and `dvh` is not that column: a virtual keyboard is an
+ * overlay, so it shrinks `visualViewport.height` and leaves the dynamic
+ * viewport untouched (index.html sets no `interactive-widget`, so the default
+ * `resizes-visual` applies). A `60dvh` cap therefore stayed at 468px while the
+ * column it lived in fell to 480px — measured on a 360x780 phone with a 300px
+ * keyboard, which put `send`, the only way to submit a free-text answer, below
+ * the column's clipped foot with no gesture that recovered it. Publishing the
+ * pinned height as a custom property gives those caps the same unit as the
+ * box they are bounded by, so they tighten exactly when the space does.
  */
 import { useEffect, useRef, useState } from "react";
 import { ModelSheet } from "../components/model-sheet";
@@ -18,6 +30,7 @@ import { SubagentsPanel } from "../components/subagents-panel";
 import { TodosPanel } from "../components/todos-panel";
 import { Transcript } from "../components/transcript";
 import { WorkingLine } from "../components/working-line";
+import { COLUMN_HEIGHT_VAR } from "../lib/column";
 import { navigate } from "../router";
 import { useCompletionView } from "../use-completion-view";
 import { AgentScreen } from "./agent-view";
@@ -78,6 +91,15 @@ export function SessionScreen({
 			   sheets (slash, model, effort) and clips them to a sliver. */
 			el.style.height = `${vv.height}px`;
 			el.style.top = `${vv.offsetTop}px`;
+			/* Same number, published as a length the children's caps can be
+			   written in. Written from THIS handler on purpose: a cap fed by a
+			   second source of truth would drift from the pin the moment one
+			   of them changed, which is the `dvh`-vs-`visualViewport`
+			   divergence this property exists to end. Consumers read it as
+			   `var(--lo-vvh, 100dvh)`, so a surface outside this column — or a
+			   browser without `visualViewport` — still gets the viewport-
+			   relative bound it had before. */
+			el.style.setProperty(COLUMN_HEIGHT_VAR, `${vv.height}px`);
 		};
 		sync();
 		vv.addEventListener("resize", sync);
@@ -87,6 +109,7 @@ export function SessionScreen({
 			vv.removeEventListener("scroll", sync);
 			el.style.height = "";
 			el.style.top = "";
+			el.style.removeProperty(COLUMN_HEIGHT_VAR);
 		};
 	}, []);
 
@@ -157,11 +180,39 @@ export function SessionScreen({
 				/>
 			) : null}
 
+			{/* The panel budget (D1). These two panels and the pending card are
+			    unshrinkable-ish siblings in a column that is `overflow-hidden`, so
+			    what they claim together comes off the bottom and is CLIPPED, not
+			    scrolled. Measured with both panels expanded beside an approval at
+			    390x844: the column reported `clientH 844 / scrollH 1427`, approve
+			    and deny were 120px below the fold with the card's own scroller
+			    already at its end, and at 360x780 the card's top landed at y=781 in
+			    a 780px viewport — entirely off screen. Real touch drags over the
+			    panels and over the card moved nothing (`colScrollTop=0` throughout);
+			    only a script assigning `scrollTop` to an `overflow:hidden` element
+			    appeared to recover it, which a finger cannot do.
+
+			    So while a request is pending the panels render COLLAPSED and hold
+			    shut. A question outranks a task list and a roster (branding §7):
+			    the card is the only thing on screen that needs a decision, and the
+			    panels are the only things that can push it off. This is a budget
+			    rather than a cap because caps compose badly — three individually
+			    bounded regions still sum past the column, which is how 40%+40%+60%
+			    overran it. Their own open state is kept, so answering restores what
+			    the user had open. With `min-h-0` on both panels (see each) the
+			    column can also always fit its children rather than clipping them. */}
 			{projection.todos.some((p) => p.items.length > 0) ? (
-				<TodosPanel todos={projection.todos} />
+				<TodosPanel
+					todos={projection.todos}
+					forceCollapsed={Boolean(projection.pending)}
+				/>
 			) : null}
 			{projection.subagents.length > 0 ? (
-				<SubagentsPanel pid={sessionId} subagents={projection.subagents} />
+				<SubagentsPanel
+					pid={sessionId}
+					subagents={projection.subagents}
+					forceCollapsed={Boolean(projection.pending)}
+				/>
 			) : null}
 
 			{projection.pending ? (

--- a/local_operator/mobile/web/src/session-view.overflow.test.tsx
+++ b/local_operator/mobile/web/src/session-view.overflow.test.tsx
@@ -531,4 +531,53 @@ describe("column budget while a request is pending", () => {
 		render(<SessionScreen sessionId="s1" />);
 		expect(screen.queryByText(/failed/)).toBeNull();
 	});
+
+	it("keeps the failure count out of the held-shut dim, and says why it is held", () => {
+		// D4: `forceClosed` used to dim the whole header button, and opacity
+		// composites the subtree — so the dim reached the failure count U5 had
+		// just added, measured at 3.30:1 from the painted frame against 7.08:1
+		// undimmed. The state that dims it is the state where a failed fan-out
+		// matters most: the user is being asked for a decision. U8: dimmed and
+		// inert is also how this product says "busy", so the held header states
+		// the rule rather than leaving a dead tap to read as a fault.
+		const withFailures = [
+			...roster().slice(0, 19),
+			row("surface-audit-19", "failed"),
+			row("surface-audit-20", "failed"),
+			row("surface-audit-21", "failed"),
+		];
+		slot = {
+			projection: projection({
+				subagents: withFailures,
+				pending: askPending(10),
+				pending_count: 1,
+			}),
+			connected: true,
+		};
+		render(<SessionScreen sessionId="s1" />);
+
+		const rosterHeader = screen.getByRole("button", { name: /subagents/ });
+		expect(rosterHeader.getAttribute("aria-expanded")).toBe("false");
+
+		// The count is legible: neither it nor any ancestor up to the header
+		// carries the dim. Walking the chain is the assertion that matters —
+		// checking the span alone passes even when the dim sits above it, which
+		// is exactly how this shipped.
+		const failed = screen.getByText(/3 failed/);
+		expect(failed.className).toContain("text-danger");
+		for (let el: HTMLElement | null = failed; el; el = el.parentElement) {
+			expect(el.className).not.toContain("opacity-60");
+			if (el === rosterHeader) break;
+		}
+
+		// The label beside it still dims, or the held state stops reading as
+		// inert at all and the tap looks live.
+		expect(
+			rosterHeader.querySelector(".opacity-60"),
+		).toBeTruthy();
+
+		// And the header says why nothing happens when it is tapped.
+		expect(screen.getAllByText(/answer first/).length).toBeGreaterThan(0);
+		expect(rosterHeader.getAttribute("title")).toMatch(/answer it to reopen/);
+	});
 });

--- a/local_operator/mobile/web/src/session-view.overflow.test.tsx
+++ b/local_operator/mobile/web/src/session-view.overflow.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment happy-dom
+//
+// Two layout contracts for the phone's session column, both regressions.
+//
+// 1. The subagent roster starts COLLAPSED. It used to open whenever any agent
+//    was running (`defaultOpen={running > 0}`), so a coordinating session with
+//    22 rows painted the whole roster on arrival and left the transcript a
+//    16px sliver with the composer off screen (measured at 390x844).
+//
+// 2. Every ask option stays REACHABLE. The card is an unshrinkable sibling of
+//    the transcript inside a `h-dvh overflow-hidden` column, so an uncapped
+//    card simply grew past the viewport and the tail was clipped with nothing
+//    to scroll — a 10-option ask measured 1426px against an 844px viewport.
+//
+// These are asserted against the REAL SessionScreen, so a reverted default or
+// a dropped cap fails here. happy-dom does no layout (every box is 0x0), so
+// the assertions are on the structural contract that produces the layout —
+// the roster's `aria-expanded`, and the presence of the cap + scroller classes
+// on the card's own elements — not on measured pixels, which this environment
+// cannot supply. The pixel evidence lives on the PR.
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionScreen } from "./screens/session-view";
+import type {
+	PendingRequest,
+	SessionProjection,
+	SubagentRow,
+} from "./types";
+
+vi.mock("./api", () => ({
+	getHistory: vi.fn(async () => ({ entries: [], has_more: false })),
+	getSubagentHistory: vi.fn(async () => ({ entries: [], has_more: false })),
+	getSubagentDetail: vi.fn(async () => null),
+	imageUrl: vi.fn(() => ""),
+	getCommands: vi.fn(async () => ({ commands: [] })),
+	getModels: vi.fn(async () => ({ models: [] })),
+	sendCommand: vi.fn(async () => ({ ok: true, detail: "answer accepted" })),
+	markSessionSeen: vi.fn(async () => ({ ok: true })),
+}));
+
+let slot: { projection: SessionProjection | null; connected: boolean } = {
+	projection: null,
+	connected: true,
+};
+vi.mock("./store", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./store")>();
+	return {
+		...actual,
+		useProjection: vi.fn(() => slot),
+		retainProjectionStream: vi.fn(() => () => {}),
+		useDraft: vi.fn(() => ["", () => {}]),
+	};
+});
+
+function row(jobId: string, status: SubagentRow["status"]): SubagentRow {
+	return {
+		job_id: jobId,
+		label: jobId,
+		agent: "coder",
+		status,
+		progress: "",
+		elapsed_s: 1,
+		model_label: "",
+		result_text: "",
+		error_text: "",
+		parent_job_id: null,
+		session_id: `${jobId}-session`,
+		prompt: "",
+		launch_message_id: "",
+		effort: "high",
+		ancestors: [],
+		ancestor_ids: [],
+		child_ids: [],
+		peer_ids: [],
+		transcript: [],
+		todos: [],
+		activity: "",
+	};
+}
+
+function projection(over: Partial<SessionProjection> = {}): SessionProjection {
+	return {
+		session_id: "s1",
+		pid: 1,
+		kind: "tui",
+		conversation_name: "Overflow",
+		cwd: "",
+		model_label: "",
+		model_selector: "",
+		effort: "",
+		effort_ladder: [],
+		streaming: false,
+		activity: "",
+		activity_started_s: 0,
+		stop_reason: "",
+		queued_count: 0,
+		ended: false,
+		degraded: false,
+		transcript: [],
+		todos: [],
+		subagents: [],
+		pending: null,
+		pending_count: 0,
+		usage: {},
+		version: 1,
+		...over,
+	} satisfies SessionProjection;
+}
+
+/** The operator's reported screen: 22 rows, exactly one of them running. */
+function roster(): SubagentRow[] {
+	return [
+		row("viewport-audit-running", "running"),
+		...Array.from({ length: 21 }, (_, i) =>
+			row(`surface-audit-${String(i + 1).padStart(2, "0")}`, "completed"),
+		),
+	];
+}
+
+function askPending(optionCount: number): PendingRequest {
+	return {
+		request_id: "req-long",
+		kind: "ask",
+		title: "A deliberately long question about rollout sequencing".repeat(4),
+		detail: "",
+		options: Array.from({ length: optionCount }, (_, i) => ({
+			label: `option-${String(i + 1).padStart(2, "0")}`,
+			description: "A paragraph-length consequence line for this option. ".repeat(4),
+		})),
+		secret: false,
+		question_index: 0,
+		question_total: 1,
+	};
+}
+
+/** The card's own element: the accent-bordered block the render site mounts. */
+function cardRoot(): HTMLElement {
+	const el = document.querySelector<HTMLElement>(".border-accent");
+	if (!el) throw new Error("pending card not mounted");
+	return el;
+}
+
+afterEach(() => {
+	cleanup();
+	localStorage.clear();
+	vi.clearAllMocks();
+	slot = { projection: null, connected: true };
+});
+
+describe("subagent roster default", () => {
+	it("opens a conversation with the roster collapsed even while an agent runs", () => {
+		slot = { projection: projection({ subagents: roster() }), connected: true };
+		render(<SessionScreen sessionId="s1" />);
+
+		// The header line stays as the at-a-glance signal...
+		expect(screen.getByText("1/22 running")).toBeTruthy();
+		// ...but its rows are not painted. `running > 0` used to open this.
+		const header = screen.getByRole("button", { name: /subagents/ });
+		expect(header.getAttribute("aria-expanded")).toBe("false");
+		expect(screen.queryByRole("button", { name: /surface-audit-01/ })).toBeNull();
+	});
+
+	it("expands on tap into a capped, internally scrolling body", () => {
+		slot = { projection: projection({ subagents: roster() }), connected: true };
+		render(<SessionScreen sessionId="s1" />);
+
+		const header = screen.getByRole("button", { name: /subagents/ });
+		fireEvent.click(header);
+
+		// The a11y contract survives the new default.
+		expect(header.getAttribute("aria-expanded")).toBe("true");
+		const firstRow = screen.getByRole("button", { name: /surface-audit-01/ });
+		expect(firstRow).toBeTruthy();
+		// Tap-target convention: every row keeps its 44px minimum.
+		expect(firstRow.className).toContain("min-h-11");
+
+		// The expanded body is bounded and scrolls itself, so 22 rows cannot
+		// push the transcript out of the column the way they used to.
+		const scroller = firstRow.closest(".lo-scroll");
+		expect(scroller).not.toBeNull();
+		expect(scroller?.className).toContain("max-h-[40dvh]");
+		expect(scroller?.className).toContain("overflow-y-auto");
+	});
+
+	it("keeps the roster collapsed when nothing is running", () => {
+		slot = {
+			projection: projection({ subagents: [row("done-01", "completed")] }),
+			connected: true,
+		};
+		render(<SessionScreen sessionId="s1" />);
+		expect(
+			screen.getByRole("button", { name: /subagents/ }).getAttribute("aria-expanded"),
+		).toBe("false");
+	});
+});
+
+describe("ask card reachability", () => {
+	it("caps the card and scrolls its body, so the last of ten options is reachable", () => {
+		slot = { projection: projection({ pending: askPending(10), pending_count: 1 }), connected: true };
+		render(<SessionScreen sessionId="s1" />);
+
+		// Every option is mounted — nothing is dropped to make the card fit.
+		expect(screen.getByRole("button", { name: /option-10/ })).toBeTruthy();
+
+		// The card is bounded against the viewport rather than growing past it.
+		const card = cardRoot();
+		expect(card.className).toContain("max-h-[60dvh]");
+		// ...and it does not shrink to nothing when the transcript is long.
+		expect(card.className).toContain("shrink-0");
+
+		// The bound only helps if the overflow is scrollable: the last option
+		// must sit inside a scroller that the card owns. Without this the cap
+		// would clip the tail exactly as `overflow-hidden` on the column did.
+		const scroller = screen
+			.getByRole("button", { name: /option-10/ })
+			.closest(".lo-scroll");
+		expect(scroller).not.toBeNull();
+		expect(scroller?.className).toContain("overflow-y-auto");
+		expect(card.contains(scroller)).toBe(true);
+		// `min-h-0` is what lets the flex child shrink below its content; a
+		// flex child defaults to `min-height:auto` and would refuse to.
+		expect(scroller?.className).toContain("min-h-0");
+	});
+
+	it("scrolls the question too, since a long question can outgrow the cap alone", () => {
+		const pending = askPending(2);
+		slot = { projection: projection({ pending, pending_count: 1 }), connected: true };
+		render(<SessionScreen sessionId="s1" />);
+
+		// The question shares the scroller with the options rather than being
+		// pinned above it, or it would reintroduce the unreachable tail.
+		const question = screen.getByText(pending.title);
+		expect(question.closest(".lo-scroll")).not.toBeNull();
+	});
+
+	it("bounds the approval variant, whose approve/deny pair overflowed the same way", () => {
+		slot = {
+			projection: projection({
+				pending: {
+					request_id: "req-approval",
+					kind: "approval",
+					title: "bash",
+					detail: "A long command plus its consequences. ".repeat(40),
+					options: [],
+					secret: false,
+					question_index: 0,
+					question_total: 1,
+				},
+				pending_count: 1,
+			}),
+			connected: true,
+		};
+		render(<SessionScreen sessionId="s1" />);
+
+		const approve = screen.getByRole("button", { name: "approve" });
+		const card = cardRoot();
+		expect(card.className).toContain("max-h-[60dvh]");
+		const scroller = approve.closest(".lo-scroll");
+		expect(scroller).not.toBeNull();
+		expect(card.contains(scroller)).toBe(true);
+		// The remember checkbox rides the same scroller as the buttons, so a
+		// long detail cannot strand it above the fold either.
+		expect(screen.getByRole("checkbox").closest(".lo-scroll")).toBe(scroller);
+	});
+
+	it("bounds the free-text/secret variant so its input and send stay reachable", () => {
+		slot = {
+			projection: projection({
+				pending: {
+					request_id: "req-secret",
+					kind: "ask",
+					title: "Paste the staging token".repeat(10),
+					detail: "Why this credential is needed, at length. ".repeat(20),
+					options: [],
+					secret: true,
+					question_index: 0,
+					question_total: 1,
+				},
+				pending_count: 1,
+			}),
+			connected: true,
+		};
+		render(<SessionScreen sessionId="s1" />);
+
+		// Scoped to the card: the composer owns a send control of its own, and
+		// the contract under test is the CARD's, not the column's.
+		const card = cardRoot();
+		const send = [...card.querySelectorAll("button")].find(
+			(b) => b.textContent === "send",
+		);
+		if (!send) throw new Error("card has no send button");
+		expect(card.className).toContain("max-h-[60dvh]");
+		expect(card.contains(send.closest(".lo-scroll"))).toBe(true);
+		// The masked input must be inside the same scroller as its button; a
+		// split would let one scroll away from the other.
+		const input = document.querySelector('input[type="password"]');
+		expect(input?.closest(".lo-scroll")).toBe(send.closest(".lo-scroll"));
+	});
+});

--- a/local_operator/mobile/web/src/session-view.overflow.test.tsx
+++ b/local_operator/mobile/web/src/session-view.overflow.test.tsx
@@ -13,13 +13,40 @@
 //    to scroll — a 10-option ask measured 1426px against an 844px viewport.
 //
 // These are asserted against the REAL SessionScreen, so a reverted default or
-// a dropped cap fails here. happy-dom does no layout (every box is 0x0), so
-// the assertions are on the structural contract that produces the layout —
-// the roster's `aria-expanded`, and the presence of the cap + scroller classes
-// on the card's own elements — not on measured pixels, which this environment
-// cannot supply. The pixel evidence lives on the PR.
+// a dropped cap fails here.
+//
+// WHAT THIS LAYER CANNOT PROVE, and which layer does.
+//
+// happy-dom does no layout: every box is 0x0, so "the last option is visible",
+// "approve is 44px tall on arrival" and "one swipe reaches the foot" are all
+// unanswerable here. Round 1 learned this the expensive way — four of the seven
+// assertions were `className` echoes (`toContain("max-h-[60dvh]")`), which
+// compare a string in the test to the same string in the source and therefore
+// pass for a cap that is PRESENT BUT INEFFECTIVE. They passed for the U2
+// regression that shipped approve/deny 0px visible at 360x780, and for the U1
+// keyboard divergence, because a class name says nothing about what the class
+// resolves to.
+//
+// So the assertions below are of two kinds, both of which can actually fail:
+//
+//  * RESOLVED STYLE, not class name. happy-dom does resolve `var()` against an
+//    ancestor's custom property, so a cap written against the column's pinned
+//    height resolves to a px calc while one written in `dvh` does not. That is
+//    the U1/C1 property — the cap tracks the column rather than the dynamic
+//    viewport — and a revert to `60dvh` fails it.
+//  * CONTAINMENT, in both directions. The scroller must contain the option
+//    list, and must NOT contain the controls or the error line. The second half
+//    is U2/U3: a control inside the scroller can be scrolled out of reach, and
+//    a class echo cannot see the difference.
+//
+// The GEOMETRIC property — that a finger reaches the last option, and that
+// approve arrives at its full 44px — is proved one layer up, by
+// `scripts/mobile_reachability_check.py`, which drives the real bundle in
+// headless Chrome with real touch input and asserts those pixels. Do not read a
+// green run of this file as proof of reachability.
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { COLUMN_HEIGHT_VAR } from "./lib/column";
 import { SessionScreen } from "./screens/session-view";
 import type {
 	PendingRequest,
@@ -133,11 +160,42 @@ function askPending(optionCount: number): PendingRequest {
 	};
 }
 
-/** The card's own element: the accent-bordered block the render site mounts. */
+/** The card's own element. Selected by test id rather than `.border-accent`,
+    which composer.tsx (drag-over) and new-session.tsx (selection) also apply,
+    so the class would pick the wrong node the first time one of those states
+    renders beside a card (C5). */
 function cardRoot(): HTMLElement {
-	const el = document.querySelector<HTMLElement>(".border-accent");
+	const el = document.querySelector<HTMLElement>('[data-testid="pending-card"]');
 	if (!el) throw new Error("pending card not mounted");
 	return el;
+}
+
+/** The card's scrolling region — the one thing inside it that may scroll. */
+function cardScroller(): HTMLElement {
+	const el = cardRoot().querySelector<HTMLElement>(".lo-scroll");
+	if (!el) throw new Error("card has no scroller");
+	return el;
+}
+
+/** Pin the column the way the session view's visualViewport handler does, and
+    return what `el`'s cap actually RESOLVES to at that column height.
+
+    This is the U1/C1 property expressed as something that can fail. The column
+    is pinned to `visualViewport.height` in px while a `dvh` cap follows the
+    dynamic viewport, and a virtual keyboard shrinks the first and not the
+    second — so the two diverge exactly when the keyboard is open. A cap in
+    column units resolves against `--lo-vvh` and tightens with it; a `dvh` cap
+    resolves to a viewport unit and does not.
+
+    happy-dom lays nothing out, so the returned string is not a height. It is
+    the resolved `calc()`, which is the most this layer can see and is enough to
+    tell a column-relative cap from a viewport-relative one. The actual pixels
+    are asserted by `scripts/mobile_reachability_check.py`. */
+function resolvedCapWithColumnAt(el: HTMLElement, pinnedPx: number): string {
+	const column = cardRoot().closest<HTMLElement>(".h-dvh");
+	if (!column) throw new Error("card is not inside the session column");
+	column.style.setProperty(COLUMN_HEIGHT_VAR, `${pinnedPx}px`);
+	return getComputedStyle(el).maxHeight;
 }
 
 afterEach(() => {
@@ -176,10 +234,19 @@ describe("subagent roster default", () => {
 
 		// The expanded body is bounded and scrolls itself, so 22 rows cannot
 		// push the transcript out of the column the way they used to.
-		const scroller = firstRow.closest(".lo-scroll");
+		const scroller = firstRow.closest<HTMLElement>(".lo-scroll");
 		expect(scroller).not.toBeNull();
-		expect(scroller?.className).toContain("max-h-[40dvh]");
 		expect(scroller?.className).toContain("overflow-y-auto");
+
+		// The bound is measured against the COLUMN, not the dynamic viewport:
+		// pin the column the way the visualViewport handler does and the cap
+		// resolves against that number. A `40dvh` cap resolves to a viewport
+		// unit instead and fails here — which is the keyboard-open divergence.
+		const column = scroller?.closest<HTMLElement>(".h-dvh");
+		column?.style.setProperty(COLUMN_HEIGHT_VAR, "480px");
+		const cap = getComputedStyle(scroller as HTMLElement).maxHeight;
+		expect(cap).toContain("480px");
+		expect(cap).toContain("0.4");
 	});
 
 	it("keeps the roster collapsed when nothing is running", () => {
@@ -202,11 +269,20 @@ describe("ask card reachability", () => {
 		// Every option is mounted — nothing is dropped to make the card fit.
 		expect(screen.getByRole("button", { name: /option-10/ })).toBeTruthy();
 
-		// The card is bounded against the viewport rather than growing past it.
 		const card = cardRoot();
-		expect(card.className).toContain("max-h-[60dvh]");
-		// ...and it does not shrink to nothing when the transcript is long.
+		// It does not shrink to nothing when the transcript is long.
 		expect(card.className).toContain("shrink-0");
+
+		// The cap TRACKS THE COLUMN. With the column pinned to a keyboard-open
+		// 480px, the card's bound resolves against that 480 rather than against
+		// the untouched dynamic viewport. This is the assertion that fails for
+		// the `60dvh` cap of round 1: `dvh` does not shrink when a keyboard
+		// overlays the visual viewport, so the cap stayed at 468px inside a
+		// 480px column and put the controls under its clipped foot.
+		expect(resolvedCapWithColumnAt(card, 480)).toContain("480px");
+		// ...and it is a fraction of it, not the whole column: a card that may
+		// claim the entire column has no cap in any useful sense.
+		expect(resolvedCapWithColumnAt(card, 480)).toContain("0.6");
 
 		// The bound only helps if the overflow is scrollable: the last option
 		// must sit inside a scroller that the card owns. Without this the cap
@@ -214,12 +290,36 @@ describe("ask card reachability", () => {
 		const scroller = screen
 			.getByRole("button", { name: /option-10/ })
 			.closest(".lo-scroll");
-		expect(scroller).not.toBeNull();
+		expect(scroller).toBe(cardScroller());
 		expect(scroller?.className).toContain("overflow-y-auto");
-		expect(card.contains(scroller)).toBe(true);
 		// `min-h-0` is what lets the flex child shrink below its content; a
 		// flex child defaults to `min-height:auto` and would refuse to.
 		expect(scroller?.className).toContain("min-h-0");
+		// Arbitrary agent text cannot scroll the card sideways (C7).
+		expect(scroller?.className).toContain("overflow-x-hidden");
+	});
+
+	it("pins the card's meta row above the scroller so it keeps its identity", () => {
+		slot = {
+			projection: projection({ pending: askPending(10), pending_count: 2 }),
+			connected: true,
+		};
+		render(<SessionScreen sessionId="s1" />);
+
+		// D2: scrolled to the option being tapped, the kind label and the "1 of
+		// N" counter were both 0% visible — the card became an unlabelled list of
+		// buttons at the exact moment of the decision. The row is one fixed line,
+		// so pinning it costs no reachability.
+		const kind = screen.getByText(/^question/);
+		const counter = screen.getByText(/1 of 2/);
+		const scroller = cardScroller();
+		expect(scroller.contains(kind)).toBe(false);
+		expect(scroller.contains(counter)).toBe(false);
+		expect(cardRoot().contains(kind)).toBe(true);
+
+		// U4: the option total is stated rather than discovered, since the cap
+		// cut first-glance options from 6 to 3 at 390x844.
+		expect(screen.getByText(/10 options/)).toBeTruthy();
 	});
 
 	it("scrolls the question too, since a long question can outgrow the cap alone", () => {
@@ -228,9 +328,11 @@ describe("ask card reachability", () => {
 		render(<SessionScreen sessionId="s1" />);
 
 		// The question shares the scroller with the options rather than being
-		// pinned above it, or it would reintroduce the unreachable tail.
+		// pinned above it, or it would reintroduce the unreachable tail. This is
+		// the deliberate asymmetry with the meta row above: a title is unbounded
+		// prose, a kind label is one line.
 		const question = screen.getByText(pending.title);
-		expect(question.closest(".lo-scroll")).not.toBeNull();
+		expect(question.closest(".lo-scroll")).toBe(cardScroller());
 	});
 
 	it("bounds the approval variant, whose approve/deny pair overflowed the same way", () => {
@@ -253,14 +355,59 @@ describe("ask card reachability", () => {
 		render(<SessionScreen sessionId="s1" />);
 
 		const approve = screen.getByRole("button", { name: "approve" });
+		const deny = screen.getByRole("button", { name: "deny" });
 		const card = cardRoot();
-		expect(card.className).toContain("max-h-[60dvh]");
-		const scroller = approve.closest(".lo-scroll");
-		expect(scroller).not.toBeNull();
-		expect(card.contains(scroller)).toBe(true);
-		// The remember checkbox rides the same scroller as the buttons, so a
-		// long detail cannot strand it above the fold either.
-		expect(screen.getByRole("checkbox").closest(".lo-scroll")).toBe(scroller);
+		const scroller = cardScroller();
+
+		// The cap tracks the column, as above.
+		expect(resolvedCapWithColumnAt(cardRoot(), 480)).toContain("480px");
+
+		// U2/Q1, the regression round 1 shipped: the DECISION is outside the
+		// scroller. Inside it, an approval with a long detail arrived with
+		// approve showing 30 of 44px at 390x844 and 0 of 44px at 360x780 — the
+		// card's primary action below the fold on arrival, where the uncapped
+		// card before it had shown both buttons whole. A control that can be
+		// scrolled away is a control that can be missed.
+		expect(scroller.contains(approve)).toBe(false);
+		expect(scroller.contains(deny)).toBe(false);
+		expect(scroller.contains(screen.getByRole("checkbox"))).toBe(false);
+		expect(card.contains(approve)).toBe(true);
+		// The detail is what scrolls instead — the content, not the controls.
+		expect(screen.getByText(/A long command plus its consequences/).closest(".lo-scroll")).toBe(
+			scroller,
+		);
+		// The action row ends clear of the overlay scrollbar's paint band, which
+		// was drawn inside `deny` at gapToContentEdge 0 (D3).
+		expect(approve.parentElement?.parentElement?.className).toContain("pr-1.5");
+	});
+
+	it("pins the stale-tap error outside the scroller, where it cannot land below the fold", async () => {
+		const { sendCommand } = await import("./api");
+		vi.mocked(sendCommand).mockRejectedValueOnce(
+			new Error("that question moved on"),
+		);
+		slot = {
+			projection: projection({ pending: askPending(10), pending_count: 1 }),
+			connected: true,
+		};
+		render(<SessionScreen sessionId="s1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: /option-10/ }));
+		const error = await screen.findByText(/That question moved on/);
+
+		// U3: the error used to be the scroller's last child, so it was appended
+		// ~26px BELOW where the user was standing — at the foot of the option
+		// list, because that is where they had just tapped. Every option greyed
+		// out and nothing explained why. Pinned, its position does not depend on
+		// the user's scroll offset at all.
+		expect(cardScroller().contains(error)).toBe(false);
+		expect(cardRoot().contains(error)).toBe(true);
+
+		// And the options must still read as inert while it shows, or a stale
+		// option sits live-looking under the message (D7).
+		expect(
+			screen.getByRole("button", { name: /option-01/ }).hasAttribute("disabled"),
+		).toBe(true);
 	});
 
 	it("bounds the free-text/secret variant so its input and send stay reachable", () => {
@@ -289,11 +436,99 @@ describe("ask card reachability", () => {
 			(b) => b.textContent === "send",
 		);
 		if (!send) throw new Error("card has no send button");
-		expect(card.className).toContain("max-h-[60dvh]");
-		expect(card.contains(send.closest(".lo-scroll"))).toBe(true);
-		// The masked input must be inside the same scroller as its button; a
-		// split would let one scroll away from the other.
-		const input = document.querySelector('input[type="password"]');
-		expect(input?.closest(".lo-scroll")).toBe(send.closest(".lo-scroll"));
+
+		// The cap tracks the column, which for THIS variant is the whole point:
+		// the keyboard is open exactly when a free-text answer is being typed,
+		// and `send` is the only way to submit one (there is no Enter-to-send
+		// path on this card). At a 300px keyboard on a 360x780 phone the old
+		// `60dvh` cap left it below the column's clipped foot (U1/C1).
+		expect(resolvedCapWithColumnAt(cardRoot(), 480)).toContain("480px");
+
+		// The input and its send button are pinned together OUTSIDE the
+		// scroller, so a long question cannot scroll either away.
+		const input = document.querySelector<HTMLElement>('input[type="password"]');
+		const scroller = cardScroller();
+		expect(scroller.contains(send)).toBe(false);
+		expect(scroller.contains(input as HTMLElement)).toBe(false);
+		// ...and they stay together, or one could move without the other.
+		expect(send.parentElement).toBe(input?.parentElement);
+		expect(send.parentElement?.parentElement?.className).toContain("pr-1.5");
+	});
+});
+
+describe("column budget while a request is pending", () => {
+	it("holds the panels collapsed so they cannot push the decision off the column", () => {
+		slot = {
+			projection: projection({
+				subagents: roster(),
+				todos: [{ name: "Todos", items: [{ text: "audit", status: "pending", reason: "" }] }],
+				pending: askPending(10),
+				pending_count: 1,
+			}),
+			connected: true,
+		};
+		render(<SessionScreen sessionId="s1" />);
+
+		// D1: the panels, the card and the composer are siblings in a column
+		// that is `overflow-hidden`, so what they claim together comes off the
+		// bottom and is CLIPPED rather than scrolled. Measured with both panels
+		// expanded beside an approval: approve/deny 120px below the fold at
+		// 390x844 with the card's own scroller already at its end, and at
+		// 360x780 the card's top at y=781 in a 780px viewport. Real touch drags
+		// recovered none of it. A question outranks a task list (branding §7),
+		// so while one is pending the panels are held shut.
+		const rosterHeader = screen.getByRole("button", { name: /subagents/ });
+		const todosHeader = screen.getByRole("button", { name: /tasks/ });
+		expect(rosterHeader.getAttribute("aria-expanded")).toBe("false");
+		expect(todosHeader.getAttribute("aria-expanded")).toBe("false");
+
+		// Held shut means held: a tap must not open them either, or the user
+		// can still put the decision off screen in one gesture.
+		fireEvent.click(rosterHeader);
+		fireEvent.click(todosHeader);
+		expect(rosterHeader.getAttribute("aria-expanded")).toBe("false");
+		expect(todosHeader.getAttribute("aria-expanded")).toBe("false");
+		expect(screen.queryByRole("button", { name: /surface-audit-01/ })).toBeNull();
+
+		// The counts stay legible, so nothing is hidden — only held.
+		expect(screen.getByText("1/22 running")).toBeTruthy();
+	});
+
+	it("releases the panels once nothing is pending", () => {
+		slot = {
+			projection: projection({ subagents: roster(), pending: null }),
+			connected: true,
+		};
+		render(<SessionScreen sessionId="s1" />);
+
+		const rosterHeader = screen.getByRole("button", { name: /subagents/ });
+		fireEvent.click(rosterHeader);
+		expect(rosterHeader.getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("surfaces a failing fan-out in the collapsed header", () => {
+		// U5: collapsing by default hid the status glyphs, and `1/22 running` is
+		// exactly what a healthy session shows — 3 failed agents rendered with
+		// no ✗ on screen and the word "failed" absent from the page entirely.
+		const withFailures = [
+			...roster().slice(0, 19),
+			row("surface-audit-19", "failed"),
+			row("surface-audit-20", "failed"),
+			row("surface-audit-21", "failed"),
+		];
+		slot = { projection: projection({ subagents: withFailures }), connected: true };
+		render(<SessionScreen sessionId="s1" />);
+
+		expect(screen.getByText("1/22 running")).toBeTruthy();
+		const failed = screen.getByText(/3 failed/);
+		expect(failed).toBeTruthy();
+		// In the danger colour, or it reads as one more neutral count.
+		expect(failed.className).toContain("text-danger");
+	});
+
+	it("says nothing about failures when there are none", () => {
+		slot = { projection: projection({ subagents: roster() }), connected: true };
+		render(<SessionScreen sessionId="s1" />);
+		expect(screen.queryByText(/failed/)).toBeNull();
 	});
 });

--- a/local_operator/mobile/web/src/styles/index.css
+++ b/local_operator/mobile/web/src/styles/index.css
@@ -351,3 +351,22 @@ html :focus-visible {
 	scrollbar-width: thin;
 	scrollbar-color: var(--color-control) transparent;
 }
+
+/* "There is more below" for a capped scroller, applied only while content is
+   actually below the fold. A phone needs this because `scrollbar-width: thin`
+   resolves to an OVERLAY scrollbar here: zero layout width, painted only while
+   a scroll is in flight, so a capped region at rest advertises nothing. The
+   measured cost of the ask card's cap was first-glance options dropping 6→3 at
+   390x844 and 5→2 at 360x780, with no cue that the rest existed.
+
+   A mask rather than a gradient overlay element, and a mask rather than a
+   pinned "more" row: it steals no vertical space (a row would give back what
+   the cap just bought), needs no stacking context inside a scroller, and fades
+   the real content instead of painting a band over it, so it cannot be mistaken
+   for a UI element to tap. 24px is about one line of body text — enough to read
+   as a cut edge at arm's length, small enough that the partially visible row
+   underneath stays legible. */
+.lo-fade-b {
+	-webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 24px), transparent 100%);
+	mask-image: linear-gradient(to bottom, #000 calc(100% - 24px), transparent 100%);
+}

--- a/scripts/mobile_overflow_capture.py
+++ b/scripts/mobile_overflow_capture.py
@@ -15,6 +15,18 @@ the survivors of a killed harness are addressable as a process group, and an
 Each capture also records the geometry behind the frame (§4): the scroll extent
 and client height of the ask card's scroller and of the layout column, so the
 stills show the symptom and the numbers show the cause.
+
+**Every scroll here is a real touch gesture**, and that is load-bearing rather
+than fastidious. An earlier version of this script reached the tail of a long
+list by assigning ``el.scrollTop = el.scrollHeight``, which a script may do on
+any element — including one inside ``overflow: hidden`` — and a finger may not.
+It therefore photographed regions as reachable that no user could reach, and
+two review rounds paid for it: a design pass was masked by exactly this and had
+to be redone, and a UX round wrote its own driver rather than trust this one.
+The harness now drives ``Input.dispatchTouchEvent`` drags, and after the
+gestures are exhausted it ASSERTS that nothing further moves by assignment —
+exiting non-zero if anything does. A capture that cannot be reproduced by a
+thumb is not evidence.
 """
 
 from __future__ import annotations
@@ -152,24 +164,69 @@ class Page:
 
         path.write_bytes(base64.b64decode(data))
 
+    def swipe(self, x: int, y: int, dy: int, steps: int = 12) -> None:
+        """One finger drag through REAL touch events.
+
+        The distinction this method exists for: a script may assign
+        ``el.scrollTop`` on any element, including one inside
+        ``overflow: hidden``, and a finger may not. A harness that scrolls by
+        assignment therefore reports a clipped, gesture-proof region as fine —
+        which is exactly what happened here. Two review rounds hit it: the
+        design round's first pass "recovered" a card that a thumb could not
+        reach, and the UX round had to write its own driver to see the defect at
+        all. So the harness dispatches what the phone dispatches: touchStart, a
+        run of touchMove, touchEnd. Whatever does not move under this does not
+        move for the user either.
+
+        `dy` is the CONTENT displacement (positive scrolls down toward the
+        tail), so the finger travels in the opposite direction.
+        """
+        self.send(
+            "Input.dispatchTouchEvent",
+            type="touchStart",
+            touchPoints=[{"x": x, "y": y}],
+        )
+        for i in range(1, steps + 1):
+            self.send(
+                "Input.dispatchTouchEvent",
+                type="touchMove",
+                touchPoints=[{"x": x, "y": y - round(dy * i / steps)}],
+            )
+            time.sleep(0.012)
+        self.send(
+            "Input.dispatchTouchEvent",
+            type="touchEnd",
+            touchPoints=[],
+        )
+        # Let momentum and any smooth-scroll settle before the next measurement;
+        # reading immediately catches the scroller mid-flight and understates it.
+        time.sleep(0.35)
+
     def close(self) -> None:
         self.ws.close()
 
 
-# The ask card is the accent-bordered block pinned above the composer. The probe
-# finds it structurally (its accent border class) rather than by a test id, so it
-# measures the shipped markup and not a hook added for the harness.
+# The ask card is the block pinned above the composer, found by the test id the
+# component ships. That id is deliberate shipped markup rather than a
+# harness-only hook: `.border-accent`, the previous selector, is also applied by
+# the composer on drag-over and by the new-session screen on selection, so a
+# class query silently measures the wrong node once either state renders.
 GEOMETRY_JS = """
 (() => {
   const col = document.querySelector('div.h-dvh') || document.querySelector('[class*="h-dvh"]');
-  const card = document.querySelector('.border-accent');
+  // By test id, not `.border-accent`: composer.tsx (drag-over) and
+  // new-session.tsx (selection) apply that class too.
+  const card = document.querySelector('[data-testid="pending-card"]');
   const scrollers = [...document.querySelectorAll('.lo-scroll')].map((el) => ({
     cls: el.className.slice(0, 60),
     scrollH: el.scrollHeight,
     clientH: el.clientHeight,
     scrollable: el.scrollHeight > el.clientHeight + 1,
   }));
-  const opts = [...document.querySelectorAll('.border-l-accent')];
+  // Scoped to the CARD: `.border-l-accent` is also the transcript's message
+  // bubble, so an unscoped query measures a chat message as though it were an
+  // ask option.
+  const opts = card ? [...card.querySelectorAll('.border-l-accent')] : [];
   const last = opts[opts.length - 1];
   const lastRect = last ? last.getBoundingClientRect() : null;
   return JSON.stringify({
@@ -205,18 +262,98 @@ GEOMETRY_JS = """
 })()
 """
 
-SCROLL_ALL_JS = """
+# Where a real finger would land to scroll a given element: the centre of its
+# visible intersection with the viewport, which is the only part a thumb can
+# reach. An element whose visible slice is empty gets no gesture at all — that
+# is the D1 state, and reporting it as unreachable is the point.
+TOUCH_TARGET_JS = """
 (() => {
-  // Drive every scroller to its end, the gesture a user makes to reach the
-  // tail of a long option list. Whatever stays off screen after this is
-  // genuinely unreachable, not merely un-scrolled.
+  const out = [];
   for (const el of document.querySelectorAll('.lo-scroll, [class*="overflow-y-auto"]')) {
-    el.scrollTop = el.scrollHeight;
+    const r = el.getBoundingClientRect();
+    const top = Math.max(r.top, 0);
+    const bottom = Math.min(r.bottom, window.innerHeight);
+    if (bottom - top < 8 || r.width < 8) continue;
+    out.push({
+      x: Math.round(Math.min(Math.max(r.left + r.width / 2, 1), window.innerWidth - 1)),
+      y: Math.round((top + bottom) / 2),
+      before: el.scrollTop,
+      max: el.scrollHeight - el.clientHeight,
+      cls: el.className.slice(0, 60),
+    });
   }
-  document.documentElement.scrollTop = document.documentElement.scrollHeight;
-  return true;
+  return JSON.stringify(out);
 })()
 """
+
+SCROLLER_STATE_JS = """
+(() => JSON.stringify(
+  [...document.querySelectorAll('.lo-scroll, [class*="overflow-y-auto"]')].map((el) => ({
+    top: el.scrollTop,
+    max: el.scrollHeight - el.clientHeight,
+  })),
+))()
+"""
+
+
+def gesture_scroll_all(page: Page, rounds: int = 14) -> list[dict[str, Any]]:
+    """Drive every visible scroller to its end with real finger drags.
+
+    Returns one record per scroller that still has content below its fold after
+    the gestures, i.e. every region a user cannot reach by swiping. An empty
+    list is the property the evidence actually needs: "the tail is reachable".
+    """
+    for _ in range(rounds):
+        targets = json.loads(page.js(TOUCH_TARGET_JS))
+        moved = False
+        for t in targets:
+            if t["before"] >= t["max"]:
+                continue
+            page.swipe(t["x"], t["y"], 320)
+            moved = True
+        if not moved:
+            break
+    return [s for s in json.loads(page.js(SCROLLER_STATE_JS)) if s["top"] < s["max"] - 2]
+
+
+def assert_gesture_honest(page: Page, key: str) -> list[str]:
+    """Fail loudly when a region is reachable by script but not by finger.
+
+    This is the check that would have caught the stacked-panels defect the
+    first time. After the real gestures above have done all they can, it asks
+    the DOM to scroll everything by assignment — the thing a script may do and
+    a thumb may not — and reports any element that moves. Anything in this list
+    is a region the harness could only "reach" by cheating, which is precisely
+    the false pass this script used to hand back.
+
+    Deliberately a report rather than a silent repair: the old behaviour was to
+    assign `scrollTop` first and photograph the result, so the frame showed a
+    reachable card that the user could never have produced.
+    """
+    cheated = json.loads(page.js("""
+(() => {
+  const moved = [];
+  const sel = '.lo-scroll, [class*="overflow-y-auto"], [class*="h-dvh"]';
+  for (const el of document.querySelectorAll(sel)) {
+    const before = el.scrollTop;
+    el.scrollTop = el.scrollHeight;
+    if (el.scrollTop > before + 2) {
+      moved.push({ cls: el.className.slice(0, 60), before, after: el.scrollTop });
+    }
+    el.scrollTop = before;
+  }
+  return JSON.stringify(moved);
+})()
+"""))
+    problems = [
+        f"{key}: {m['cls']!r} moved {m['before']}→{m['after']} by scrollTop "
+        "assignment AFTER real gestures were exhausted — reachable by script, "
+        "not by finger"
+        for m in cheated
+    ]
+    for line in problems:
+        print(f"  UNREACHABLE  {line}", file=sys.stderr)
+    return problems
 
 
 def main() -> None:
@@ -225,6 +362,7 @@ def main() -> None:
     base = f"http://127.0.0.1:{port}"
     chrome = Chrome()
     report: dict[str, dict[str, Any]] = {}
+    unreachable: list[str] = []
     try:
         page = Page(chrome.target_ws())
         for width, height in VIEWPORTS:
@@ -261,10 +399,14 @@ def main() -> None:
                     name = f"{label}-{vp}-{session}-expanded"
                 page.shot(outdir / f"{name}-top.png")
                 report[f"{name}-top"] = json.loads(page.js(GEOMETRY_JS))
-                page.js(SCROLL_ALL_JS)
-                time.sleep(0.6)
+                # Real finger drags, never `scrollTop = scrollHeight`: see
+                # Page.swipe. What does not move here does not move for a user.
+                stranded = gesture_scroll_all(page)
                 page.shot(outdir / f"{name}-bottom.png")
-                report[f"{name}-bottom"] = json.loads(page.js(GEOMETRY_JS))
+                geo = json.loads(page.js(GEOMETRY_JS))
+                geo["strandedAfterGestures"] = stranded
+                report[f"{name}-bottom"] = geo
+                unreachable.extend(assert_gesture_honest(page, f"{name}-bottom"))
         page.close()
     finally:
         chrome.close()
@@ -278,6 +420,21 @@ def main() -> None:
             f" composer={geo['composerVisible']}"
             f" scrollable={[s['scrollable'] for s in geo['scrollers']]}"
         )
+
+    # A non-zero exit rather than a note in the log. This harness exists to
+    # produce review evidence, and evidence that quietly reports a
+    # finger-unreachable region as fine is worse than no evidence — it is what
+    # let the stacked-panels defect through a capture round. If this fires,
+    # something on the captured screen can only be reached by a script.
+    if unreachable:
+        print(
+            f"\nFAIL: {len(unreachable)} region(s) reachable only by scrollTop "
+            "assignment, not by a real gesture:",
+            file=sys.stderr,
+        )
+        for line in unreachable:
+            print(f"  - {line}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/mobile_overflow_capture.py
+++ b/scripts/mobile_overflow_capture.py
@@ -1,0 +1,284 @@
+"""Capture the fixture's phone surfaces out of headless Chrome over CDP.
+
+Run:  .venv/bin/python scripts/mobile_overflow_capture.py <port> <outdir> <label>
+
+Follows AGENTS.md §6 exactly and for the reasons recorded there: a unique
+``mktemp`` profile under /tmp (never the operator's), ``--remote-debugging-port=0``
+with the real port read from ``DevToolsActivePort`` (a fixed port silently drives
+another session's Chrome), ``--headless=new`` (a headful window steals the
+operator's focus — the 2026-09-07 incident), the viewport set by
+``Emulation.setDeviceMetricsOverride`` rather than ``--window-size`` (which clamps
+at a 500px floor and yields a dimension nobody set), ``start_new_session=True`` so
+the survivors of a killed harness are addressable as a process group, and an
+``atexit`` sweep that ASSERTS zero leftovers rather than trusting the terminate.
+
+Each capture also records the geometry behind the frame (§4): the scroll extent
+and client height of the ask card's scroller and of the layout column, so the
+stills show the symptom and the numbers show the cause.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from websockets.sync.client import connect
+
+CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+VIEWPORTS = [(390, 844), (360, 780)]
+PASSWORD = "overflow-demo"
+
+
+class Chrome:
+    """A throwaway headless Chrome owned by this process group."""
+
+    def __init__(self) -> None:
+        self.profile = Path(tempfile.mkdtemp(prefix="lo-harness-askcap."))
+        self.proc = subprocess.Popen(
+            [
+                CHROME,
+                "--headless=new",
+                f"--user-data-dir={self.profile}",
+                "--remote-debugging-port=0",
+                "--use-mock-keychain",
+                "--password-store=basic",
+                "--no-first-run",
+                "--no-default-browser-check",
+                "about:blank",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        atexit.register(self.close)
+        # Chrome writes DevToolsActivePort asynchronously: an immediate read gets
+        # an empty file and the connect fails intermittently, which reads like a
+        # flaky harness rather than a race.
+        port_file = self.profile / "DevToolsActivePort"
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if port_file.exists() and port_file.stat().st_size > 0:
+                break
+            time.sleep(0.2)
+        else:
+            raise RuntimeError("Chrome never wrote DevToolsActivePort")
+        self.port = int(port_file.read_text().splitlines()[0])
+
+    def target_ws(self) -> str:
+        # Reuse the about:blank target Chrome already opened rather than asking
+        # for a new one: `/json/new` requires PUT on current Chrome (152 answers
+        # a GET with 405), and one page target is all this harness needs.
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            with urllib.request.urlopen(f"http://127.0.0.1:{self.port}/json/list") as r:
+                targets = [t for t in json.load(r) if t.get("type") == "page"]
+            if targets:
+                return targets[0]["webSocketDebuggerUrl"]
+            time.sleep(0.3)
+        raise RuntimeError("Chrome exposed no page target")
+
+    def close(self) -> None:
+        if self.proc.poll() is None:
+            try:
+                os.killpg(os.getpgid(self.proc.pid), signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                self.proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+        time.sleep(1.5)
+        # Scoped to OUR unique profile prefix, never `pkill -f "Google Chrome"`:
+        # SIGTERM to the browser pid alone left 0-5 helpers behind across
+        # measured runs, so the count is asserted rather than assumed.
+        subprocess.run(["pkill", "-f", str(self.profile)], capture_output=True)
+        time.sleep(0.5)
+        left = subprocess.run(
+            ["pgrep", "-f", str(self.profile)], capture_output=True, text=True
+        ).stdout.split()
+        subprocess.run(["rm", "-rf", str(self.profile)], check=False)
+        if left:
+            raise RuntimeError(f"leaked {len(left)} Chrome processes: {left}")
+
+
+class Page:
+    def __init__(self, ws_url: str) -> None:
+        self.ws = connect(ws_url, max_size=80 * 1024 * 1024)
+        self.n = 0
+        self.send("Page.enable")
+        self.send("Runtime.enable")
+
+    def send(self, method: str, **params: Any) -> dict[str, Any]:
+        self.n += 1
+        self.ws.send(json.dumps({"id": self.n, "method": method, "params": params}))
+        while True:
+            msg = json.loads(self.ws.recv())
+            if msg.get("id") == self.n:
+                if "error" in msg:
+                    raise RuntimeError(f"{method}: {msg['error']}")
+                return msg.get("result", {})
+
+    def metrics(self, width: int, height: int) -> None:
+        self.send(
+            "Emulation.setDeviceMetricsOverride",
+            width=width,
+            height=height,
+            deviceScaleFactor=2,
+            mobile=True,
+        )
+
+    def goto(self, url: str) -> None:
+        self.send("Page.navigate", url=url)
+        time.sleep(2.0)
+
+    def js(self, expression: str) -> Any:
+        result = self.send(
+            "Runtime.evaluate", expression=expression, awaitPromise=True, returnByValue=True
+        )
+        return result.get("result", {}).get("value")
+
+    def shot(self, path: Path) -> None:
+        data = self.send("Page.captureScreenshot", format="png")["data"]
+        import base64
+
+        path.write_bytes(base64.b64decode(data))
+
+    def close(self) -> None:
+        self.ws.close()
+
+
+# The ask card is the accent-bordered block pinned above the composer. The probe
+# finds it structurally (its accent border class) rather than by a test id, so it
+# measures the shipped markup and not a hook added for the harness.
+GEOMETRY_JS = """
+(() => {
+  const col = document.querySelector('div.h-dvh') || document.querySelector('[class*="h-dvh"]');
+  const card = document.querySelector('.border-accent');
+  const scrollers = [...document.querySelectorAll('.lo-scroll')].map((el) => ({
+    cls: el.className.slice(0, 60),
+    scrollH: el.scrollHeight,
+    clientH: el.clientHeight,
+    scrollable: el.scrollHeight > el.clientHeight + 1,
+  }));
+  const opts = [...document.querySelectorAll('.border-l-accent')];
+  const last = opts[opts.length - 1];
+  const lastRect = last ? last.getBoundingClientRect() : null;
+  return JSON.stringify({
+    viewport: [window.innerWidth, window.innerHeight],
+    column: col ? { clientH: col.clientHeight, scrollH: col.scrollHeight } : null,
+    card: card
+      ? {
+          rectTop: Math.round(card.getBoundingClientRect().top),
+          rectBottom: Math.round(card.getBoundingClientRect().bottom),
+          scrollH: card.scrollHeight,
+          clientH: card.clientHeight,
+        }
+      : null,
+    scrollers,
+    optionCount: opts.length,
+    lastOption: lastRect
+      ? {
+          label: last.textContent.slice(0, 12),
+          top: Math.round(lastRect.top),
+          bottom: Math.round(lastRect.bottom),
+          // "Reachable" is the real question: is the last option's box inside
+          // the viewport after scrolling every scroller to its end?
+          insideViewport: lastRect.bottom <= window.innerHeight + 1 && lastRect.top >= -1,
+        }
+      : null,
+    composerVisible: (() => {
+      const ta = document.querySelector('textarea');
+      if (!ta) return null;
+      const r = ta.getBoundingClientRect();
+      return r.bottom <= window.innerHeight + 1 && r.top >= 0;
+    })(),
+  });
+})()
+"""
+
+SCROLL_ALL_JS = """
+(() => {
+  // Drive every scroller to its end, the gesture a user makes to reach the
+  // tail of a long option list. Whatever stays off screen after this is
+  // genuinely unreachable, not merely un-scrolled.
+  for (const el of document.querySelectorAll('.lo-scroll, [class*="overflow-y-auto"]')) {
+    el.scrollTop = el.scrollHeight;
+  }
+  document.documentElement.scrollTop = document.documentElement.scrollHeight;
+  return true;
+})()
+"""
+
+
+def main() -> None:
+    port, outdir, label = int(sys.argv[1]), Path(sys.argv[2]), sys.argv[3]
+    outdir.mkdir(parents=True, exist_ok=True)
+    base = f"http://127.0.0.1:{port}"
+    chrome = Chrome()
+    report: dict[str, dict[str, Any]] = {}
+    try:
+        page = Page(chrome.target_ws())
+        for width, height in VIEWPORTS:
+            page.metrics(width, height)
+            vp = f"{width}x{height}"
+            # Log in once per viewport: the cookie is per profile, and a
+            # re-navigation to /login after an auth cookie exists just redirects.
+            page.goto(f"{base}/login")
+            page.js(
+                "(() => { const f = document.querySelector('form');"
+                f" f.password.value = {PASSWORD!r}; f.submit(); return true; }})()"
+            )
+            time.sleep(2.0)
+            for session, expand in (
+                ("roster", False),
+                ("roster", True),
+                ("ask-long", False),
+                ("approval", False),
+                ("ask-free", False),
+            ):
+                page.goto(f"{base}/#/s/{session}")
+                time.sleep(1.5)
+                name = f"{label}-{vp}-{session}"
+                if expand:
+                    # Tap the roster header, so the expanded body's cap and
+                    # internal scrolling are captured too, not just the
+                    # collapsed default.
+                    page.js(
+                        "(() => { const b = [...document.querySelectorAll('button')]"
+                        ".find((x) => /subagents/.test(x.textContent));"
+                        " if (b) b.click(); return true; })()"
+                    )
+                    time.sleep(0.8)
+                    name = f"{label}-{vp}-{session}-expanded"
+                page.shot(outdir / f"{name}-top.png")
+                report[f"{name}-top"] = json.loads(page.js(GEOMETRY_JS))
+                page.js(SCROLL_ALL_JS)
+                time.sleep(0.6)
+                page.shot(outdir / f"{name}-bottom.png")
+                report[f"{name}-bottom"] = json.loads(page.js(GEOMETRY_JS))
+        page.close()
+    finally:
+        chrome.close()
+    (outdir / f"{label}-geometry.json").write_text(json.dumps(report, indent=2))
+    for key, geo in report.items():
+        last = geo.get("lastOption")
+        print(
+            f"{key:<46} vp={geo['viewport']}"
+            f" card={geo['card'] and (geo['card']['rectTop'], geo['card']['rectBottom'])}"
+            f" lastOpt={last and (last['top'], last['bottom'], last['insideViewport'])}"
+            f" composer={geo['composerVisible']}"
+            f" scrollable={[s['scrollable'] for s in geo['scrollers']]}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mobile_overflow_fixture.py
+++ b/scripts/mobile_overflow_fixture.py
@@ -23,6 +23,11 @@ Three sessions, each one shaped to isolate one surface:
   position can be measured on arrival rather than inferred (U3).
 * ``failures`` — a fan-out with failed agents, for the collapsed header's
   failure count (U5).
+* ``failures-pending`` — the same fan-out WITH a request pending, so the
+  failure count and the held-shut panel state appear at once. The compounding
+  case: `forceClosed` dims the header, and a dim above the count's level takes
+  the count with it (design D4). No other fixture puts both on screen, which is
+  why the dim's cost to that glyph went unmeasured until round 2.
 
 No runtime scanner and no registrant sockets (``dial_registrants=False``), so
 this never touches the operator's live daemon or their sessions. HOME and
@@ -335,6 +340,38 @@ def _failures_projection() -> SessionProjection:
     return projection
 
 
+def _failures_pending_projection() -> SessionProjection:
+    """Failed agents AND a pending request in one column (D4).
+
+    The state where a failed fan-out matters most is the one that dimmed it:
+    the panels are held shut precisely while the user is being asked for a
+    decision, so the `· 3 failed` count is dimmed at the moment it is most
+    worth reading. Needs both halves at once — `failures` has no pending
+    request and `stacked` has no failures — so neither could show it.
+    """
+    projection = _failures_projection()
+    projection.session_id = "failures-pending"
+    projection.pid = 900009
+    projection.conversation_name = "Failing fan-out, decision waiting"
+    projection.todos = [
+        TodoPhase(
+            name="Remediation",
+            items=[
+                TodoItem(text=f"Land finding {i:02d} and re-measure it", status="pending")
+                for i in range(1, 13)
+            ],
+        )
+    ]
+    projection.pending = PendingRequest(
+        request_id="req-failures-pending",
+        kind="approval",
+        title="bash",
+        detail=APPROVAL_DETAIL,
+    )
+    projection.pending_count = 1
+    return projection
+
+
 def _stale_projection() -> SessionProjection:
     """An ask whose answers the daemon refuses as moved-on (U3).
 
@@ -372,6 +409,7 @@ async def main() -> None:
         _stacked_projection("stacked", approval=False),
         _stacked_projection("stacked-approval", approval=True),
         _failures_projection(),
+        _failures_pending_projection(),
         _stale_projection(),
     ):
         record = SessionRecord(

--- a/scripts/mobile_overflow_fixture.py
+++ b/scripts/mobile_overflow_fixture.py
@@ -1,0 +1,281 @@
+"""Serve the REAL mobile bundle with synthetic projections that provoke both
+defects under review, for before/after capture at a phone viewport.
+
+Run:  PYTHONPATH=. .venv/bin/python scripts/mobile_overflow_fixture.py [PORT]
+Login at http://127.0.0.1:<port> with password `overflow-demo`.
+
+Three sessions, each one shaped to isolate one surface:
+
+* ``roster``   — 22 subagent rows, exactly one running. This is the operator's
+  reported screen: ``defaultOpen={running > 0}`` opens the roster on arrival.
+* ``ask-long`` — a long question plus 10 options carrying paragraph-length
+  descriptions, the shape that overruns the card.
+* ``approval`` — the approval variant of the same card (approve/deny +
+  remember), which overflows identically.
+* ``ask-free`` — the free-text/secret variant, to prove the cap does not strand
+  the input or its send button.
+
+No runtime scanner and no registrant sockets (``dial_registrants=False``), so
+this never touches the operator's live daemon or their sessions. HOME and
+LOCAL_OPERATOR_CONFIG_DIR are re-homed by ``scripts.probe_isolation`` on import.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import uvicorn
+
+import scripts.probe_isolation  # noqa: F401  -- must be the first local import
+from local_operator.mobile.daemon import MobileDaemon, SessionEntry, build_app
+from local_operator.mobile.types import (
+    AskOptionWire,
+    PendingRequest,
+    SessionProjection,
+    SessionRecord,
+    SubagentRow,
+    TranscriptEntry,
+)
+
+PASSWORD = "overflow-demo"
+
+LONG_QUESTION = (
+    "The remediation touches the mobile projection wire, the phone's ask card, "
+    "the subagent roster and the session layout column, and each of those has a "
+    "different blast radius on the terminal viewer. Which sequencing do you want "
+    "for the rollout, given that the phone bundle ships inside the wheel and the "
+    "terminal viewer reads the same projection fold?"
+)
+
+OPTION_DESCRIPTIONS = [
+    "Land the layout cap first and leave the roster default alone, so the "
+    "smallest possible diff reaches the released wheel and the roster change "
+    "can be judged against a card that already cannot overflow.",
+    "Land the roster default first, because it is the change the operator "
+    "actually reported, and accept that a long ask still clips until the "
+    "second patch lands in the following release window.",
+    "Land both together in one patch, which is the shape under review here: "
+    "the two defects share the same layout column and reviewing them apart "
+    "means reading the same contract twice.",
+    "Hold both behind a feature flag read off the projection, so a phone on an "
+    "older bundle keeps today's behaviour and the rollout can be reverted "
+    "without cutting a release.",
+    "Split the work by surface rather than by defect: one patch for every "
+    "collapsible panel in the column, another for every card pinned above the "
+    "composer, which is a larger diff but a cleaner contract.",
+    "Rewrite the column as a single scroll container with sticky header and "
+    "composer, which removes the whole class of defect and is far too large a "
+    "change to review inside this window.",
+    "Defer everything to the next minor and ship only a documentation note in "
+    "AGENTS.md describing the overflow, which leaves the operator's phone "
+    "broken but costs nothing to review.",
+    "Cap the card at a fixed pixel height instead of a viewport fraction, "
+    "which is simpler to reason about and wrong on every device whose screen "
+    "is not the one it was measured on.",
+    "Move the ask card into a modal sheet over the transcript, reusing the "
+    "existing sheet idiom and its scroller, at the cost of hiding the "
+    "conversation the question is about.",
+    "Escalate to the operator with the measured frames and let him pick the "
+    "sequencing, which is what this fixture's evidence is for and the option "
+    "that has to stay reachable at the bottom of a ten-option list.",
+]
+
+APPROVAL_DETAIL = (
+    'bash — export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH" && cd '
+    "~/workspace/repos/lo-mobile-ask-collapse/local_operator/mobile/web && "
+    "pnpm install --frozen-lockfile && pnpm build && pnpm test && "
+    "cd ../../.. && .venv/bin/python -m flake8 local_operator && "
+    ".venv/bin/python -m black --check local_operator && "
+    ".venv/bin/python -m pytest tests/unit/mobile -q\n\n"
+    "The command rebuilds the phone bundle in place and runs the vitest suite. "
+    "It writes into the worktree's dist/ directory, which is gitignored, and it "
+    "reads no credentials. Approving it authorises the whole pipeline, including "
+    "the prebuild step that regenerates themes.generated.css and src/lib/mark.ts "
+    "from their sources, so a stale generated file becomes a real diff in the "
+    "working tree rather than a silent mismatch at review time.\n\n"
+    "It then runs the Python gates against the same worktree. Those read the "
+    "worktree's own .venv, which is installed editable from this checkout, so "
+    "nothing here resolves the parent repository's tree — verified by importing "
+    "local_operator and printing its __file__ before the run. The pytest "
+    "selection is scoped to tests/unit/mobile because the diff under review is "
+    "confined to the phone bundle's TypeScript, and the root conftest caps xdist "
+    "worker count so a concurrent sibling worktree is not starved of memory.\n\n"
+    "Nothing in this pipeline reaches the network beyond the pnpm store, which "
+    "is already populated, and nothing touches the operator's live daemon, "
+    "their real tunnel, or any registrant socket. Denying it leaves the tree "
+    "exactly as it is; the only cost is that the evidence for the review round "
+    "has to be regenerated by hand afterwards, which is slower but not lossy."
+)
+
+
+def _roster_projection() -> SessionProjection:
+    """22 rows, one running — the reported ``subagents 1/22 running`` screen.
+
+    The transcript is deliberately non-empty: the defect is the roster pushing a
+    real conversation off the top, and an empty transcript would hide it behind
+    the "no messages yet" placeholder instead.
+    """
+    projection = SessionProjection(
+        session_id="roster",
+        pid=900001,
+        kind="tui",
+        conversation_name="Roster overflow",
+        streaming=True,
+        activity="coordinating remediation",
+        activity_started_s=612,
+        transcript=[
+            TranscriptEntry(
+                id=f"r-{i}",
+                kind="user" if i % 2 == 0 else "assistant",
+                text=(
+                    "Audit every mobile surface against the phone viewport."
+                    if i % 2 == 0
+                    else "Fanning the audit out across one subagent per surface; "
+                    "this line is the conversation the roster must not cover."
+                ),
+            )
+            for i in range(6)
+        ],
+        version=7,
+    )
+    projection.subagents = [
+        SubagentRow(
+            job_id="row-00",
+            label="viewport-audit-running",
+            agent="reviewer",
+            status="running",
+            progress="measuring the session column",
+            elapsed_s=612,
+            parent_job_id=None,
+            session_id="roster-child-00",
+            activity="measuring the session column",
+        )
+    ] + [
+        SubagentRow(
+            job_id=f"row-{i:02d}",
+            label=f"surface-audit-{i:02d}",
+            agent="coder" if i % 2 else "designer",
+            status="completed",
+            elapsed_s=30 + i,
+            parent_job_id=None,
+            session_id=f"roster-child-{i:02d}",
+            result_text=f"Surface {i} measured.",
+        )
+        for i in range(1, 22)
+    ]
+    return projection
+
+
+def _ask_projection() -> SessionProjection:
+    projection = SessionProjection(
+        session_id="ask-long",
+        pid=900002,
+        kind="tui",
+        conversation_name="Ask overflow",
+        streaming=False,
+        transcript=[
+            TranscriptEntry(
+                id="a-1",
+                kind="user",
+                text="Decide the rollout sequencing for the mobile layout fixes.",
+            ),
+            TranscriptEntry(
+                id="a-2",
+                kind="assistant",
+                text="Both defects share the session column, so the sequencing matters.",
+            ),
+        ],
+        version=3,
+    )
+    projection.pending = PendingRequest(
+        request_id="req-ask-long",
+        kind="ask",
+        title=LONG_QUESTION,
+        options=[
+            AskOptionWire(label=f"option-{i + 1:02d}", description=text)
+            for i, text in enumerate(OPTION_DESCRIPTIONS)
+        ],
+    )
+    projection.pending_count = 1
+    return projection
+
+
+def _approval_projection() -> SessionProjection:
+    projection = SessionProjection(
+        session_id="approval",
+        pid=900003,
+        kind="tui",
+        conversation_name="Approval overflow",
+        streaming=False,
+        transcript=[
+            TranscriptEntry(id="p-1", kind="user", text="Rebuild the bundle and run the suite."),
+        ],
+        version=2,
+    )
+    projection.pending = PendingRequest(
+        request_id="req-approval",
+        kind="approval",
+        title="bash",
+        detail=APPROVAL_DETAIL,
+    )
+    projection.pending_count = 2
+    return projection
+
+
+def _free_text_projection() -> SessionProjection:
+    projection = SessionProjection(
+        session_id="ask-free",
+        pid=900004,
+        kind="tui",
+        conversation_name="Secret ask",
+        streaming=False,
+        transcript=[
+            TranscriptEntry(id="f-1", kind="user", text="Load the staging token."),
+        ],
+        version=2,
+    )
+    projection.pending = PendingRequest(
+        request_id="req-ask-free",
+        kind="ask",
+        title=LONG_QUESTION,
+        detail="\n\n".join(OPTION_DESCRIPTIONS[:4]),
+        secret=True,
+        persist=True,
+    )
+    projection.pending_count = 1
+    return projection
+
+
+async def main() -> None:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 4187
+    daemon = MobileDaemon(port=port, password=PASSWORD, dial_registrants=False)
+    for projection in (
+        _roster_projection(),
+        _ask_projection(),
+        _approval_projection(),
+        _free_text_projection(),
+    ):
+        record = SessionRecord(
+            pid=projection.pid,
+            kind="tui",
+            session_id=projection.session_id,
+            conversation_name=projection.conversation_name,
+            cwd="/synthetic",
+            model_label="fixture",
+            control_port=1,
+            control_key="fixture",
+        )
+        entry = SessionEntry(record)
+        entry.projection = projection
+        daemon.session_projections[projection.session_id] = projection
+        daemon.table.entries[record.pid] = entry
+    app = build_app(daemon)
+    print(f"Fixture mobile: http://127.0.0.1:{port} password {PASSWORD}", flush=True)
+    await uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    ).serve()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/mobile_overflow_fixture.py
+++ b/scripts/mobile_overflow_fixture.py
@@ -14,6 +14,15 @@ Three sessions, each one shaped to isolate one surface:
   remember), which overflows identically.
 * ``ask-free`` — the free-text/secret variant, to prove the cap does not strand
   the input or its send button.
+* ``stacked`` / ``stacked-approval`` — todos panel AND subagent roster AND a
+  pending request in ONE column. This is the screen the operator actually has,
+  and the one the per-panel caps could not bound: each region was individually
+  capped while their SUM overran the column, which is `overflow-hidden`, so the
+  decision controls were clipped rather than scrolled (D1).
+* ``stale`` — an ask whose answers are refused as moved-on, so the error line's
+  position can be measured on arrival rather than inferred (U3).
+* ``failures`` — a fan-out with failed agents, for the collapsed header's
+  failure count (U5).
 
 No runtime scanner and no registrant sockets (``dial_registrants=False``), so
 this never touches the operator's live daemon or their sessions. HOME and
@@ -35,6 +44,8 @@ from local_operator.mobile.types import (
     SessionProjection,
     SessionRecord,
     SubagentRow,
+    TodoItem,
+    TodoPhase,
     TranscriptEntry,
 )
 
@@ -247,6 +258,109 @@ def _free_text_projection() -> SessionProjection:
     return projection
 
 
+def _stacked_projection(session_id: str, approval: bool) -> SessionProjection:
+    """Todos + roster + a pending request in one column (D1).
+
+    The panels are what make this distinct from the plain ask/approval
+    scenarios: each region carries its own cap, but caps do not compose — two
+    panels at 40% plus a card at 60% demand 140% of a column that cannot
+    scroll, so whatever lands past the foot is CLIPPED. Measured before the
+    fix: approve/deny 120px below the fold at 390x844 with the card's own
+    scroller already at its end, and at 360x780 the card's top at y=781 in a
+    780px viewport.
+    """
+    projection = SessionProjection(
+        session_id=session_id,
+        pid=900005 if approval else 900006,
+        kind="tui",
+        conversation_name="Stacked panels",
+        streaming=True,
+        activity="coordinating remediation",
+        activity_started_s=612,
+        transcript=[
+            TranscriptEntry(
+                id=f"s-{i}",
+                kind="user" if i % 2 == 0 else "assistant",
+                text="The conversation the panels and the card compete with.",
+            )
+            for i in range(6)
+        ],
+        version=5,
+    )
+    projection.subagents = _roster_projection().subagents
+    projection.todos = [
+        TodoPhase(
+            name="Remediation",
+            items=[
+                TodoItem(text=f"Land finding {i:02d} and re-measure it", status="pending")
+                for i in range(1, 13)
+            ],
+        )
+    ]
+    if approval:
+        projection.pending = PendingRequest(
+            request_id="req-stacked-approval",
+            kind="approval",
+            title="bash",
+            detail=APPROVAL_DETAIL,
+        )
+    else:
+        projection.pending = PendingRequest(
+            request_id="req-stacked-ask",
+            kind="ask",
+            title=LONG_QUESTION,
+            options=[
+                AskOptionWire(label=f"option-{i + 1:02d}", description=text)
+                for i, text in enumerate(OPTION_DESCRIPTIONS)
+            ],
+        )
+    projection.pending_count = 1
+    return projection
+
+
+def _failures_projection() -> SessionProjection:
+    """A fan-out with failures (U5).
+
+    Collapsing the roster by default is right, but it took the status glyphs
+    off screen with it — and `1/22 running` is exactly what a healthy session
+    shows, so three failed agents were indistinguishable from none.
+    """
+    projection = _roster_projection()
+    projection.session_id = "failures"
+    projection.pid = 900007
+    projection.conversation_name = "Failing fan-out"
+    for rowobj in projection.subagents[1:4]:
+        rowobj.status = "failed"
+        rowobj.error_text = "surface probe exited 1"
+    return projection
+
+
+def _stale_projection() -> SessionProjection:
+    """An ask whose answers the daemon refuses as moved-on (U3).
+
+    `control_port=1` means every answer fails, which is what this scenario
+    wants: the point is WHERE the resulting error line renders, and before the
+    fix it was appended as the scroller's last child — i.e. ~26px below
+    wherever the user was standing, which is the foot of the option list,
+    because that is where they had just tapped.
+    """
+    projection = _ask_projection()
+    projection.session_id = "stale"
+    projection.pid = 900008
+    projection.conversation_name = "Stale tap"
+    projection.pending = PendingRequest(
+        request_id="req-stale",
+        kind="ask",
+        title=LONG_QUESTION,
+        options=[
+            AskOptionWire(label=f"option-{i + 1:02d}", description=text)
+            for i, text in enumerate(OPTION_DESCRIPTIONS)
+        ],
+    )
+    projection.pending_count = 1
+    return projection
+
+
 async def main() -> None:
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 4187
     daemon = MobileDaemon(port=port, password=PASSWORD, dial_registrants=False)
@@ -255,6 +369,10 @@ async def main() -> None:
         _ask_projection(),
         _approval_projection(),
         _free_text_projection(),
+        _stacked_projection("stacked", approval=False),
+        _stacked_projection("stacked-approval", approval=True),
+        _failures_projection(),
+        _stale_projection(),
     ):
         record = SessionRecord(
             pid=projection.pid,

--- a/scripts/mobile_reachability_check.py
+++ b/scripts/mobile_reachability_check.py
@@ -1,0 +1,365 @@
+"""Assert the phone's REACHABILITY contract with real touch input.
+
+Run:  PYTHONPATH=. .venv/bin/python scripts/mobile_reachability_check.py <port>
+
+This is the layer that proves what the vitest suite structurally cannot. The
+web tests run under happy-dom, which does no layout: every box is 0x0, so
+"approve is 44px tall on arrival" and "a finger reaches option-10" are not
+questions that environment can answer. It can only assert the STRUCTURE that
+produces the layout. Round 1 of review on PR #1018 is the cautionary case —
+four of seven assertions compared a class name in the test to the same class
+name in the source, which passes for a cap that is present but ineffective, and
+an approval card shipped with its primary action 0px visible at 360x780.
+
+So the properties below are measured, in a real engine, after real gestures:
+
+  R1  a capped card's cap tracks the COLUMN, not the dynamic viewport, so it
+      still binds while the keyboard is open (C1/U1)
+  R2  the primary action is fully visible ON ARRIVAL, at or above the 44px iOS
+      tap-target floor, before any gesture (U2/Q1)
+  R3  the last option of a long list is reachable BY GESTURE (the original
+      reported defect)
+  R4  the stale-tap error is visible where it renders, not below the fold (U3)
+  R5  with panels and a pending card stacked, every control is finger-reachable
+      and nothing is clipped (D1)
+
+R1's test is the important one to get right, and it is easy to get wrong. The
+obvious way to simulate a keyboard — shrinking the viewport with
+``Emulation.setDeviceMetricsOverride`` — moves the layout viewport AND the
+visual viewport together, so ``dvh`` shrinks along with the column and a broken
+``dvh`` cap looks fine. That artefact hid this defect from a review round's
+first attempt. A real iOS keyboard is an OVERLAY: it shrinks
+``visualViewport.height`` and leaves the dynamic viewport untouched. CDP cannot
+express that divergence directly (``Emulation.setVisibleSize`` is accepted and
+does nothing observable on current headless Chrome — measured), so this script
+reproduces the geometry the way the app itself does: it pins the column to a
+keyboard-reduced height exactly as ``screens/session-view.tsx`` does on a
+``visualViewport`` resize, leaving device metrics at full height so ``dvh`` is
+unchanged, and then measures. That is the divergence, driven through the app's
+own mechanism rather than a browser flag.
+
+Follows AGENTS.md §6 for the browser itself; see mobile_overflow_capture.py,
+whose Chrome/Page helpers this reuses rather than duplicating.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from scripts.mobile_overflow_capture import (
+    PASSWORD,
+    VIEWPORTS,
+    Chrome,
+    Page,
+    gesture_scroll_all,
+)
+
+# The tap-target floor the Button primitive documents, and the number U2 failed
+# against: 30px of a 44px control reads as tappable while sitting under it.
+TAP_FLOOR = 44
+
+# Keyboard heights to drive R1 at. These are the ones the UX round measured the
+# failure against, and 300px is a plain iOS portrait keyboard — the cap has to
+# hold at all of them, not just the smallest.
+KEYBOARD_HEIGHTS = (260, 300, 336)
+
+
+MEASURE_JS = """
+(() => {
+  const vis = (el) => {
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const top = Math.max(r.top, 0);
+    const bottom = Math.min(r.bottom, window.innerHeight);
+    return {
+      h: Math.round(r.height),
+      visible: Math.max(0, Math.round(bottom - top)),
+      fully: r.top >= 0 && r.bottom <= window.innerHeight && r.height > 0,
+    };
+  };
+  const byText = (re) =>
+    [...document.querySelectorAll('button')].find((b) => re.test(b.textContent || ''));
+  // The test id is how the shipped card identifies itself. The `.border-accent`
+  // fallback exists so this script can also measure a PRE-FIX tree, which
+  // predates the id — a before/after pair has to be captured by one instrument
+  // or the comparison measures the instrument. It is a fallback and not the
+  // primary selector because that class is also applied by composer.tsx on
+  // drag-over and by new-session.tsx on selection.
+  const card =
+    document.querySelector('[data-testid="pending-card"]') ||
+    document.querySelector('.border-accent');
+  const col = document.querySelector('[class*="h-dvh"]');
+  // Scoped to the CARD. `.border-l-accent` is also the transcript's message
+  // bubble, so an unscoped query measures a scrolled-away chat message and
+  // reports the card's first option as off screen — a harness bug that reads
+  // exactly like the defect under test.
+  const opts = card ? [...card.querySelectorAll('.border-l-accent')] : [];
+  const err = [...document.querySelectorAll('p')].find((p) =>
+    /moved on|Already answered|didn.t respond|went away/.test(p.textContent || ''),
+  );
+  return JSON.stringify({
+    viewport: [window.innerWidth, window.innerHeight],
+    visualViewport: window.visualViewport
+      ? Math.round(window.visualViewport.height)
+      : null,
+    column: col
+      ? {
+          clientH: col.clientHeight,
+          scrollH: col.scrollHeight,
+          clipped: col.scrollHeight - col.clientHeight,
+          styleH: col.style.height || null,
+        }
+      : null,
+    card: card
+      ? {
+          top: Math.round(card.getBoundingClientRect().top),
+          bottom: Math.round(card.getBoundingClientRect().bottom),
+          h: Math.round(card.getBoundingClientRect().height),
+          capResolved: getComputedStyle(card).maxHeight,
+          withinColumn:
+            !!col &&
+            card.getBoundingClientRect().bottom <= col.getBoundingClientRect().bottom + 1,
+        }
+      : null,
+    approve: vis(byText(/^approve$/)),
+    deny: vis(byText(/^deny$/)),
+    send: vis(byText(/^send$/)),
+    composer: vis(document.querySelector('textarea')),
+    lastOption: vis(opts[opts.length - 1]),
+    optionCount: opts.length,
+    error: err ? { ...vis(err), text: (err.textContent || '').slice(0, 60) } : null,
+    panelsExpanded: [...document.querySelectorAll('[aria-expanded]')].map((b) =>
+      b.getAttribute('aria-expanded'),
+    ),
+  });
+})()
+"""
+
+
+# Pin the column exactly as screens/session-view.tsx does on a visualViewport
+# resize. This is the divergence case: device metrics stay at full height, so
+# `dvh` is UNCHANGED, while the column drops by the keyboard's height — which is
+# what an overlay keyboard does on iOS and what a uniform viewport shrink cannot
+# reproduce. A cap in column units tightens with this; a `dvh` cap does not.
+PIN_COLUMN_JS = """
+(() => {
+  const col = document.querySelector('[class*="h-dvh"]');
+  if (!col) return JSON.stringify({ ok: false });
+  const pinned = window.innerHeight - %d;
+  col.style.height = pinned + 'px';
+  col.style.setProperty('--lo-vvh', pinned + 'px');
+  // Same fallback as MEASURE_JS, so a pre-fix tree can be pinned and measured
+  // by this instrument too.
+  const card =
+    document.querySelector('[data-testid="pending-card"]') ||
+    document.querySelector('.border-accent');
+  return JSON.stringify({
+    ok: true,
+    pinned,
+    dvhUnchanged: window.innerHeight,
+    capResolved: card ? getComputedStyle(card).maxHeight : null,
+  });
+})()
+"""
+
+
+def login(page: Page, base: str) -> None:
+    page.goto(f"{base}/login")
+    page.js(
+        "(() => { const f = document.querySelector('form');"
+        f" f.password.value = {PASSWORD!r}; f.submit(); return true; }})()"
+    )
+    import time
+
+    time.sleep(2.0)
+
+
+def measure(page: Page) -> dict[str, Any]:
+    return json.loads(page.js(MEASURE_JS))
+
+
+def main() -> None:
+    port = int(sys.argv[1])
+    base = f"http://127.0.0.1:{port}"
+    chrome = Chrome()
+    failures: list[str] = []
+    results: dict[str, Any] = {}
+
+    def check(name: str, ok: bool, detail: str) -> None:
+        status = "PASS" if ok else "FAIL"
+        print(f"  [{status}] {name}: {detail}")
+        results[name] = {"ok": ok, "detail": detail}
+        if not ok:
+            failures.append(f"{name}: {detail}")
+
+    try:
+        page = Page(chrome.target_ws())
+        for width, height in VIEWPORTS:
+            vp = f"{width}x{height}"
+            page.metrics(width, height)
+            login(page, base)
+            print(f"\n=== {vp} ===")
+
+            # R2: the approval's primary action, ON ARRIVAL, no gesture.
+            page.goto(f"{base}/#/s/approval")
+            m = measure(page)
+            for label in ("approve", "deny"):
+                got = m[label]
+                check(
+                    f"R2 {vp} {label} visible on arrival",
+                    bool(got) and got["visible"] >= TAP_FLOOR,
+                    f"{got and got['visible']}/{TAP_FLOOR}px visible"
+                    f" (height {got and got['h']}px)",
+                )
+            check(
+                f"R2 {vp} card within column",
+                bool(m["card"]) and m["card"]["withinColumn"],
+                f"card {m['card'] and (m['card']['top'], m['card']['bottom'])}"
+                f" column clientH={m['column'] and m['column']['clientH']}",
+            )
+
+            # R1: the keyboard divergence, driven the way the app drives it.
+            for kb in KEYBOARD_HEIGHTS:
+                pin = json.loads(page.js(PIN_COLUMN_JS % kb))
+                m2 = measure(page)
+                col_bottom = pin["pinned"]
+                # The card must end inside the pinned column, which is the
+                # property `send`/`approve` staying on screen depends on.
+                card_bottom = m2["card"]["bottom"]
+                check(
+                    f"R1 {vp} kb={kb} card inside pinned column",
+                    card_bottom <= col_bottom + 1,
+                    f"card bottom {card_bottom} vs column {col_bottom}"
+                    f" (dvh still {pin['dvhUnchanged']}, cap {pin['capResolved']})",
+                )
+                for label in ("approve", "deny"):
+                    got = m2[label]
+                    if got:
+                        check(
+                            f"R1 {vp} kb={kb} {label} reachable",
+                            got["visible"] >= TAP_FLOOR,
+                            f"{got['visible']}/{TAP_FLOOR}px visible",
+                        )
+
+            # R1 for the variant it actually bites: free-text/secret, where the
+            # keyboard is open BECAUSE the user is typing and `send` is the only
+            # way to submit.
+            page.goto(f"{base}/#/s/ask-free")
+            for kb in KEYBOARD_HEIGHTS:
+                pin = json.loads(page.js(PIN_COLUMN_JS % kb))
+                m2 = measure(page)
+                got = m2["send"]
+                check(
+                    f"R1 {vp} kb={kb} send reachable (secret variant)",
+                    bool(got) and got["visible"] >= TAP_FLOOR,
+                    f"{got and got['visible']}/{TAP_FLOOR}px visible;"
+                    f" column {pin['pinned']}, dvh {pin['dvhUnchanged']},"
+                    f" cap {pin['capResolved']}",
+                )
+
+            # R3: the last of ten options, by gesture only.
+            page.goto(f"{base}/#/s/ask-long")
+            before = measure(page)
+            stranded = gesture_scroll_all(page)
+            after = measure(page)
+            check(
+                f"R3 {vp} option-{after['optionCount']:02d} reachable by gesture",
+                bool(after["lastOption"]) and after["lastOption"]["fully"],
+                f"last option fully visible={after['lastOption'] and after['lastOption']['fully']}"
+                f" (was {before['lastOption'] and before['lastOption']['fully']} on arrival);"
+                f" scrollers still stranded: {len(stranded)}",
+            )
+
+            # R5: the stacked state, with finger gestures only.
+            for session in ("stacked", "stacked-approval"):
+                page.goto(f"{base}/#/s/{session}")
+                m3 = measure(page)
+                clipped = m3["column"]["clipped"] if m3["column"] else -1
+                check(
+                    f"R5 {vp} {session} column not clipped",
+                    clipped <= 1,
+                    f"column clientH={m3['column'] and m3['column']['clientH']}"
+                    f" scrollH={m3['column'] and m3['column']['scrollH']}"
+                    f" clipped={clipped}px;"
+                    f" panels aria-expanded={m3['panelsExpanded']}",
+                )
+                # What must be on screen without a gesture differs by variant,
+                # and conflating the two would assert something false. For the
+                # approval the DECISION itself must be visible — that is U2. For
+                # the options variant the decision is a list that can legitimately
+                # be longer than the card, so the contract is weaker but still
+                # real: the card and its first option are on screen on arrival,
+                # and the tail is reachable by finger. A list needing one swipe
+                # is inherent; a list needing a swipe that does nothing is D1.
+                if m3["approve"]:
+                    check(
+                        f"R5 {vp} {session} decision visible on arrival",
+                        m3["approve"]["visible"] >= TAP_FLOOR,
+                        f"approve {m3['approve']['visible']}/{TAP_FLOOR}px;"
+                        f" card {m3['card'] and (m3['card']['top'], m3['card']['bottom'])}",
+                    )
+                else:
+                    first = json.loads(
+                        page.js(
+                            "(() => { const c ="
+                            " document.querySelector('[data-testid=\"pending-card\"]');"
+                            " const o = c && c.querySelector('.border-l-accent');"
+                            " if (!o) return 'null'; const r = o.getBoundingClientRect();"
+                            " return JSON.stringify({ visible: Math.max(0,"
+                            " Math.round(Math.min(r.bottom, window.innerHeight)"
+                            " - Math.max(r.top, 0))) }); })()"
+                        )
+                    )
+                    check(
+                        f"R5 {vp} {session} first option visible on arrival",
+                        bool(first) and first["visible"] >= TAP_FLOOR,
+                        f"first option {first and first['visible']}/{TAP_FLOOR}px;"
+                        f" card {m3['card'] and (m3['card']['top'], m3['card']['bottom'])}",
+                    )
+                    stranded_stack = gesture_scroll_all(page)
+                    m3b = measure(page)
+                    check(
+                        f"R5 {vp} {session} option tail reachable by gesture",
+                        bool(m3b["lastOption"]) and m3b["lastOption"]["fully"],
+                        f"last option fully visible="
+                        f"{m3b['lastOption'] and m3b['lastOption']['fully']};"
+                        f" scrollers still stranded: {len(stranded_stack)}",
+                    )
+
+            # R4: the stale-tap error, where it renders.
+            page.goto(f"{base}/#/s/stale")
+            gesture_scroll_all(page)
+            page.js(
+                "(() => { const b = [...document.querySelectorAll('button')]"
+                ".filter((x) => /option-/.test(x.textContent));"
+                " if (b.length) b[b.length - 1].click(); return true; })()"
+            )
+            import time
+
+            time.sleep(1.5)
+            m4 = measure(page)
+            err = m4["error"]
+            check(
+                f"R4 {vp} stale-tap error visible",
+                bool(err) and err["visible"] > 0 and err["fully"],
+                f"error {err and err['text']!r} visible={err and err['visible']}px"
+                f" fully={err and err['fully']}",
+            )
+
+        page.close()
+    finally:
+        chrome.close()
+
+    print(f"\n{len(results) - len(failures)}/{len(results)} checks passed")
+    if failures:
+        print("\nFAILURES:")
+        for line in failures:
+            print(f"  - {line}")
+        sys.exit(1)
+    print("All reachability properties hold.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mobile_reachability_check.py
+++ b/scripts/mobile_reachability_check.py
@@ -194,6 +194,28 @@ PIN_COLUMN_JS = """
 """
 
 
+# Undo PIN_COLUMN_JS. A re-`goto` cannot do this: the app is a hash-router SPA,
+# so navigating to the same `#/s/...` is a SAME-DOCUMENT navigation that never
+# reloads, and the pin — inline style on a live DOM node — survives it
+# (measured: the column stayed 508px after the re-goto). Clearing the property
+# and the custom property is the only thing that actually restores the column,
+# and the caller asserts the restore rather than trusting it, because a pin that
+# silently outlives its block makes every later measurement read a stale column.
+UNPIN_COLUMN_JS = """
+(() => {
+  const col = document.querySelector('[class*="h-dvh"]');
+  if (!col) return JSON.stringify({ ok: false });
+  col.style.removeProperty('height');
+  col.style.removeProperty('--lo-vvh');
+  return JSON.stringify({
+    ok: true,
+    clientH: col.clientHeight,
+    innerH: window.innerHeight,
+  });
+})()
+"""
+
+
 def reach_detail(got: dict[str, Any] | None) -> str:
     """Render a control's reachability so a FAIL says which half failed.
 
@@ -204,7 +226,7 @@ def reach_detail(got: dict[str, Any] | None) -> str:
     """
     if not got:
         return "control absent"
-    detail = f"{got['visible']}/{TAP_FLOOR}px visible (height {got['h']}px)," f" hit={got['hit']}"
+    detail = f"{got['visible']}/{TAP_FLOOR}px visible (height {got['h']}px), hit={got['hit']}"
     if not got["hit"]:
         detail += f" — centre lands on {got['hitText']!r}"
     return detail
@@ -285,8 +307,16 @@ def main() -> None:
                     f" column clientH={m['column'] and m['column']['clientH']}",
                 )
             # Unpin, so the R1 block below starts from the same state it always
-            # did rather than inheriting this block's last keyboard.
-            page.goto(f"{base}/#/s/approval")
+            # did rather than inheriting this block's last keyboard. Checked,
+            # not assumed: R1's first act happens to re-pin, so a reset that
+            # silently did nothing would go unnoticed here and mislead whoever
+            # inserts a check between the two blocks.
+            unpinned = json.loads(page.js(UNPIN_COLUMN_JS))
+            check(
+                f"R2 {vp} column unpinned before R1",
+                unpinned["ok"] and unpinned["clientH"] == unpinned["innerH"],
+                f"column clientH={unpinned.get('clientH')} innerH={unpinned.get('innerH')}",
+            )
 
             # R1: the keyboard divergence, driven the way the app drives it.
             for kb in KEYBOARD_HEIGHTS:

--- a/scripts/mobile_reachability_check.py
+++ b/scripts/mobile_reachability_check.py
@@ -68,15 +68,44 @@ KEYBOARD_HEIGHTS = (260, 300, 336)
 
 MEASURE_JS = """
 (() => {
+  // The column is what CLIPS, so it is what visibility is measured against.
+  // `window.innerHeight` is not that box while a keyboard is open: the column
+  // is pinned to `innerHeight - kb` and is `overflow: hidden`, so a control
+  // below the COLUMN's foot is invisible to the user while still sitting above
+  // the window's. Measuring against the window scored `send` 44/44px visible on
+  // a build with the `dvh` cap fully reintroduced, where 0-31px were actually on
+  // screen — the exact assertion U1/C1 asked for, green on the defect it names
+  // (review R1 / UX U7). Falls back to the window when no column is pinned,
+  // which is the keyboard-closed case and genuinely is the clipping box then.
+  const clipBox = () => {
+    const col = document.querySelector('[class*="h-dvh"]');
+    if (!col) return { top: 0, bottom: window.innerHeight };
+    const cr = col.getBoundingClientRect();
+    return {
+      top: Math.max(cr.top, 0),
+      bottom: Math.min(cr.bottom, window.innerHeight),
+    };
+  };
   const vis = (el) => {
     if (!el) return null;
     const r = el.getBoundingClientRect();
-    const top = Math.max(r.top, 0);
-    const bottom = Math.min(r.bottom, window.innerHeight);
+    const clip = clipBox();
+    const top = Math.max(r.top, clip.top);
+    const bottom = Math.min(r.bottom, clip.bottom);
+    const visible = Math.max(0, Math.round(bottom - top));
+    // Geometry says a pixel is painted there; hit-testing says a FINGER lands
+    // on the control. They disagree exactly when something overlays it, which
+    // geometry alone cannot see, so the reachability checks require both.
+    const cx = Math.round(r.left + r.width / 2);
+    const cy = Math.round(r.top + r.height / 2);
+    const hit =
+      cy >= clip.top && cy <= clip.bottom ? document.elementFromPoint(cx, cy) : null;
     return {
       h: Math.round(r.height),
-      visible: Math.max(0, Math.round(bottom - top)),
-      fully: r.top >= 0 && r.bottom <= window.innerHeight && r.height > 0,
+      visible,
+      fully: r.top >= clip.top && r.bottom <= clip.bottom && r.height > 0,
+      hit: !!hit && !!el && (hit === el || el.contains(hit)),
+      hitText: hit ? (hit.textContent || '').trim().slice(0, 28) : null,
     };
   };
   const byText = (re) =>
@@ -165,6 +194,29 @@ PIN_COLUMN_JS = """
 """
 
 
+def reach_detail(got: dict[str, Any] | None) -> str:
+    """Render a control's reachability so a FAIL says which half failed.
+
+    Visible-pixels and hit-testing answer different questions — "is it painted
+    inside the box that clips" and "does a finger landing on its centre reach
+    it" — and a control can pass one while failing the other, so the detail line
+    has to carry both or a failure reads as a mystery.
+    """
+    if not got:
+        return "control absent"
+    detail = f"{got['visible']}/{TAP_FLOOR}px visible (height {got['h']}px)," f" hit={got['hit']}"
+    if not got["hit"]:
+        detail += f" — centre lands on {got['hitText']!r}"
+    return detail
+
+
+def column_detail(pin: dict[str, Any] | None) -> str:
+    """The pinned-column context a keyboard-open failure has to be read against."""
+    if not pin:
+        return ""
+    return f"; column {pin['pinned']}, dvh {pin['dvhUnchanged']}"
+
+
 def login(page: Page, base: str) -> None:
     page.goto(f"{base}/login")
     page.js(
@@ -203,22 +255,38 @@ def main() -> None:
             print(f"\n=== {vp} ===")
 
             # R2: the approval's primary action, ON ARRIVAL, no gesture.
+            #
+            # Run twice: keyboard-closed, then with the column PINNED. The
+            # on-arrival form is the strongest assertion in this file (a full
+            # 44px before the user does anything), and it used to run only in the
+            # easiest state, so the tightest check and the hardest scenario never
+            # met (review R2). A keyboard is open on arrival whenever the user is
+            # already typing when the request lands, which is the ordinary case
+            # for an approval raised mid-composition.
             page.goto(f"{base}/#/s/approval")
-            m = measure(page)
-            for label in ("approve", "deny"):
-                got = m[label]
+            for kb in (None, *KEYBOARD_HEIGHTS):
+                if kb is None:
+                    state, pin = "", None
+                else:
+                    pin = json.loads(page.js(PIN_COLUMN_JS % kb))
+                    state = f" kb={kb}"
+                m = measure(page)
+                for label in ("approve", "deny"):
+                    got = m[label]
+                    check(
+                        f"R2 {vp}{state} {label} visible on arrival",
+                        bool(got) and got["visible"] >= TAP_FLOOR and got["hit"],
+                        reach_detail(got) + column_detail(pin),
+                    )
                 check(
-                    f"R2 {vp} {label} visible on arrival",
-                    bool(got) and got["visible"] >= TAP_FLOOR,
-                    f"{got and got['visible']}/{TAP_FLOOR}px visible"
-                    f" (height {got and got['h']}px)",
+                    f"R2 {vp}{state} card within column",
+                    bool(m["card"]) and m["card"]["withinColumn"],
+                    f"card {m['card'] and (m['card']['top'], m['card']['bottom'])}"
+                    f" column clientH={m['column'] and m['column']['clientH']}",
                 )
-            check(
-                f"R2 {vp} card within column",
-                bool(m["card"]) and m["card"]["withinColumn"],
-                f"card {m['card'] and (m['card']['top'], m['card']['bottom'])}"
-                f" column clientH={m['column'] and m['column']['clientH']}",
-            )
+            # Unpin, so the R1 block below starts from the same state it always
+            # did rather than inheriting this block's last keyboard.
+            page.goto(f"{base}/#/s/approval")
 
             # R1: the keyboard divergence, driven the way the app drives it.
             for kb in KEYBOARD_HEIGHTS:
@@ -239,8 +307,8 @@ def main() -> None:
                     if got:
                         check(
                             f"R1 {vp} kb={kb} {label} reachable",
-                            got["visible"] >= TAP_FLOOR,
-                            f"{got['visible']}/{TAP_FLOOR}px visible",
+                            got["visible"] >= TAP_FLOOR and got["hit"],
+                            reach_detail(got),
                         )
 
             # R1 for the variant it actually bites: free-text/secret, where the
@@ -253,10 +321,8 @@ def main() -> None:
                 got = m2["send"]
                 check(
                     f"R1 {vp} kb={kb} send reachable (secret variant)",
-                    bool(got) and got["visible"] >= TAP_FLOOR,
-                    f"{got and got['visible']}/{TAP_FLOOR}px visible;"
-                    f" column {pin['pinned']}, dvh {pin['dvhUnchanged']},"
-                    f" cap {pin['capResolved']}",
+                    bool(got) and got["visible"] >= TAP_FLOOR and got["hit"],
+                    reach_detail(got) + column_detail(pin) + f", cap {pin['capResolved']}",
                 )
 
             # R3: the last of ten options, by gesture only.

--- a/tests/unit/mobile/test_tui_ask.py
+++ b/tests/unit/mobile/test_tui_ask.py
@@ -404,7 +404,17 @@ async def test_secret_ask_projects_a_free_text_card_without_leaking_the_value() 
             assert pending.secret is True
             wire = handle._fold.projection.to_json()
             assert wire["pending"]["secret"] is True
-            assert "sk-" not in json.dumps(wire)
+            # Scoped to the PENDING PAYLOAD, not the whole serialised
+            # projection. The projection also carries `cwd`, so the whole-dict
+            # form matched the checkout's own path and failed in any worktree
+            # whose name happened to contain "sk-" — which is how it failed in
+            # `lo-mobile-a`sk-`collapse`, reporting a credential leak that was
+            # really the directory name. Narrowing it does not weaken what it
+            # protects: the secret only ever reaches the projection through
+            # `pending`, so that is the surface where a leak would appear, and
+            # the assertion still fails if the value lands in the title, the
+            # detail, the options, or any field added to the payload later.
+            assert "sk-" not in json.dumps(wire["pending"])
             request_id = pending.request_id
 
             reply = await control.send("ask_answer", request_id=request_id, value="sk-supersecret")


### PR DESCRIPTION
Release: patch — the phone opens on the conversation instead of the subagent roster, and a long ask keeps every option tappable

# PR Description

## Summary of Changes

Two phone layout defects in the session column. Both take the conversation, or the controls that answer a question, off screen with **no gesture that recovers them** — the column is `h-dvh … overflow-hidden` with the transcript as its only `flex-1` scroller, so anything past its foot is clipped rather than scrolled.

**1. A conversation opened with its subagent roster expanded.** `AgentRoster` used `defaultOpen={running > 0}`, so *any* running subagent opened the roster on arrival — which is the normal state of a coordinating session, not an exception. The operator's real screen showed `subagents 1/22 running` with 22 rows covering the transcript.

The todos panel beside it already carries the precedent and the reasoning (see its module docstring: the panel sits above the transcript, so an auto-expanded list pushed the conversation off the top). The roster now applies the same two guards: it starts **collapsed** — the header's `n/m running` count is the at-a-glance signal, and it is kept verbatim — and its expanded body is **capped at ~40dvh with internal `lo-scroll`**, so even a 22-row fan-out cannot crowd out the messages. `aria-expanded` and the `min-h-11` row tap targets are unchanged.

The non-collapsible roster is deliberately left uncapped: it is the whole point of the surface hosting it, and a nested scroller inside a page that already scrolls is the second-competing-pattern the `Disclosure` docstring warns about. The cap belongs where the roster is a *secondary* panel above a transcript.

**2. The ask popup overflowed and its options could not be scrolled to.** `PendingCard` had no max height and no scroller while being an unshrinkable sibling of the transcript, so it simply grew past the viewport. Measured at 390x844: a 10-option ask with paragraph-length descriptions rendered a **1426px** card against an **844px** viewport, so options 06–10 *and the composer* were off screen with nothing to scroll. The approval variant overflowed identically, putting approve/deny below the fold.

The card is now capped at **~60% of the session column** (see the round-1 section below: this was `60dvh` as originally submitted, which does not bind when the keyboard is open) and its scrolling body is a `lo-scroll … overflow-y-auto` scroller, the same idiom the todos panel and the sheet use. Three details are load-bearing and commented as such:

- **The question rides inside the scroller, not pinned above it.** On a phone a paragraph-length question can outgrow the cap on its own; pinning it would reintroduce the same unreachable tail the cap exists to prevent.
- **`min-h-0` on the scroller.** A flex child defaults to `min-height: auto` and refuses to shrink below its content, which is precisely how the card grew past the viewport in the first place.
- **60%, not 40% and not a pixel height.** A question awaiting an answer outranks a task list (branding §7), and a fixed pixel bound is correct only on the device it was measured on.

## Related Issue(s)

- Related: none filed; both reported from the operator's phone.

## Impact

- No breaking changes, no dependency updates, no API or wire surface touched. `pyproject.toml` is untouched (combined-release rule).
- Confined to two components in the phone bundle plus two new capture scripts under `scripts/`. The terminal viewer is unaffected — it renders neither component.
- Behaviour change a user will notice: a session with running subagents now opens on the conversation, and the roster is one tap away instead of open. That is the intent; the header count keeps the signal.

## Reproduction

A new fixture serves the **real** mobile bundle (`build_app` + `MobileDaemon`, `dial_registrants=False`, no runtime scanner, HOME/config re-homed by `scripts.probe_isolation`) with four synthetic projections: a 22-row roster with one running, a 10-option ask with long descriptions, an approval with a long detail, and the secret/free-text variant.

```sh
# before-frames: a throwaway worktree at origin/main, so no checkout is reverted
git worktree add --detach /tmp/lo-before-mobile origin/main
(cd /tmp/lo-before-mobile/local_operator/mobile/web && pnpm install && pnpm build)

PYTHONPATH=. .venv/bin/python scripts/mobile_overflow_fixture.py 4194 &
.venv/bin/python scripts/mobile_overflow_capture.py 4194 /tmp/evidence/before before
```

`mobile_overflow_capture.py` drives headless Chrome over CDP per AGENTS.md §6 — unique `mktemp` profile, `--remote-debugging-port=0` with the port read from `DevToolsActivePort`, `--headless=new`, `Emulation.setDeviceMetricsOverride` for the viewport, `start_new_session=True` + an `atexit` sweep that **asserts zero** leftover processes (it did, every run). It scrolls every scroller to its end before measuring, so anything still off screen is genuinely unreachable rather than merely un-scrolled.

**Observed before the fix** (`lastOpt` is the last option's box; `insideViewport` is after scrolling everything to its end):

```
before-390x844-roster-top      lastOpt=(-57, -1, False)      composer=False
before-360x780-roster-top      lastOpt=(-78, -22, False)     composer=False
before-390x844-ask-long-bottom card=(57, 1485) lastOpt=(1359, 1474, False) composer=False
before-360x780-ask-long-bottom card=(57, 1565) lastOpt=(1419, 1554, False) composer=False
before-390x844-approval-bottom card=(57, 909)  composer=False
before-360x780-approval-bottom card=(57, 987)  composer=False
```

The roster case is the sharpest number: the transcript's scroller reported **`clientH: 16`** against `scrollH: 367` — a 16-pixel conversation — while the column's `scrollH` was 1309 inside an 844px viewport.

**After:**

```
after-390x844-roster-top       lastOpt=(294, 350, True)      composer=True
after-360x780-roster-top       lastOpt=(336, 392, True)      composer=True
after-390x844-ask-long-bottom  card=(242, 748) lastOpt=(621, 737, True)  composer=True
after-360x780-ask-long-bottom  card=(216, 684) lastOpt=(538, 673, True)  composer=True
after-390x844-approval-bottom  card=(242, 748) composer=True
after-360x780-approval-bottom  card=(216, 684) composer=True
```

Every card now ends **at or above** the composer (748 < 844, 684 < 780), and the last option's `insideViewport` flips `False → True` at both viewports. Note `after-*-ask-long-top` still reports `lastOpt=(1543, …, False)` — that is the *unscrolled* frame, and it is the point: the tail is reached by scrolling, which is exactly what was impossible before.

## Evidence

Before/after at the same viewport, same fixture, same headless mode (never a cross-mode pair). Full set plus both geometry JSONs on the `evidence/pr-mobile-collapse-ask-scroll` branch, per AGENTS.md §7.

**(a) A fresh session with subagents present**

![roster 390x844](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-mobile-collapse-ask-scroll/frames/compare-roster-390.png)

![roster 360x780](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-mobile-collapse-ask-scroll/frames/compare-roster-360.png)

The header line survives the change — `subagents 1/22 running` is visible in both after-frames, directly above the composer.

**(b) A 10-option ask, scrolled to the bottom so the LAST option is visible**

![ask 390x844](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-mobile-collapse-ask-scroll/frames/compare-ask-390.png)

![ask 360x780](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-mobile-collapse-ask-scroll/frames/compare-ask-360.png)

Both before-frames are already scrolled as far as the page allows and still end at option-05; `option-10` is fully visible and tappable in both after-frames.

**(c) The approval card with its buttons visible**

![approval 390x844](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-mobile-collapse-ask-scroll/frames/compare-approval-390.png)

![approval 360x780](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-mobile-collapse-ask-scroll/frames/compare-approval-360.png)

**(d) The roster expanded by tap — the cap and its internal scroll**

![roster expanded](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-mobile-collapse-ask-scroll/frames/after-roster-expanded-390.png)

Scrolled to `surface-audit-21`, with the transcript, the working line and the composer all still on screen.

**(e) The free-text/secret variant**

![secret](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-mobile-collapse-ask-scroll/frames/compare-secret-390.png)

## Testing Details

New file `src/session-view.overflow.test.tsx` — 7 tests against the **real `SessionScreen`**, not the components in isolation, so a reverted default or a dropped cap fails here.

**The tests were proven able to fail**, by running the new file against the pristine `origin/main` sources in the throwaway before-worktree (no checkout was reverted to do this):

```
× roster collapsed even while an agent runs   → expected 'true' to be 'false'
× expands on tap into a capped body           → expected 'false' to be 'true'
× caps the card, last of ten reachable        → expected '…' to contain 'max-h-[60dvh]'
× scrolls the question too                    → expected null not to be null
× bounds the approval variant                 → expected '…' to contain 'max-h-[60dvh]'
× bounds the free-text/secret variant         → expected '…' to contain 'max-h-[60dvh]'
✓ keeps the roster collapsed when nothing is running   (correctly passes on both trees)
Tests  6 failed | 1 passed (7)
```

happy-dom performs no layout, so these assert the structural contract that *produces* the layout — `aria-expanded`, and the cap/scroller classes on the card's own elements — rather than pixels the environment cannot supply. The pixels are the CDP frames above.

Gates, from `local_operator/mobile/web` and the worktree root:

```
pnpm build                    ✓ built in 621ms — tsc -b clean (the only typecheck)
pnpm test                     16 files, 93 passed (was 86; +7)
flake8 .                      0
black --check                 2 files (mine) clean; 1258 unchanged tree-wide
isort --check                 clean on mine
pyright                       0 errors, 0 warnings, 0 informations
```

The worktree owns its own venv, verified per AGENTS.md before anything was trusted:
`.venv/bin/python -c "import local_operator; print(local_operator.__file__)"` →
`/Users/damian/workspace/repos/lo-mobile-ask-collapse/local_operator/__init__.py`.

Two pre-existing `isort --check .` failures tree-wide (`evaluation/runner/provider_client.py`, `session/runtime/serving.py`) reproduce unchanged on `origin/main` in the before-worktree and are **not** from this diff; left alone as out of scope.

The Python unit suite is not run here: this diff adds no importable package code (both new files are standalone `scripts/`, not imported by `local_operator`), so no unit test can observe it. The gate that *can* observe this diff is the `Mobile web` workflow, which is path-gated on `local_operator/mobile/web/**` and runs exactly the two commands above.

## Not addressed

- **The root column's `overflow-hidden` is still absolute.** Both fixes bound their own panel rather than making the column scrollable, which matches the existing idiom (capped region + `lo-scroll`) and keeps the composer pinned. A third unshrinkable sibling could reintroduce the same class of defect; making the column itself the scroller is the larger refactor and is not attempted here.
- ~~**The 40dvh/60dvh bounds are not adaptive.** … Each is individually bounded and each scrolls, so nothing becomes unreachable, but no budget is shared between them.~~
  **CORRECTED in review round 1 — the struck claim above was false, and is fixed in `2c43bb024`.** The design round falsified it from a frame: with both panels expanded beside an approval the column measured `clientH 844 / scrollH 1427` (293px clipped) at 390x844, and at 360x780 the ask card's top landed at **y=781 in a 780px viewport** — entirely off screen. Because the column is `overflow-hidden`, that content was **clipped rather than scrolled**, and real touch drags over the panels and over the card recovered none of it (`colScrollTop=0` throughout); only a script assigning `scrollTop` appeared to recover it, which a finger cannot do. So "nothing becomes unreachable" was not a conservative statement — it was wrong, and it is corrected here because the next agent to touch this column would have read it as a measured fact.
  There is now a budget rather than three independent caps: **while a request is pending the panels render collapsed and hold shut** (a question outranks a task list, branding §7), and both carry `min-h-0` so the column can fit its children rather than clip them. Measured after: `clientH 844 / scrollH 844`, clipped **0px**, approve/deny 44/44px visible on arrival at both viewports.
- ~~**The card's scrollbar overlaps the option text's right edge**…~~ **Ruled on in review round 1 and resolved in `2c43bb024`.** The design round measured it and split the case: over prose the overlay behaviour is the app-wide `lo-scroll` idiom and is ACCEPTABLE (a gutter would cost 4px of line length on every card at 360px), but over a *control* it is not — the thumb painted inside `deny` and `send` at `gapToContentEdge = 0`. `pr-1.5` now applies to the control rows only; prose is deliberately unchanged.
- **`docs/evidence/mobile-subagent-fullscreen/`** still sits in the tree from before the AGENTS.md §7 sweep. Not touched.
- ~~No design/UX review round yet~~ — **four independent rounds are on this PR** (reviewer, QA, design, UX), all remediated in `2c43bb024`. See the four `remediation — round 1` comments.

## Review round 1 — what changed since `12f95f3f6`

The four rounds found one root cause wearing several faces: **content and controls shared one scroller, and the caps were written in a unit that does not match the viewport the column is pinned to.** Both are fixed at the root.

- **The unit (C1/U1).** `60dvh` follows the *dynamic* viewport; the column is pinned to `visualViewport.height`. A keyboard is an overlay, so it shrinks one and not the other — at 360x780 with a 300px keyboard the card stayed 468px inside a 480px column and `send` went under the clipped foot. The column now publishes `--lo-vvh` from the same sync that pins it, and every cap is a fraction of that (`lib/column.ts`).
- **The scroller (U2/Q1, U3).** Capping the card put its own controls below the fold — `approve` arrived at 30/44px at 390x844 and **0/44px** at 360x780. The card is now three regions: a pinned meta row, a scrolling body (title/detail/options), and a pinned `shrink-0` footer holding the controls and the error line.
- **The budget (D1).** See the corrected bullet above.
- Plus D2 (pinned meta row), D3 (`pr-1.5` on control rows), U4 (option count + bottom fade), U5 (`· N failed` in the roster header), U6 (re-pin the transcript on *resize*, preserve the roster's scroll), C3 (delete the dead branch), C5/C6/C7, and G-4 (the secret assertion matched the worktree *path*, not a leak).

**Tests (C4/Q2).** Four of the seven original assertions were class-name echoes that passed for a present-but-ineffective cap — they passed for the U2 regression. Replaced with assertions on resolved style and on containment in both directions, mutation-verified (revert the cap → 4 fail; un-pin the controls → 3 fail; drop the budget → 1 fail). The geometric property lives in the new `scripts/mobile_reachability_check.py`, which drives the real bundle with real touch input: **before 19/44 checks, after 44/44.**

**Harness.** `scripts/mobile_overflow_capture.py` reached clipped regions by assigning `scrollTop` and dispatched no input events, so it reported the D1 state as fine and masked it from design's first pass. It now drives real touch drags and exits non-zero if anything still moves by assignment afterwards.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [ ] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

