### PR TITLE
perf(tui): avoid whole-roster work on scalar viewer updates

### DIFF
--- a/docs/TUI_BACKGROUND_RESPONSIVENESS.md
+++ b/docs/TUI_BACKGROUND_RESPONSIVENESS.md
@@ -1,0 +1,85 @@
+# Background activity and the viewer input loop
+
+The normal terminal frontend is an `AttachedSession`: runtime deltas arrive on
+its event loop, which is also Textual's keyboard and compositor loop. A scalar
+activity update must not serialize, validate or freeze every retained child
+trajectory. It must also not rebuild unrelated compatibility collections.
+
+## Ownership and ordering constraints
+
+- `FrontendStateStore.apply_update` validates the supplied fields through an
+  ephemeral `FrontendSessionState`, then installs only its explicitly supplied
+  fields. This preserves model field validators and `extra="allow"` across mixed
+  runtime/viewer versions. Unchanged owned job payloads remain shared and frozen.
+- Job deltas retain the existing append/replacement and todo-plan merge rules.
+  Todo sequence watermarks are staged with the update, so an invalid later field
+  cannot partially consume a plan. Explicit `jobs=[]` clears; `jobs=null` remains
+  invalid. A degraded frame advances sequence without pretending its omitted
+  body was unchanged; resynchronization still belongs to the attached subscriber.
+- `AttachedSession` replaces the jobs/comms, wakes and MCP compatibility
+  collections only when their fields changed. A full snapshot always replaces
+  all collections, including after reconnect and sequence reset.
+- `SnapshotJobs.get` indexes IDs, but returns a detached Pydantic shell just as
+  before. Its first-duplicate-ID semantics and the ordered list view are retained.
+- The TUI coalescer retains the authoritative session until its scheduled paint,
+  then reads one latest public snapshot. Session-generation invalidation happens
+  before that read, so queued callbacks cannot paint or copy a retired session.
+
+None of these changes caches a mutable job by its identity, trajectory length,
+status or current progress string. Those are not revisions: a bounded trajectory
+can rotate at constant length, and nested usage/todos can change independently.
+
+## Reusable deterministic benchmark
+
+```sh
+.venv/bin/python scripts/bench_tui_background.py \
+  --attached --children 0 10 50 --samples 120 \
+  --capture /tmp/tui-after --output /tmp/tui-after.json
+
+# The same harness and dependencies against an exact baseline source archive:
+.venv/bin/python scripts/bench_tui_background.py \
+  --source-root /tmp/tui-baseline-source \
+  --attached --children 0 10 50 --samples 120 \
+  --capture /tmp/tui-before --output /tmp/tui-before.json
+
+# Keep a long transcript scrolled away from the live tail while slow backend
+# pricing work completes. This records each composed frame's scroll offset.
+.venv/bin/python scripts/bench_tui_background.py \
+  --attached --children 50 --samples 120 --scroll --slow-stats-ms 50 \
+  --output /tmp/tui-scroll-io.json
+```
+
+The script isolates HOME/config before any application import, scrubs every
+`CMUX_*`, and uses synthetic session IDs. Production shimmer remains enabled;
+the capture helper's usual no-animation setting would remove part of the load
+being measured. No provider requests or operator sessions are needed.
+
+The owner mode (without `--attached`) uses the real job ledger, canonical state
+projection and progress event fanout. Attached mode executes the real
+`AttachedSession._on_frontend_update` callback, including validation, facade
+updates and subscriptions, with deterministic wire-shaped deltas. It starts at
+the decoded socket callback, not at a model or an actual transport connection;
+independent end-to-end QA must exercise the latter separately.
+
+An OS thread injects keys independently of the event loop. Timing ends only when
+Textual's actual compositor update contains the new marker in the composer's
+rows. This is **input injection to composed frame**, not `pilot.press`/`pause`
+roundtrip time, and not a claim about a physical terminal's display latency.
+Wrapping is exercised by 120 deterministic characters. Positive/negative
+canaries require an injected blocking sleep to appear in wall latency, a normal
+character to paint, and an absent marker to remain undetected.
+
+A burst is offered every 50ms after the previous burst finishes. Load continues
+until every key has been injected, with `--edges` setting only a minimum number
+of bursts. This prevents the fixed build from finishing its work early and
+measuring most keys on an idle screen. Report achieved event/burst counts and
+throughput: a saturated baseline necessarily services fewer bursts. All offered
+edges must reach the correct final state and every injected character must
+appear in a composed update. Per-operation counts/latencies and loop CPU/wall
+gaps distinguish loop work from ambient host contention. No numeric latency
+ceiling belongs in CI.
+
+Run paired/interleaved baseline and fixed cells on the same host. JSON records
+application source paths/hashes, interpreter and harness hash; verify an archive's
+files against the baseline commit before relying on it. Generated JSON, logs,
+SVGs, geometry and PNGs are external evidence, never repository contents.

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -3812,7 +3812,7 @@ class AttachedSession:
         if self._frontend_store is None:
             raise ConnectionError("frontend update arrived before synchronization")
         state = self._frontend_store.apply_update(update)
-        self._apply_frontend_facades(state)
+        self._apply_frontend_facades(state, changed_fields=set(update.changes))
         if update.degraded:
             # The owner shed this delta's body to keep the line under the socket
             # limit. The sequence was consumed on both sides, so the gap check
@@ -3858,8 +3858,15 @@ class AttachedSession:
                 continue
             self._on_frontend_update(update.model_dump(mode="json"))
 
-    def _apply_frontend_facades(self, state: FrontendSessionState) -> None:
-        """Refresh compatibility facades after one canonical install."""
+    def _apply_frontend_facades(
+        self, state: FrontendSessionState, *, changed_fields: set[str] | None = None
+    ) -> None:
+        """Refresh changed facades; a full snapshot replaces every collection.
+
+        Scalar deltas arrive at token cadence. Rebuilding the job/comms facade
+        on each one copied the entire child roster despite no child changing.
+        None means full install, distinct from an empty degraded delta.
+        """
         self._streaming = state.streaming
         self._generation = state.generation
         self._model = state.selected_model
@@ -3884,10 +3891,13 @@ class AttachedSession:
             and get_provider_definition(selected.provider) is not None
         ):
             self._birth_model = ModelSpec(provider=selected.provider, model_id=selected.model_id)
-        self.jobs.replace(state.jobs)
-        self._subagent_comms.replace(state.jobs)
-        self.wake_scheduler.replace(state.wakes)
-        self.mcp_manager.replace(state.mcp_servers)
+        if changed_fields is None or "jobs" in changed_fields:
+            self.jobs.replace(state.jobs)
+            self._subagent_comms.replace(state.jobs)
+        if changed_fields is None or "wakes" in changed_fields:
+            self.wake_scheduler.replace(state.wakes)
+        if changed_fields is None or "mcp_servers" in changed_fields:
+            self.mcp_manager.replace(state.mcp_servers)
         startup = state.mcp_startup
         if isinstance(startup, Mapping):
             from local_operator.session.mcp_status import McpStartupOutcome

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -2402,12 +2402,19 @@ class SnapshotJobs:
         # deep-copy tuple-backed Mapping/Sequence wrappers: the wrappers must
         # stay immutable while consumers retain their abstract container API.
         self._values = [_public_job(value) for value in values]
+        # Roster rendering asks get() once per row. A linear lookup made one
+        # paint quadratic in the number of children; retain the first duplicate
+        # ID to preserve the old next(...) behaviour for malformed extensions.
+        self._by_id: dict[str, JobState] = {}
+        for value in self._values:
+            self._by_id.setdefault(value.id, value)
 
     def list(self) -> list[JobState]:
         return [_public_job(value) for value in self._values]
 
     def get(self, job_id: str) -> JobState | None:
-        return next((_public_job(value) for value in self._values if value.id == job_id), None)
+        value = self._by_id.get(job_id)
+        return _public_job(value) if value is not None else None
 
 
 class SnapshotWakeScheduler:
@@ -3000,6 +3007,9 @@ class FrontendStateStore:
                 subscriber(update.model_copy(deep=True))
             return self.state
         changes = copy.deepcopy(update.changes)
+        # A malformed field later in a jobs delta must not advance a plan's
+        # watermark: validation either installs the entire update or nothing.
+        todo_sequences = dict(self._todo_sequences)
         if "jobs" in changes:
             previous = {job.id: job for job in self._state.jobs}
             replacements = set(update.job_trajectory_replacements)
@@ -3018,23 +3028,33 @@ class FrontendStateStore:
                     del trajectory[: len(trajectory) - _TRAJECTORY_CAP]
                 raw["trajectory"] = trajectory
                 raw["todos"] = _wire_value(prior.todos) if prior is not None else None
-                if (
-                    job_id in update.job_todo_updates
-                    and update.sequence > self._todo_sequences.get(job_id, -1)
+                if job_id in update.job_todo_updates and update.sequence > todo_sequences.get(
+                    job_id, -1
                 ):
                     raw["todos"] = update.job_todo_updates[job_id]
-                    self._todo_sequences[job_id] = update.sequence
+                    todo_sequences[job_id] = update.sequence
                 rebuilt.append(raw)
             changes["jobs"] = rebuilt
             retained = {str(row["id"]) for row in rebuilt}
-            self._todo_sequences = {
-                key: seq for key, seq in self._todo_sequences.items() if key in retained
+            todo_sequences = {key: seq for key, seq in todo_sequences.items() if key in retained}
+        # Validate only the supplied fields, through the MODEL rather than a
+        # bare TypeAdapter: its before-validators normalize Usage/ModelSpec,
+        # and extra='allow' preserves fields introduced by a newer runtime.
+        # Defaults fill this ephemeral model but are never installed. Dumping
+        # the previous state here serialized every child's retained trajectory
+        # for each scalar streaming edge, blocking the viewer's keyboard loop.
+        patch = FrontendSessionState.model_validate(
+            {
+                "session_id": self._state.session_id,
+                **changes,
+                "epoch": update.epoch,
+                "sequence": update.sequence,
             }
-        payload = self._state.model_dump()
-        payload.update(changes)
-        payload["epoch"] = update.epoch
-        payload["sequence"] = update.sequence
-        self._state = _freeze_state_jobs(FrontendSessionState.model_validate(payload))
+        )
+        normalized = {name: getattr(patch, name) for name in patch.model_fields_set}
+        candidate = self._state.model_copy(update=normalized)
+        self._state = _freeze_state_jobs(candidate, jobs_are_canonical="jobs" not in changes)
+        self._todo_sequences = todo_sequences
         for subscriber in list(self._subscribers):
             subscriber(update.model_copy(deep=True))
         return self.state

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -3051,7 +3051,16 @@ class FrontendStateStore:
                 "sequence": update.sequence,
             }
         )
-        normalized = {name: getattr(patch, name) for name in patch.model_fields_set}
+        # Unknown wire names may collide with our properties or BaseModel
+        # methods (e.g. model_dump). Attribute lookup would substitute the
+        # property/method for the accepted JSON value and poison later exports.
+        # Read validated storage instead; extras have their own owning mapping.
+        normalized = {
+            name: patch.__dict__[name]
+            for name in patch.model_fields_set
+            if name in FrontendSessionState.model_fields
+        }
+        normalized.update(patch.model_extra or {})
         candidate = self._state.model_copy(update=normalized)
         self._state = _freeze_state_jobs(candidate, jobs_are_canonical="jobs" not in changes)
         self._todo_sequences = todo_sequences

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8104,20 +8104,22 @@ class OperatorApp(App[None]):
     def _invalidate_pending_frontend_state(self) -> None:
         """Retire queued paints before another session becomes authoritative."""
         self._frontend_session_generation = getattr(self, "_frontend_session_generation", 0) + 1
-        self._pending_frontend_state = None
+        self._pending_frontend_session = None
         # The old callback remains queued in Textual, but it carries the retired
         # generation and returns without clearing a newer session's scheduled bit.
         self._frontend_apply_scheduled = False
 
     def _on_frontend_update(self, update: Any) -> None:
         session = self._session
-        state = getattr(session, "frontend_state", None) if session is not None else None
         # Socket and local callbacks share this seam. A burst can publish several
         # ordered fields before Textual gets its next turn; only the latest
         # complete snapshot needs painting, while scheduling every intermediate
         # one repeats the full status/band scan and delays keyboard handling.
         generation = getattr(self, "_frontend_session_generation", 0)
-        self._pending_frontend_state = state
+        # Retain the session, not a public snapshot. frontend_state detaches all
+        # child row shells; reading it before the scheduled-bit guard repeated
+        # that O(children) work for EVERY update in a coalesced burst.
+        self._pending_frontend_session = session
         if getattr(self, "_frontend_apply_scheduled", False):
             return
         self._frontend_apply_scheduled = True
@@ -8129,8 +8131,9 @@ class OperatorApp(App[None]):
         if generation != getattr(self, "_frontend_session_generation", 0):
             return
         self._frontend_apply_scheduled = False
-        state = getattr(self, "_pending_frontend_state", None)
-        self._pending_frontend_state = None
+        session = getattr(self, "_pending_frontend_session", None)
+        self._pending_frontend_session = None
+        state = getattr(session, "frontend_state", None) if session is not None else None
         # ONLY on an ordered update, never on the adoption snapshot painted by
         # `_adopt_session`. That snapshot is taken BEFORE the remembered choice
         # is restored onto the fresh session's spec (whose dial defaults off),

--- a/scripts/bench_tui_background.py
+++ b/scripts/bench_tui_background.py
@@ -1,0 +1,491 @@
+"""Measure input injection -> compositor-painted text under synthetic child load.
+
+Run with the worktree interpreter, e.g. ``.venv/bin/python
+scripts/bench_tui_background.py --children 0 10 50 --output /tmp/baseline.json``.
+No provider or retained session is used. Wall latency is an observation, NEVER
+an assertion suitable for CI: the host can deschedule this process. CPU gaps,
+operation counts and positive/negative canaries distinguish that from loop work.
+The paint boundary is Textual's actual compositor update handed to _display,
+not pilot.press/pause and not the physical terminal's presentation latency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import random
+import statistics
+import string
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+_source_parser = argparse.ArgumentParser(add_help=False)
+_source_parser.add_argument("--source-root", default=str(Path(__file__).resolve().parents[1]))
+_source_args, _ = _source_parser.parse_known_args()
+# The small baseline archive may omit test helpers. Fixtures belong to this
+# benchmark's checkout; application imports below MUST resolve the selected
+# source root (asserted in the provenance record).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tests  # noqa: E402,F401
+
+sys.path.insert(0, str(Path(_source_args.source_root).resolve()))
+import scripts.probe_isolation  # noqa: E402,F401
+
+# Isolation normally disables shimmer for stills. The timing workload must keep
+# production animation enabled, or the measurement removes the work it studies.
+os.environ.pop("LOCAL_OPERATOR_NO_SHIMMER", None)
+
+from textual._compositor import ChopsUpdate, LayoutUpdate  # noqa: E402
+from textual.events import Key, MouseScrollUp  # noqa: E402
+
+from local_operator.harness.jobs import AsyncJob, AsyncJobManager  # noqa: E402
+from local_operator.harness.types import SubagentProgressEvent  # noqa: E402
+from local_operator.session.attached import AttachedSession  # noqa: E402
+from local_operator.session.frontend_state import (  # noqa: E402
+    FrontendSessionState,
+    FrontendStateStore,
+    FrontendUpdate,
+)
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.events import SubagentProgress  # noqa: E402
+from local_operator.tui.widgets import subagent_panel  # noqa: E402
+from local_operator.tui.widgets.transcript import NoticeBlock  # noqa: E402
+from scripts.benchmark_residual_child_lag import Timings, _events  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+def summary(values: list[float]) -> dict[str, float | int]:
+    ordered = sorted(values)
+    return {
+        "n": len(values),
+        "p50_ms": statistics.median(values) * 1000 if values else 0,
+        "p95_ms": ordered[int((len(values) - 1) * 0.95)] * 1000 if values else 0,
+        "max_ms": max(values, default=0) * 1000,
+    }
+
+
+class LoadSession(FakeSession):
+    """Real job ledger, state projection and canonical/raw event fanout."""
+
+    def __init__(self, children: int, *, attached: bool = False) -> None:
+        super().__init__()
+        self.jobs = AsyncJobManager(on_job_change=self.changed)
+        self._source_jobs = self.jobs
+        self.pending = False
+        self.delivered = 0
+        self.edges_sent = 0
+        self.raw: Any = None
+        self._frontend_state_store: FrontendStateStore = FrontendStateStore(
+            FrontendSessionState(session_id=self.session_id, epoch="benchmark")
+        )
+        for i in range(children):
+            self.jobs._jobs[f"benchmark-child-{i}"] = AsyncJob(
+                id=f"benchmark-child-{i}",
+                type="task",
+                label=f"Synthetic coder {i}",
+                status="running",
+                start_time=time.time() - 60,
+                started_at=time.time() - 60,
+                trajectory=_events(100),
+                agent_role="coder",
+                prompt="Synthetic load only",
+            )
+        self._frontend_state_store.refresh_jobs(self)
+        self.viewer = None
+        if attached:
+            self.owns_runtime = False
+            self.outcome_is_synchronous = False
+            self.runtime_locality = "this-machine"
+
+            async def never():
+                raise AssertionError("benchmark must not take over a live runtime")
+
+            self.viewer = AttachedSession(
+                config_dir=Path(os.environ["LOCAL_OPERATOR_CONFIG_DIR"]),
+                session_id=self.session_id,
+                takeover_factory=never,
+            )
+            self.viewer._install_frontend(self._frontend_state_store.state)
+            self.jobs = self.viewer.jobs
+            self._subagent_comms = self.viewer._subagent_comms
+            assert self.viewer._frontend_store is not None
+            self._frontend_state_store = self.viewer._frontend_store
+
+    @property
+    def session_id(self) -> str:
+        return "benchmark-parent"
+
+    @property
+    def frontend_state(self):
+        return self._frontend_state_store.state
+
+    def subscribe_frontend(self, callback):
+        return self._frontend_state_store.subscribe(callback)
+
+    def refresh_frontend_usage(self) -> None:
+        pass
+
+    def changed(self) -> None:
+        if not self.pending:
+            self.pending = True
+            asyncio.get_running_loop().call_later(0.05, self.flush)
+
+    def flush(self) -> None:
+        if self.viewer is not None:
+            return
+        self.pending = False
+        self._frontend_state_store.refresh_jobs(self)
+
+    def edge(self, index: int) -> None:
+        self.edges_sent += 1
+        if self.viewer is not None:
+            # Real AttachedSession ingestion, including facade refresh and local
+            # subscriber fanout. The socket codec has already produced this dict
+            # at the production callback boundary; no I/O or models are faked here.
+            for _ in range(max(1, len(self.jobs.list()))):
+                update = FrontendUpdate(
+                    epoch="benchmark",
+                    sequence=self._frontend_state_store._state.sequence + 1,
+                    changes={"activity_phase": f"edge-{index}-{self.delivered}"},
+                )
+                self.viewer._on_frontend_update(update.model_dump(mode="json"))
+                self.delivered += 1
+            return
+        for job in self.jobs.list():
+            event = SubagentProgressEvent(job_id=job.id, label=job.label, progress=f"edge-{index}")
+            self._source_jobs._progress_fn(job.id)(event.progress)
+            self._frontend_state_store.observe_event(self, event)
+            if self.raw is not None:
+                self.raw(event)
+            self.delivered += 1
+
+
+class PaintProbe:
+    """Observe only rendered updates; never force an extra render to find text."""
+
+    def __init__(self, app: OperatorApp) -> None:
+        self.pending: list[tuple[str, float]] = []
+        self.samples: list[float] = []
+        self.frames = 0
+        self.scroll_pending: list[tuple[float, float]] = []
+        self.scroll_samples: list[float] = []
+        self.scroll_frames: list[float] = []
+        original = app._display
+
+        def display(screen, renderable) -> None:
+            original(screen, renderable)
+            if renderable is None:
+                return
+            # Consume the exact composed update, not widget.text (which can be
+            # current while the screen still contains the previous character).
+            region = app._editor().region
+            lines = []
+            if isinstance(renderable, LayoutUpdate):
+                for y, strips in enumerate(renderable.strips, renderable.region.y):
+                    if region.y <= y < region.bottom:
+                        lines.append("".join(strip.text for strip in strips))
+            elif isinstance(renderable, ChopsUpdate):
+                for y in sorted({span[0] for span in renderable.spans}):
+                    if region.y <= y < region.bottom:
+                        lines.append(
+                            "".join(
+                                strip.text
+                                for strip in renderable.chops[y].values()
+                                if strip is not None
+                            )
+                        )
+            else:
+                raise AssertionError(f"unrecognized compositor update: {type(renderable)}")
+            text = "".join(lines).replace(" ", "")
+            self.frames += 1
+            now = time.perf_counter()
+            offset = float(app._transcript_view().scroll_y)
+            self.scroll_frames.append(offset)
+            for previous, started in self.scroll_pending[:]:
+                if offset < previous:
+                    self.scroll_samples.append(now - started)
+                    self.scroll_pending.remove((previous, started))
+            for marker, started in self.pending[:]:
+                if marker in text:
+                    self.samples.append(now - started)
+                    self.pending.remove((marker, started))
+
+        app._display = display
+
+    def inject(self, app: OperatorApp, prefix: str, char: str) -> None:
+        self.pending.append((prefix[-8:], time.perf_counter()))
+        app.post_message(Key(char, char))
+
+
+async def loop_probe(
+    stop: asyncio.Event,
+    wall: list[float],
+    cpu: list[float],
+    ready: asyncio.Event | None = None,
+) -> None:
+    previous = time.perf_counter(), time.thread_time()
+    if ready is not None:
+        ready.set()
+    while not stop.is_set():
+        await asyncio.sleep(0.005)
+        now = time.perf_counter(), time.thread_time()
+        wall.append(now[0] - previous[0])
+        cpu.append(now[1] - previous[1])
+        previous = now
+
+
+async def loop_canaries() -> dict[str, Any]:
+    readings = {}
+    for mode in ("cpu", "blocking_io", "idle"):
+        wall: list[float] = []
+        cpu: list[float] = []
+        ready, stop = asyncio.Event(), asyncio.Event()
+        task = asyncio.create_task(loop_probe(stop, wall, cpu, ready))
+        await ready.wait()
+        if mode == "cpu":
+            started = time.thread_time()
+            while time.thread_time() - started < 0.025:
+                pass
+        elif mode == "blocking_io":
+            time.sleep(0.06)
+        await asyncio.sleep(0.02)
+        stop.set()
+        await task
+        readings[mode] = {"wall": summary(wall), "cpu": summary(cpu)}
+    assert readings["cpu"]["cpu"]["max_ms"] >= 20
+    assert readings["blocking_io"]["wall"]["max_ms"] >= 50
+    assert readings["blocking_io"]["cpu"]["max_ms"] < readings["cpu"]["cpu"]["max_ms"]
+    assert readings["idle"]["cpu"]["max_ms"] < readings["cpu"]["cpu"]["max_ms"]
+    return readings
+
+
+async def scenario(children: int, args: argparse.Namespace) -> dict[str, Any]:
+    session = LoadSession(children, attached=args.attached)
+    app = OperatorApp(lambda: _factory(session))
+    timings = Timings()
+    loop_thread = threading.get_ident()
+    stats_threads: list[int] = []
+    original_stats = subagent_panel.job_stats
+
+    def slow_stats(*a: Any, **kw: Any):
+        stats_threads.append(threading.get_ident())
+        time.sleep(args.slow_stats_ms / 1000)
+        return original_stats(*a, **kw)
+
+    if args.slow_stats_ms:
+        subagent_panel.job_stats = slow_stats
+    wall_gaps: list[float] = []
+    cpu_gaps: list[float] = []
+    async with app.run_test(size=(120, 40)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is session:
+                break
+        assert app._session is session
+        transcript = app._transcript_view()
+        with transcript.batch_append():
+            for i in range(args.blocks):
+                transcript.append_block(NoticeBlock(f"Retained event {i}: " + "word " * 12))
+        await pilot.pause()
+        app._editor().focus()
+        if args.scroll:
+            transcript.scroll_to(y=transcript.max_scroll_y / 2, immediate=True, animate=False)
+            await pilot.pause()
+        scroll_start = float(transcript.scroll_y)
+        session.raw = lambda e: app.on_subagent_progress(
+            SubagentProgress(e.job_id, e.label, e.progress)
+        )
+        for owner, method, name in [
+            (session._frontend_state_store, "refresh_jobs", "store.refresh_jobs"),
+            (session._frontend_state_store, "apply_update", "store.apply_update"),
+            (app, "_apply_frontend_state", "app.apply_frontend_state"),
+            (app, "_refresh_band", "app.refresh_band"),
+        ]:
+            timings.wrap(owner, method, name)
+        paint = PaintProbe(app)
+        stop = asyncio.Event()
+
+        finished_keys = threading.Event()
+
+        async def stream() -> None:
+            index = 0
+            # Keep offering load until EVERY key has been injected. Otherwise
+            # the fast build spends most input samples idle after it finishes
+            # the same fixed edge count, manufacturing an apparent latency win.
+            while index < args.edges or not finished_keys.is_set():
+                await asyncio.sleep(0.05)
+                session.edge(index)
+                index += 1
+
+        probe_task = asyncio.create_task(loop_probe(stop, wall_gaps, cpu_gaps))
+        stream_task = asyncio.create_task(stream())
+        # A separate OS thread injects at its own cadence: a blocked event loop
+        # must not postpone the START of the measurement and hide its own stall.
+        typed = "".join(random.Random(42).choices(string.ascii_letters, k=args.samples))
+        started = time.perf_counter()
+
+        def keys() -> None:
+            prefix = ""
+            for char in typed:
+                time.sleep(0.08)
+                prefix += char
+                paint.inject(app, prefix, char)
+                if args.scroll and len(prefix) % 10 == 0:
+                    paint.scroll_pending.append((float(transcript.scroll_y), time.perf_counter()))
+                    transcript.post_message(
+                        MouseScrollUp(transcript, 4, 4, 0, -1, 0, False, False, False)
+                    )
+            finished_keys.set()
+
+        thread = threading.Thread(target=keys, daemon=True)
+        thread.start()
+        await asyncio.to_thread(thread.join)
+        await stream_task
+        session.flush()
+        await pilot.pause()
+        stop.set()
+        await probe_task
+        elapsed = time.perf_counter() - started
+        assert app._editor().text == typed, app._editor().text
+        assert len(paint.samples) == args.samples, (len(paint.samples), paint.pending)
+        assert (
+            session.delivered
+            == (max(1, children) if args.attached else children) * session.edges_sent
+        )
+        if not args.attached:
+            assert all(
+                j.latest_details == {"progress": f"edge-{session.edges_sent - 1}"}
+                for j in session.jobs.list()
+            )
+        else:
+            assert (
+                session.frontend_state.activity_phase
+                == f"edge-{session.edges_sent - 1}-{session.delivered - 1}"
+            )
+        if args.scroll:
+            assert len(paint.scroll_samples) == args.samples // 10, paint.scroll_pending
+            assert transcript.scroll_y < scroll_start
+            # Repeated frames must never snap toward the tail between wheels.
+            assert all(
+                b <= a for a, b in zip(paint.scroll_frames, paint.scroll_frames[1:])
+            ), paint.scroll_frames
+        if args.slow_stats_ms and children:
+            assert stats_threads and loop_thread not in stats_threads
+        if args.capture:
+            root = Path(args.capture)
+            root.mkdir(parents=True, exist_ok=True)
+            save_capture(app, str(root / f"children-{children}.svg"))
+        result = {
+            "children": children,
+            "input_to_compositor_paint": summary(paint.samples),
+            "wheel_to_compositor_paint": summary(paint.scroll_samples),
+            "scroll_offsets_per_frame": paint.scroll_frames if args.scroll else [],
+            "slow_stats_calls": len(stats_threads),
+            "slow_stats_ran_on_loop": loop_thread in stats_threads,
+            "loop_wall_gap": summary(wall_gaps),
+            "loop_cpu_gap": summary(cpu_gaps),
+            "operations": {k: summary(v) for k, v in timings.values.items()},
+            "frames": paint.frames,
+            "elapsed_s": elapsed,
+            "achieved_events_per_s": session.delivered / elapsed,
+            "events_delivered": session.delivered,
+            "bursts_delivered": session.edges_sent,
+            "correctness": (
+                f"{args.samples} characters painted; every progress edge delivered; "
+                "latest job state matches"
+            ),
+        }
+    subagent_panel.job_stats = original_stats
+    return result
+
+
+async def canaries() -> dict[str, Any]:
+    app = OperatorApp(lambda: _factory(LoadSession(0)))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app._editor().focus()
+        paint = PaintProbe(app)
+        paint.pending.append(("IMPOSSIBLE-MARKER", time.perf_counter()))
+        paint.inject(app, "a", "a")
+        await pilot.pause()
+        assert len(paint.samples) == 1
+        clean = paint.samples[0]
+
+        def delayed_key() -> None:
+            time.sleep(0.02)
+            paint.inject(app, "ab", "b")
+
+        thread = threading.Thread(target=delayed_key)
+        thread.start()
+        # Deliberate regression: CPU-only timing cannot see blocking I/O, but
+        # input-to-painted-frame WALL latency must count time asleep on the loop.
+        time.sleep(0.18)
+        await asyncio.to_thread(thread.join)
+        await pilot.pause()
+        assert len(paint.samples) == 2
+        assert [item[0] for item in paint.pending] == ["IMPOSSIBLE-MARKER"]
+        blocked = paint.samples[1]
+        assert blocked > 0.12, blocked
+        return {
+            "clean_ms": clean * 1000,
+            "blocked_ms": blocked * 1000,
+            "absent_marker_detected": False,
+            "painted_characters": app._editor().text,
+        }
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--children", type=int, nargs="+", default=[0, 10, 50])
+    parser.add_argument("--samples", type=int, default=120)
+    parser.add_argument("--blocks", type=int, default=500)
+    parser.add_argument(
+        "--edges",
+        type=int,
+        default=3,
+        help="minimum bursts; load continues until all keys injected",
+    )
+    parser.add_argument("--source-root", default=_source_args.source_root)
+    parser.add_argument("--slow-stats-ms", type=float, default=0)
+    parser.add_argument("--scroll", action="store_true")
+    parser.add_argument("--attached", action="store_true")
+    parser.add_argument("--capture")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    checks = await canaries()
+    checks["loop_probe"] = await loop_canaries()
+    print(json.dumps({"canaries": checks}), flush=True)
+    results = []
+    for count in args.children:
+        result = await scenario(count, args)
+        results.append(result)
+        print(json.dumps(result), flush=True)
+    sources = {}
+    for cls in (OperatorApp, AttachedSession, FrontendStateStore):
+        filename = sys.modules[cls.__module__].__file__
+        assert filename is not None
+        path = Path(filename).resolve()
+        assert path.is_relative_to(Path(args.source_root).resolve()), path
+        sources[str(path)] = hashlib.sha256(path.read_bytes()).hexdigest()
+    provenance = {
+        "modules": sources,
+        "script_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "python": sys.executable,
+    }
+    Path(args.output).write_text(
+        json.dumps(
+            {"args": vars(args), "provenance": provenance, "canaries": checks, "results": results},
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/session/test_frontend_delta_work.py
+++ b/tests/unit/session/test_frontend_delta_work.py
@@ -7,6 +7,7 @@ compatibility facade would still freeze the production TUI after the unit test.
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
@@ -86,6 +87,48 @@ def test_scalar_patch_preserves_model_validators_extras_and_public_isolation() -
     assert current is not None and current["future_new_field"] == {"nested": ["new"]}
     assert store.state.jobs[0].label != "public mutation"
     assert original.sequence == 0 and store.state.sequence == 1
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("cumulative_cost", 42),
+        ("model_label", "new-wire-label"),
+        ("model_dump", {"nested": [{"value": "future"}]}),
+        ("model_fields", {"nested": [{"value": "future"}]}),
+        ("model_extra", {"nested": [{"value": "future"}]}),
+        ("model_fields_set", {"nested": [{"value": "future"}]}),
+    ],
+)
+def test_reserved_extra_names_preserve_wire_values_and_nested_isolation(
+    name: str, value: Any
+) -> None:
+    # A newer runtime is allowed to introduce a field whose name happens to be
+    # a property/method in this viewer. Attribute lookup is not value lookup.
+    original_extra = {"nested": [{"value": "retained"}]}
+    seed = state().model_copy(update={"existing_extra": original_extra})
+    store = FrontendStateStore(seed)
+    publications: list[FrontendUpdate] = []
+    store.subscribe(publications.append)
+    incoming = delta(**{name: copy.deepcopy(value)})
+    result = store.apply_update(incoming)
+    assert result.model_dump(mode="json")[name] == value
+    assert result.model_extra is not None
+    assert result.model_extra["existing_extra"] == {"nested": [{"value": "retained"}]}
+
+    original_extra["nested"][0]["value"] = "original caller mutation"
+    result.model_extra["existing_extra"]["nested"][0]["value"] = "public mutation"
+    if isinstance(value, dict):
+        incoming.changes[name]["nested"][0]["value"] = "incoming mutation"
+        result.model_extra[name]["nested"][0]["value"] = "public collision mutation"
+        publications[0].changes[name]["nested"][0]["value"] = "subscriber mutation"
+    # Unchanged nested extras survive another scalar edge and neither their
+    # original caller nor a public snapshot/subscriber owns canonical storage.
+    current = store.apply_update(
+        FrontendUpdate(epoch="owner", sequence=2, changes={"activity_phase": "responding"})
+    ).model_dump(mode="json")
+    assert current[name] == value
+    assert current["existing_extra"] == {"nested": [{"value": "retained"}]}
 
 
 def test_invalid_job_patch_does_not_commit_state_or_todo_watermarks() -> None:

--- a/tests/unit/session/test_frontend_delta_work.py
+++ b/tests/unit/session/test_frontend_delta_work.py
@@ -1,0 +1,190 @@
+"""A scalar viewer edge must not walk retained child histories or rebuild facades.
+
+These are work/ownership invariants, not machine-dependent latency ceilings.
+The real AttachedSession callback is included: a cheap store with an expensive
+compatibility facade would still freeze the production TUI after the unit test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from local_operator.harness.types import Usage
+from local_operator.session import frontend_state as module
+from local_operator.session.attached import AttachedSession
+from local_operator.session.frontend_state import (
+    FrontendSessionState,
+    FrontendStateStore,
+    FrontendUpdate,
+    JobState,
+    SnapshotJobs,
+)
+
+
+def state() -> FrontendSessionState:
+    value = FrontendSessionState(
+        session_id="benchmark-parent",
+        epoch="owner",
+        jobs=[
+            JobState(
+                id="child",
+                type="task",
+                trajectory=[{"type": "message_update", "delta": "retained"}],
+                trajectory_length=500,
+                latest_details={"nested": {"status": "running"}},
+                todos=[{"name": "Build", "items": [{"text": "keep", "status": "pending"}]}],
+            )
+        ],
+    )
+    return value.model_copy(update={"future_owner_field": {"keep": True}})
+
+
+def delta(**changes: Any) -> FrontendUpdate:
+    return FrontendUpdate(epoch="owner", sequence=1, changes=changes)
+
+
+def test_scalar_update_does_not_serialize_or_refreeze_existing_jobs() -> None:
+    store = FrontendStateStore(state())
+    owned_job = store._state.jobs[0]
+    with (
+        patch.object(FrontendSessionState, "model_dump", side_effect=AssertionError("full dump")),
+        patch.object(module, "_freeze_job", side_effect=AssertionError("retained job freeze")),
+    ):
+        result = store.apply_update(delta(activity_phase="responding"))
+    assert store._state.jobs[0] is owned_job
+    assert result.jobs[0] is not owned_job
+    assert result.jobs[0].trajectory_length == 500
+    assert result.jobs[0].trajectory[0]["delta"] == "retained"
+    assert result.activity_phase == "responding"
+
+
+def test_scalar_patch_preserves_model_validators_extras_and_public_isolation() -> None:
+    store = FrontendStateStore(state())
+    original = store.state
+    incoming = delta(
+        last_usage=Usage(input_tokens=12, output_tokens=3),
+        future_new_field={"nested": ["new"]},
+    )
+    result = store.apply_update(incoming)
+    assert result.last_usage is not None and result.last_usage.input_tokens == 12
+    assert result.model_extra == {
+        "future_owner_field": {"keep": True},
+        "future_new_field": {"nested": ["new"]},
+    }
+    incoming.changes["future_new_field"]["nested"].append("caller mutation")
+    assert result.model_extra is not None
+    result.model_extra["future_new_field"]["nested"].append("public mutation")
+    # Frozen models can still have their owning __dict__ edited by consumers;
+    # canonical state must not share that mutable Pydantic shell.
+    cast(dict[str, Any], result.jobs[0].__dict__)["label"] = "public mutation"
+    current = store.state.model_extra
+    assert current is not None and current["future_new_field"] == {"nested": ["new"]}
+    assert store.state.jobs[0].label != "public mutation"
+    assert original.sequence == 0 and store.state.sequence == 1
+
+
+def test_invalid_job_patch_does_not_commit_state_or_todo_watermarks() -> None:
+    store = FrontendStateStore(state())
+    original = store.state.model_dump(mode="json")
+    watermarks = dict(store._todo_sequences)
+    published: list[FrontendUpdate] = []
+    store.subscribe(published.append)
+    invalid = delta(jobs=[{"id": "child", "type": "task"}], context_tokens="invalid")
+    invalid.job_todo_updates = {"child": [{"name": "New", "items": []}]}
+    with pytest.raises(ValidationError):
+        store.apply_update(invalid)
+    assert store.state.model_dump(mode="json") == original
+    assert store._todo_sequences == watermarks
+    assert published == []
+    invalid.changes["context_tokens"] = 123
+    result = store.apply_update(invalid)
+    assert result.sequence == 1
+    plan = result.jobs[0].todos
+    assert plan is not None and plan[0]["name"] == "New"
+    assert store._todo_sequences["child"] == 1
+    assert [update.sequence for update in published] == [1]
+
+
+def test_explicit_jobs_clear_still_drops_rows_and_todo_watermarks() -> None:
+    store = FrontendStateStore(state())
+    store._todo_sequences["child"] = 0
+    # Null is NOT a clear in the existing wire contract; only [] is.
+    with pytest.raises(TypeError):
+        store.apply_update(delta(jobs=None))
+    assert len(store.state.jobs) == 1
+    assert store._todo_sequences == {"child": 0}
+    result = store.apply_update(delta(jobs=[]))
+    assert list(result.jobs) == []
+    assert store._todo_sequences == {}
+
+
+def test_snapshot_job_get_uses_index_and_preserves_detached_owners() -> None:
+    jobs = SnapshotJobs(FrontendStateStore(state()).state.jobs)
+
+    class NoTraversal(list[JobState]):
+        def __iter__(self):
+            raise AssertionError("get() walked the roster")
+
+    jobs._values = NoTraversal(jobs._values)
+    first = jobs.get("child")
+    assert first is not None
+    cast(dict[str, Any], first.__dict__)["label"] = "changed outside"
+    second = jobs.get("child")
+    assert second is not None and second.label != first.label
+    assert jobs.get("absent") is None
+    jobs.replace([JobState(id="replacement", type="task")])
+    assert jobs.get("child") is None
+    assert jobs.get("replacement") is not None
+
+
+def test_snapshot_duplicate_ids_keep_first_lookup_semantics() -> None:
+    jobs = SnapshotJobs(
+        [
+            JobState(id="same", type="task", label="first"),
+            JobState(id="same", type="task", label="second"),
+        ]
+    )
+    first = jobs.get("same")
+    assert first is not None and first.label == "first"
+    assert [j.label for j in jobs.list()] == ["first", "second"]
+
+
+def test_attached_scalar_callback_preserves_unrelated_collection_facades(tmp_path: Path) -> None:
+    async def never():
+        raise AssertionError("no takeover expected")
+
+    viewer = AttachedSession(
+        config_dir=tmp_path, session_id="benchmark-parent", takeover_factory=never
+    )
+    viewer._install_frontend(state())
+    with (
+        patch.object(viewer.jobs, "replace", wraps=viewer.jobs.replace) as jobs,
+        patch.object(
+            viewer._subagent_comms, "replace", wraps=viewer._subagent_comms.replace
+        ) as comms,
+        patch.object(
+            viewer.wake_scheduler, "replace", wraps=viewer.wake_scheduler.replace
+        ) as wakes,
+        patch.object(viewer.mcp_manager, "replace", wraps=viewer.mcp_manager.replace) as mcp,
+    ):
+        viewer._on_frontend_update(delta(activity_phase="responding").model_dump(mode="json"))
+        for spy in (jobs, comms, wakes, mcp):
+            spy.assert_not_called()
+        update = FrontendUpdate(epoch="owner", sequence=2, changes={"jobs": []})
+        viewer._on_frontend_update(update.model_dump(mode="json"))
+        jobs.assert_called_once()
+        comms.assert_called_once()
+        wakes.assert_not_called()
+        mcp.assert_not_called()
+        assert viewer.jobs.list() == []
+        # Full snapshots always refresh, even after a sequence reset/reconnect.
+        viewer._install_frontend(state())
+        assert jobs.call_count == 2
+        assert comms.call_count == 2
+        wakes.assert_called_once()
+        mcp.assert_called_once()

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1843,13 +1843,19 @@ async def test_a_failed_remote_cancel_never_prints_a_confirmed_success() -> None
 
 @pytest.mark.asyncio
 async def test_frontend_update_burst_coalesces_to_latest_snapshot() -> None:
-    """Queued canonical updates repaint once, from the newest complete state."""
+    """Coalesce the snapshot COPY too, not only the eventual repaint."""
     from local_operator.session.frontend_state import FrontendSessionState
 
     class StatefulSession(FakeSession):
         def __init__(self) -> None:
             super().__init__()
-            self.frontend_state = FrontendSessionState(session_id="sess", epoch="owner")
+            self._state = FrontendSessionState(session_id="sess", epoch="owner")
+            self.reads = 0
+
+        @property
+        def frontend_state(self) -> FrontendSessionState:
+            self.reads += 1
+            return self._state.model_copy()
 
     session = StatefulSession()
     app = OperatorApp(lambda: _factory(session))
@@ -1868,19 +1874,18 @@ async def test_frontend_update_burst_coalesces_to_latest_snapshot() -> None:
         app.call_later = schedule
         app._apply_frontend_state = apply
 
-        session.frontend_state = session.frontend_state.model_copy(
-            update={"conversation_title": "first"}
-        )
+        session.reads = 0
+        session._state = session._state.model_copy(update={"conversation_title": "first"})
         app._on_frontend_update(object())
-        session.frontend_state = session.frontend_state.model_copy(
-            update={"conversation_title": "latest"}
-        )
+        session._state = session._state.model_copy(update={"conversation_title": "latest"})
         app._on_frontend_update(object())
 
+        assert session.reads == 0
         assert len(scheduled) == 1
         callback, args = scheduled[0]
         callback(*args)
         assert [state.conversation_title for state in applied] == ["latest"]
+        assert session.reads == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_fast_mode.py
+++ b/tests/unit/tui/test_fast_mode.py
@@ -13,7 +13,7 @@ over a request that is not fast is a claim about the user's money.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -257,7 +257,11 @@ async def test_a_provider_refusal_takes_the_dial_off_the_band_and_the_memory() -
         session.set_model(session.model.model_copy(update={"fast_mode": False}))
         assert app._status is not None
         app._status.update(fast=_fast_label_for_test(session))
-        app._pending_frontend_state = _State(session.model)
+        from types import SimpleNamespace
+
+        app._pending_frontend_session = cast(
+            Any, SimpleNamespace(frontend_state=_State(session.model))
+        )
         app._apply_pending_frontend_state(getattr(app, "_frontend_session_generation", 0))
         for _ in range(4):
             await pilot.pause()


### PR DESCRIPTION
## Summary

Release: patch — attached TUI streaming updates no longer reconstruct every retained child history, rebuild unrelated facades, or copy a snapshot for every edge in a coalesced burst.

**Change class: C2.** The delivery contract is significant measured responsiveness improvement with many background subagents, while preserving ordered state delivery, mutable/public ownership boundaries, lifecycle/todo/trajectory correctness, composer input and scroll position. No layout/style, model/provider calls, wire schema, heartbeat cadence, broad mutable-job cache, or version bump is included.

## Source of the stall

The normal frontend is an `AttachedSession`. Its ordered update callback runs on Textual's input loop. Previously even a scalar activity delta did `state.model_dump()` → full `FrontendSessionState.model_validate(...)` → freeze every job, including retained history. The callback then rebuilt all compatibility collections. The TUI copied another public snapshot before checking its existing paint-coalescer guard. `SnapshotJobs.get()` additionally scanned the roster once per requested child.

Four bounded changes:

1. Validate only supplied fields through an ephemeral **model** (not bare TypeAdapters, which lose model validators and unknown future fields); merge those fields into canonical state without traversing unrelated job histories. Stage todo watermarks until all fields validate.
2. Rebuild jobs/comms, wakes, and MCP compatibility collections only when their fields changed; full snapshot installs still rebuild everything.
3. Index `SnapshotJobs.get()` while retaining detached owners, ordered list results, and first-duplicate-ID behavior.
4. Read one latest public snapshot in the scheduled TUI apply callback, after its session-generation check; do not copy every intermediate snapshot.

## Paired reproduction and measured improvement

Reusable script: `scripts/bench_tui_background.py`; rationale and methodology: `docs/TUI_BACKGROUND_RESPONSIVENESS.md`.

The benchmark drives the **real OperatorApp** with 500 transcript blocks and synthetic real job/state objects. Attached mode exercises the real `AttachedSession._on_frontend_update` decoded-wire callback through facade updates and subscriber fanout. A separate OS thread injects 120 deterministic characters independently of loop stalls; a sample ends only when an actual compositor update contains that marker in the composer's rows. This is injection-to-composed-frame wall latency, **not** `pilot.press/pause` time and **not** physical-terminal display latency.

Each child contributes a scalar delta per offered 50ms burst. Load continues until every key has been injected: the fixed build cannot finish its workload early and measure idle typing. Achieved throughput is reported because a saturated baseline services fewer bursts. Every offered edge and every character is accounted for.

Two interleaved **before → after** pairs used the same interpreter/dependencies and an exact `494ad221d` source archive. Source-module paths/hashes and harness SHA are in each JSON; the three changed module hashes were independently checked against `git show 494ad221d:<path>`. Each cell has **120 paint samples per run**, 240 across the pair (percentiles below are per-run, not pooled).

| Children | Before input→paint p95, runs 1 / 2 | After p95, runs 1 / 2 |
|---|---:|---:|
| 0 | 36.9 / 34.5 ms | 67.5 / 37.1 ms |
| 10 | 781.3 / 1341.3 ms | 586.6 / 49.6 ms |
| 50 | 16455.0 / 13233.4 ms | 923.8 / 228.8 ms |

At 50 children, p95 fell **94.4% / 98.3%**. Median `apply_update` dropped **100.29 / 76.88 ms → 0.384 / 0.386 ms**, while achieved event delivery increased **5.63 / 7.83 → 153.64 / 547.91 events/s**. All samples and final states passed correctness assertions.

**Host limitation:** unrelated concurrent jobs drove this 14-core machine to load averages ~176–201 during the pairs. Wall observations therefore have a wide range, including idle-cell variation; this PR claims no measured idle improvement or portable numeric latency SLA. The structural guards below are the reliable regression contracts. A 100-child stress cell was deliberately not run under that contention.

Commands (run sequentially, never alongside a suite):

```sh
.venv/bin/python scripts/bench_tui_background.py \
  --source-root /tmp/lop-architect-5ExvkO --attached --children 0 10 50 \
  --samples 120 --edges 3 --capture /tmp/lop-tui-background-evidence/before-final \
  --output /tmp/lop-tui-background-evidence/before-final-1.json
.venv/bin/python scripts/bench_tui_background.py \
  --attached --children 0 10 50 --samples 120 --edges 3 \
  --capture /tmp/lop-tui-background-evidence/after-final \
  --output /tmp/lop-tui-background-evidence/after-final-1.json
# Repeat the pair with output suffix -2.
```

Additional real-UI scroll/slow-I/O cell: 50 children, 120 characters, 12 wheel events, 6050 ordered deltas. All passed. Every consecutive painted scroll offset moved monotonically **243 → 219**, with no tail snap. All **503 injected 50ms pricing calls ran off the loop**. Input p95 305.8ms; wheel-to-painted-frame p95 148.7ms under the same host contention.

```sh
.venv/bin/python scripts/bench_tui_background.py --attached --children 50 \
  --samples 120 --edges 3 --scroll --slow-stats-ms 50 \
  --capture /tmp/lop-tui-background-evidence/after-scroll \
  --output /tmp/lop-tui-background-evidence/after-scroll.json
```

Instrumentation canaries require ordinary characters to paint, absent markers not to appear, and an intentional loop-blocking sleep to appear in input wall latency. Paired runs observed blocked samples **167–179ms**. The reusable script also separately calibrates the shared loop probe against CPU work, blocking I/O, and idle sleep.

## Correctness and validation

- Focused pre-gate run: **70 passed, 327 deselected** in 18.49s (canonical state, frontend apply coalescing, and fast-mode fixtures).
- Structural guards: scalar updates may not dump the whole state or refreeze jobs; indexed get may not iterate the roster; scalar attached callbacks may not replace collection facades; coalesced updates take zero immediate snapshots and exactly one latest snapshot at apply.
- Invalid known fields leave canonical state, sequence, publications and todo watermarks untouched. Valid model normalization, unknown future extras, detached public shells, explicit list clears, trajectory append/rotation, and retained todo behavior remain covered.
- R1 regression discrimination: **6 failed on initial `c5ffc7764`**, all six pass on the baseline and remediated head. Computed-property, BaseModel-method, and metadata-property collisions preserve JSON, original nested extras, and source/public/subscriber ownership.
- Structural regression discrimination against exact baseline source: **5 expected failures / 9 passed** (4.53s): full dump, non-atomic todo watermark, linear lookup, unrelated facade replacements, and immediate snapshot copies. Fixed focused run: **76 passed / 327 deselected** (18.62s).
- Final committed harness smoke passed (0/10 children, 12 characters each): paint 5.06ms clean vs 170.86ms deliberately blocked; CPU-work probe 25.11ms CPU, blocking-I/O probe 67.36ms wall / 0.171ms CPU, idle 0.115ms CPU. Correct module hashes and all delivery assertions passed.
- Final full-tree gates on `4ae27401b`: `python -m flake8 .` passed; pinned Black 26.1.0 `--check .` reports **1259 unchanged**; isort 5.13.2 `--check .` passed (**2 excluded files**); pyright 1.1.411 `--pythonpath .venv/bin/python .` reports **0 errors, 0 warnings**.
- Full `tests/unit -q` gate on `4ae27401b`: **19140 passed, 20 skipped, 720 warnings in 1345.08s (22:25)**. Actual final summary verified, not only exit status. Warnings include existing Pydantic deprecations and unawaited-coroutine warnings from harness cancellation tests; none was suppressed by this change.
- Independent review gates are recorded and answered: [code round 2 TERMINAL clean](https://github.com/damianvtran/local-operator/pull/1019#issuecomment-5647093660), [QA round 2 TERMINAL PASS](https://github.com/damianvtran/local-operator/pull/1019#issuecomment-5647091997), and [design round 1 TERMINAL PASS with explicit current-head applicability](https://github.com/damianvtran/local-operator/pull/1019#issuecomment-5647091442). Author remediation replies cover both code/QA rounds and design round 1. Independent QA included **113 E2E passes**; **7 browser-ownership E2Es were skipped because extension esbuild was unavailable**, an unchanged unrelated coverage limit. CI is watched separately by the manager; the PR remains draft pending that remote gate and release coordination.

All TUI runs isolate HOME/config/cache before imports, scrub every `CMUX_*`, and use synthetic IDs. No live model requests or operator sessions were used. Main checkout and its untracked work were not altered.

## Agent-review remediation audit trail

Initial reviewed scope: `494ad221d712e37e65366b2af3581e8ddfd2b136..c5ffc7764bc97bb04c9bc5cb0ec5f8f14bcf1909`.

The independent reviewer found **R1 (major)**: retrieving an accepted unknown wire field through `getattr` resolves a colliding property/method instead of its JSON value. `cumulative_cost=42` became null; `model_dump={...}` became a bound method and poisoned later serialization.

Unified remediation commit **`4ae27401b9a95a1b9248958106d3f54a53140d36`** reads declared validated storage and merges `model_extra` directly. Six collision/serialization/ownership regression cases prove the old head fails and the new one passes. This is the sole semantic delta from the measured implementation and does not change the normal activity fields in the load fixture. Convergence scope is `c5ffc7764..4ae27401b`.

Measurement provenance is explicit: the measured `frontend_state.py` hash `c4544873...` differs from initial committed `eccedf20...` only by two Black reflows (verified by exact reconstructed hash and AST equality). The recorded paired harness predates its committed CPU-probe canaries and runtime-locality spelling correction; the final committed script was separately smoked as above. Older paired JSON is not presented as an execution record of the newer harness.

## Rendered and raw evidence (publicly accessible)

Evidence uses this repository's established SVG/JSON gist convention (as in PR #976), not committed generated files. The **unlisted, link-accessible bundle** contains 57 synthetic files: [complete artifact index](https://gist.github.com/damianvtran/253f44eb6d452470fb037da5fbe3af34).
Unauthenticated fetches of both headline SVGs returned **HTTP 200, image/svg+xml**; paired JSON also returned HTTP 200. These are actual accessible links, not local `/tmp` references.

### Headline before/after — 50 children, 120×40

[Open before rendered SVG](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/ff90c0901bdc297fe4807b83377f87c4179db94b/before-50.svg) · [Open after rendered SVG](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/21d8da07486b23758cb2cad4da0bba99b0be625d/after-50.svg)

![Before: 50 children, 120×40](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/ff90c0901bdc297fe4807b83377f87c4179db94b/before-50.svg)

![After: 50 children, 120×40](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/21d8da07486b23758cb2cad4da0bba99b0be625d/after-50.svg)

Both have 960×680 native pixels and preserve identical geometry/content placement; elapsed child time differs.

| Children | Before SVG | After SVG | Before geometry | After geometry |
|---|---|---|---|---|
| 0 | [frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/9ac48916bd9274abdb4fcfd20d9c717e163ecd85/before-0.svg) | [frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/9ac48916bd9274abdb4fcfd20d9c717e163ecd85/after-0.svg) | [JSON](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/adf3238d05e3d512f58016ce6b08e9fa34e1382c/before-0.geometry.json) | [JSON](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/adf3238d05e3d512f58016ce6b08e9fa34e1382c/after-0.geometry.json) |
| 10 | [frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/96f0bbda76443cc12e90592bdabdffb3764551ee/before-10.svg) | [frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/3bde2f12474adfd5fd33b1f165f81cec492bbfa1/after-10.svg) | [JSON](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/d4d1c64e5904657b33a09ccbcd92703553113462/before-10.geometry.json) | [JSON](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/d4d1c64e5904657b33a09ccbcd92703553113462/after-10.geometry.json) |
| 50 | [frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/ff90c0901bdc297fe4807b83377f87c4179db94b/before-50.svg) | [frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/21d8da07486b23758cb2cad4da0bba99b0be625d/after-50.svg) | [JSON](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/d4d1c64e5904657b33a09ccbcd92703553113462/before-50.geometry.json) | [JSON](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/d4d1c64e5904657b33a09ccbcd92703553113462/after-50.geometry.json) |

### Independent QA — real runtime/follower/app sequence

| State | 120×36 | 72×36 |
|---|---|---|
| before-empty | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/7b10b0dd65920ca410363557fad56bcfde897338/qa-120-before-empty.svg) | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/7435ff6af46ae44c879616a48b0f73d7f0d7f973/qa-72-before-empty.svg) |
| loading-queued | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/e66ce3f5c76bb6aeff9e284431388034e99c708c/qa-120-loading-queued.svg) | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/0c3e5d72c4adecd6c8c85761c7c0c4fdc3c3e093/qa-72-loading-queued.svg) |
| after-populated | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/37dcc27ba20212e7a23bf126260f5ac535831cb6/qa-120-after-populated.svg) | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/11fefd16c2eeb4c4f7c35163db394da3ef474b1a/qa-72-after-populated.svg) |
| scroll-0 | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/d2550a1ba9ab3f4eeeb1e69701381bfb5696c5e4/qa-120-scroll-0.svg) | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/74157bb0dca9c58007d793110aaa79143c81e733/qa-72-scroll-0.svg) |
| scroll-1 | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/21a84c306f074d1ed191dc9ea637799710529f0f/qa-120-scroll-1.svg) | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/238a6f6abf293413d4d083d8656d6c0ef404c1dd/qa-72-scroll-1.svg) |
| scroll-2 | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/0699330f847b02c834649f165efea3c314ff3538/qa-120-scroll-2.svg) | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/5404db537a128eeba613630dd25ef91d6c64d567/qa-72-scroll-2.svg) |
| error-settled | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/b038f2f8a05e270aec2f13a838c600aa29c6d88b/qa-120-error-settled.svg) | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/2f49f5d00d844ac1763ee7c0ae55f3ba85916acc/qa-72-error-settled.svg) |
| error-consecutive | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/b038f2f8a05e270aec2f13a838c600aa29c6d88b/qa-120-error-consecutive.svg) | [rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/2f49f5d00d844ac1763ee7c0ae55f3ba85916acc/qa-72-error-consecutive.svg) |

Matching per-frame geometry JSON is in the bundle under each frame name.

### Measurements and exact provenance

- [Before pair 1](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/d0499f079ba01c1efd9d7f86532deba6981c4889/before-paired-1.json)
- [After pair 1](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/e23259fd73004e63aece46fbc25df8f71ed0d74c/after-paired-1.json)
- [Before pair 2](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/f1d8185ab7728a54a33c04b4d7adff36a4ac55f2/before-paired-2.json)
- [After pair 2](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/5dd713c5b239b04ea9e809711f962866c8b9cda7/after-paired-2.json)
- [Scroll/slow-I/O measurements](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/ad7282a8abc8229151cf9704f7de16f4919cf4e4/after-scroll.json)
- [Scroll/slow-I/O rendered frame](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/38c577ae15c8d39d6c9dd22beacab2f054656920/after-scroll-50.svg)
- [Final committed harness and all canaries](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/8c56d28e01004954aaea7bfd32f06145fdf7a004/final-script-smoke.json)
- [Exact formatter-only provenance proof](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/4f194d793ccadd0373eb2a5a157e2dc7c3d4144f/format-only-provenance.txt)
- [Actual final gate summaries](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/eb930c4720dad2bbc2ffb9fcc019773c0713c84f/verification.txt)
- [Independent QA round 1](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/2a99ea31a4f1bbc48bfc2f8876c343610c6a7abb/qa-round-1.md)
- [Independent QA round 2](https://gist.githubusercontent.com/damianvtran/253f44eb6d452470fb037da5fbe3af34/raw/2f15b2e264d2974466636cf9dde7648a14e87b69/qa-round-2.md)

Generated proof remains outside feature Git; the reusable benchmark and methodology document are committed. Chronology and workload limitations above remain unchanged.

## Rollout and non-goals

No version bump or release is carried here. Manager owns independent review, merge, and the combined release window. Rollback is reverting this PR; there is no migration or persisted format change. This does not redesign the event bus, change the 50ms owner notification cadence, add a mutable trajectory cache, or claim provider/physical-terminal latency improvements.
