### PR TITLE
chore(release): bump version to 0.54.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.26"
+version = "0.54.27"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed (post-v0.54.26). **Owner session pid: 21866** (manager of lopdev, "Review DeepSeek Models and Client Optimization"). This lock is mine — please do not convert, merge or re-cut it from another session; ping me instead, and send PR# + merge SHA + your `Release:` line **at merge time**, not later.

Window (re-derived from `git log v0.54.26..origin/main` immediately before this edit):
- [x] [#970](https://github.com/damianvtran/local-operator/pull/970) — `fix(session)`: a turn cut off by anything but a deliberate stop is an error with a named cause. Merged `d67f5727745cbc528982ee0083ebcc9e7b2a0ebb` at 17:10:05Z on `86ba40750`. `Release: patch — a turn cut off by anything but a deliberate stop is an error with a named cause, and the attach frame fits its line again`.
- [x] [#1016](https://github.com/damianvtran/local-operator/pull/1016) - `feat(sessions)`: one conversation search, shared by every surface, over HTTP. Merged `5873c810c297242363fea09d5c2d9e06d284aff2` at 17:19:24Z. `Release: patch - one conversation search shared by every surface (TUI picker, phone daemon, desktop), and a new additive GET /v1/desktop/sessions/search with a session_search capability`.
- [x] [#1021](https://github.com/damianvtran/local-operator/pull/1021) — `fix(deepseek)`: honour live models and native cache contracts. Merged `6f01a421ddbb9a9ffc7da206aa948ce75b303a47` at 17:44:28Z. `Release: patch — direct DeepSeek live/cache/first-frame inventory and capability correctness, including Flash vision, native effort, stable reasoning/tool-image cache prefixes and strict SSE completion.`
- [ ] [#998](https://github.com/damianvtran/local-operator/pull/998) — `fix(session)`: bounded recovery arms, the steer-failure seam, the phone arrival fill, the daemon-kill cause token and the round-3 polish. Mine; rebase onto main in flight, then one convergence round on the new head.

Proposed bump: **PATCH → 0.54.27**, decided for the window as a whole. #970 is a bug fix with additive protocol fields that default to empty (no `PROTOCOL_VERSION` bump). #1016's new surface is additive but does not clear the step-function bar AGENTS.md reserves for a minor (a new surface or subsystem a user would adopt — browser extension, mobile relay, peer messaging); both mergers argue patch, and the stated doctrine is to err toward patch.

The original owner confirmed #998 is unready and will NOT hold this release. Ship the three merged PRs now, re-deriving the window immediately before tagging. Adopted by pid 21866 after the prior runtime stopped and the lock remained unchanged for more than 15 minutes. `pyproject.toml` is at 0.54.26 on every branch and untouched by both PRs, so no version collision.



