### PR TITLE
fix(deepseek): honor live models and native cache contracts

### DIFF
--- a/docs/DEEPSEEK.md
+++ b/docs/DEEPSEEK.md
@@ -1,0 +1,105 @@
+# Direct DeepSeek
+
+The `deepseek` provider uses the native OpenAI-compatible Chat Completions
+endpoint. This document records the contract checked on 2026-09-12; it is not
+a claim that every optional feature of DeepSeek's official harness is present.
+OpenRouter's DeepSeek routes retain OpenRouter's own routing, cache-affinity and
+effort behavior.
+
+## Inventory and metadata authority
+
+The authenticated [`GET /models`](https://api-docs.deepseek.com/api/list-models)
+response returned exactly `deepseek-flash` and `deepseek-v4-pro`. Each row had
+only `id`, `object` and `owned_by`: **the endpoint did not advertise vision,
+tools, limits, prices or reasoning capabilities**.
+
+A successful native listing, including an empty one, owns the selectable set in
+both the model picker and `/v1/models` HTTP catalogue. The existing catalogue
+cache avoids redundant fetches and provides stale results when offline. When
+there is no usable listing, documented static rows remain an honest fallback;
+legacy manual selectors are not removed from saved sessions.
+
+Present, valid fields in the recognized compatibility schema override static
+metadata through discovery, disk cache, `ModelInfo` and `ModelSpec`. This
+includes explicit `false`, zero prices and an empty reasoning effort allowlist.
+Omitted fields are enriched from the native documented rows, not from another
+provider's route. Unknown future ids do not acquire an aggregator's capabilities
+merely because the native listing is sparse.
+
+[Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing) documents:
+
+| Native selector | Current implementation | Context | Maximum output | Images |
+| --- | --- | ---: | ---: | --- |
+| `deepseek-flash` | V4.1 Flash | 1,000,000 | 393,216 | Yes |
+| `deepseek-v4-pro` | V4 Pro 0813 | 1,000,000 | 393,216 | No |
+
+The documented floating aliases `deepseek-v4-flash` and
+`deepseek-v4-flash-vision-exp` now serve V4.1 Flash. Old pinned `0731` metadata is
+not upgraded speculatively. A live listing hides these legacy selectors unless
+the endpoint itself lists them.
+
+Prices are **conservative peak estimates**, not exact time-of-use bills:
+
+| Per million tokens | Flash | Pro |
+| --- | ---: | ---: |
+| Uncached input | $0.30 | $1.32 |
+| Cached input | $0.006 | $0.044 |
+| Output | $1.20 | $3.96 |
+
+Off-peak prices are half. Peak is Monday–Friday 01:00–04:00 and 06:00–10:00 UTC.
+The local usage model does not apply a time-of-use tariff. The provider's bill
+remains authoritative; these estimates must not be presented as charged cost.
+
+## Thinking, images and stable caching
+
+The native [thinking contract](https://api-docs.deepseek.com/guides/thinking_mode)
+offers `none`, `low`, `high`, `max`, with `high` as the default. `none` sends
+`thinking.type=disabled` and omits `reasoning_effort`; other levels enable
+thinking and send their native effort. This is provider-scoped, not a regex
+applied to every DeepSeek model on every host.
+
+The [completion schema](https://api-docs.deepseek.com/api/create-chat-completion)
+distinguishes maximum output from request budget. Unspecified budgets use 8,192
+in non-thinking mode, 65,536 in thinking mode, and 131,072 at max effort. Explicit
+small requests stay small; requests cannot exceed the advertised maximum.
+Sampling parameters that are ignored or constrained by native thinking mode
+remain omitted, leaving DeepSeek's defaults intact.
+
+With tools, **all previous native reasoning must be replayed**, including
+reasoning-only assistant turns. Existing replay provenance checks (provider,
+model, endpoint, account and message integrity) still apply. Display text or
+another account's retained payload cannot bypass them. Raw tool argument bytes
+remain intact.
+
+The [vision guide](https://api-docs.deepseek.com/guides/vision) places image input
+in user messages. Tool results therefore remain strings; images from a complete
+consecutive tool-result group are projected into a following synthetic user
+message. Parallel assistant/tool pairing is preserved, and appending a new turn
+does not rewrite earlier request messages.
+
+[Context caching](https://api-docs.deepseek.com/guides/kv_cache) is automatic.
+DeepSeek persists complete prefix units at request boundaries, detected common
+prefixes and fixed token intervals. Matching just part of a previously cached
+unit does not guarantee a hit. The direct route sends neither ephemeral
+`cache_control` markers nor `prompt_cache_key`; moving markers must not rewrite
+old messages. Native hit/miss counters remain the evidence of actual reuse.
+Cache persistence takes seconds and is best-effort, not a 100% hit guarantee.
+
+## Official harness comparison
+
+Audit reference: [`deepseek-ai/deepseek-harness` at
+`c291e7961a515f6d7af9304e7fd1d257929aef26`](https://github.com/deepseek-ai/deepseek-harness/tree/c291e7961a515f6d7af9304e7fd1d257929aef26).
+
+| Surface | Official reference | Local Operator |
+| --- | --- | --- |
+| Discovery | Configured static `listModels` | Native live inventory, cached with documented fallback |
+| Reasoning replay | Retains previous `reasoning_content` | Retains all provenance-valid native reasoning; raw arguments preserved |
+| Tool screenshots | `serialize.ts`: user-only image projection after tool groups | Same role constraint and stable grouping |
+| Stream completion | `sse.ts`: requires `[DONE]`; `translate.ts`: malformed JSON fails | Native route requires `[DONE]` plus recognized finish; malformed/truncated streams use retryable provider errors |
+| Resource exhaustion | Explicit failure | `insufficient_system_resource` becomes retryable provider failure, never success |
+| Cache reuse | Preserves serialized conversation prefix | No direct explicit cache controls; append-only projected messages; measured native hit counters |
+
+Optional Files API uploads, Responses migration, a server-generated `user_id`
+policy and the official tokenizer are not introduced here. They are not needed
+to fix the native discovery, metadata, replay and cache-continuity defects, and
+this change makes no universal “same or better” claim about those features.

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -599,7 +599,18 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
     # stops offering `none`/`low` on the OpenRouter route, because the router
     # says those rungs 400 there. A rung we cannot send is not a rung.
     listing_levels = _listing_effort(canonical, model_name)
-    effort_levels = listing_levels if listing_levels else supported_efforts(model_name)
+    # The native endpoint documents none/low/high/max, high by default. Scope
+    # this to the route: aggregators own their own effort gate (and defaults).
+    direct_deepseek = canonical == "deepseek" and model_name in {
+        "deepseek-flash",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-vision-exp",
+    }
+    fallback_levels = (
+        ("none", "low", "high", "max") if direct_deepseek else supported_efforts(model_name)
+    )
+    effort_levels = listing_levels if listing_levels is not None else fallback_levels
     # THE LADDER and THE SEED are two separate questions with two different
     # answers, and conflating them is what made two earlier revisions wrong.
     #
@@ -682,7 +693,9 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
         # membership guard is for a listing that NARROWS below the table's
         # default; seed nothing rather than clamping to a neighbouring rung no
         # source stated.
-        table_default = default_effort(model_name)
+        table_default = "high" if direct_deepseek else default_effort(model_name)
+        if canonical == "deepseek" and info is not None and info.reasoning_default_effort:
+            table_default = info.reasoning_default_effort
         reasoning_effort = table_default if table_default in effort_levels else None
     # A model with an effort ladder reasons BY DEFINITION, whatever its name
     # looks like: `claude-opus-5` matches none of the markers below — it says
@@ -692,6 +705,11 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
     reasoning = bool(effort_levels) or any(
         marker in lowered for marker in ("o1", "o3", "reasoner", "thinking", "deep-research")
     )
+    if info is not None and isinstance(getattr(info, "reasoning", None), bool):
+        reasoning = bool(info.reasoning)
+        if not reasoning:
+            effort_levels = ()
+            reasoning_effort = None
     # Keyed on the model, not on the provider that fronts it. `claude-opus-5`
     # returns 200 through OpenRouter only because the aggregator strips the
     # parameters before forwarding — the model never honoured them on either
@@ -804,7 +822,11 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
         default_context_window=getattr(info, "default_context_window", None),
         max_context_window=getattr(info, "max_context_window", None),
         max_output_tokens=max_output,
-        supports_tools=True,
+        supports_tools=(
+            bool(info.supports_tools)
+            if info is not None and isinstance(getattr(info, "supports_tools", None), bool)
+            else True
+        ),
         supports_images=supports_images,
         supports_prompt_cache=supports_cache,
         supports_responses_api=supports_responses_api,
@@ -1445,11 +1467,7 @@ def _info_from_discovery(
     putting that on the import path would cost every CLI invocation.
     """
     try:
-        from local_operator.model.discovery import (
-            DEFAULT_TIMEOUT_S,
-            available_models,
-            sane_listing_max_tokens,
-        )
+        from local_operator.model.discovery import DEFAULT_TIMEOUT_S, available_models
 
         secret, is_oauth, account_id = _listing_credential.get() or _catalogue_credential(provider)
         rows, status = available_models(
@@ -1479,6 +1497,20 @@ def _info_from_discovery(
     if row is None:
         logger.debug("%s listing (%s) has no entry for %s", provider, status, model_name)
         return fallback
+
+    return info_from_discovered_model(provider, model_name, row, fallback)
+
+
+def info_from_discovered_model(
+    provider: str, model_name: str, row: "DiscoveredModel", fallback: ModelInfo
+) -> ModelInfo:
+    """Project an already authenticated listing without another credential lookup.
+
+    The HTTP catalogue and runtime resolution must share field precedence. A
+    second fetch here could use a different account than the route's dependency
+    and silently replace the inventory the caller was actually authorized for.
+    """
+    from local_operator.model.discovery import sane_listing_max_tokens
 
     # Keyed on the id the CALLER asked for, not on ``row.id``: the match above
     # may have gone through id normalisation, and ``build_model_spec`` looks the
@@ -1523,7 +1555,27 @@ def _info_from_discovery(
         # already carries ``Optional[bool]`` with the same meaning, and
         # ``build_model_spec`` reads ``is not None`` before trusting it.
         info.supports_images = row.supports_images
+    if row.supports_tools is not None:
+        info.supports_tools = row.supports_tools
+    if row.reasoning is not None:
+        info.reasoning = row.reasoning
+    if provider == "deepseek" and row.reasoning_default_effort is not None:
+        info.reasoning_default_effort = row.reasoning_default_effort
     info.supports_prompt_cache = info.supports_prompt_cache or row.supports_prompt_cache
+    # Presence survives the listing cache: zero-price/false flags and valid
+    # small output limits must not turn into static guesses at this last hop.
+    native_fields = {
+        "context_window": "context_window",
+        "max_tokens": "max_tokens",
+        "input_price": "input_price",
+        "output_price": "output_price",
+        "cache_read_price": "cache_reads_price",
+        "cache_write_price": "cache_writes_price",
+        "supports_prompt_cache": "supports_prompt_cache",
+    }
+    for field in row.authoritative_fields:
+        if field in native_fields:
+            setattr(info, native_fields[field], getattr(row, field))
     return info
 
 
@@ -1825,7 +1877,7 @@ def _resolve_model_info_cached(
                 "max_context_window": None,
             }
         )
-    if oauth or _listing_can_correct(info):
+    if oauth or canonical == "deepseek" or _listing_can_correct(info):
         # EVERY provider, not just the aggregators. The gate used to be
         # `canonical in LISTING_PROVIDERS`, which left a hole that the model picker
         # turned into a routine path: the picker offers whatever a provider's live
@@ -1838,7 +1890,9 @@ def _resolve_model_info_cached(
         # Reached when the registry is missing the window or BOTH prices, and ALSO
         # when its limits are a dated transcription of this very listing — see
         # `_listing_can_correct`. A row that is complete and first-hand still costs
-        # nothing: no HTTP call, no cache read, no listing scan.
+        # nothing: no HTTP call, no cache read, no listing scan. DeepSeek is an
+        # exception: /models owns inventory/capabilities even when our documented
+        # fallback is complete. Its cached listing must get first refusal.
         #
         # The two cases get different budgets. Missing data is BLOCKING — the
         # session has no context window until the listing answers — so it keeps the
@@ -1857,7 +1911,10 @@ def _resolve_model_info_cached(
             timeout=None if _needs_enrichment(info) else _REFRESH_TIMEOUT_S,
         )
     route_context = (info.context_window, info.default_context_window, info.max_context_window)
-    if _needs_enrichment(info):
+    if _needs_enrichment(info) and canonical != "deepseek":
+        # DeepSeek's missing fields use documented native fallbacks, not an
+        # aggregator route's prices or capabilities. Unknown future ids stay
+        # unknown until the provider publishes those details.
         # STILL incomplete after the provider's own listing had its turn, which for
         # every DIRECT provider is the normal outcome rather than a failure: none of
         # them quote money in `/v1/models`, and for an id the registry has not been

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -264,6 +264,10 @@ def sane_listing_max_tokens(max_tokens: int, context_window: int) -> int:
 #: the only transports that quote a price at all.
 LISTING_CAPTURE_VERSIONS: dict[str, int] = {
     "anthropic": 2,
+    # Version 1 could normalize malformed nonempty /models data to []. The
+    # original payload is gone, so it cannot safely authorize an empty native
+    # inventory. Only DeepSeek pays the refetch; other caches stay valid.
+    "deepseek": 2,
     "openai": 2,
     "openrouter": 6,
     "radient": 6,
@@ -718,13 +722,21 @@ def _entry_list(body: object, *keys: str) -> list[Mapping[str, object]] | None:
     dropped instead of failing the page, so one junk entry cannot hide a
     provider's entire catalogue.
     """
+    entries = _raw_entry_list(body, *keys)
+    return (
+        [entry for entry in entries if isinstance(entry, Mapping)] if entries is not None else None
+    )
+
+
+def _raw_entry_list(body: object, *keys: str) -> list[object] | None:
+    """Retain array provenance before row filtering can turn junk into []."""
     if isinstance(body, list):
-        return [entry for entry in body if isinstance(entry, Mapping)]
+        return body
     if isinstance(body, Mapping):
         for key in keys:
             value = body.get(key)
             if isinstance(value, list):
-                return [entry for entry in value if isinstance(entry, Mapping)]
+                return value
     return None
 
 
@@ -1148,8 +1160,14 @@ def _fetch_openai_compat(ctx: _FetchContext) -> list[DiscoveredModel] | None:
     # ``_is_meta_route`` is only valid for an aggregator: this same parser
     # serves every ``openai-compat`` provider, and on Ollama the listing is the
     # user's own filesystem (see R1).
-    rows = (_row_from_openai_entry(entry, ctx.provider_id) for entry in entries)
-    return [row for row in rows if row is not None]
+    parsed = (_row_from_openai_entry(entry, ctx.provider_id) for entry in entries)
+    rows = [row for row in parsed if row is not None]
+    # A native listing may remove models, but filtering [null] or [{}] must
+    # not authorize an empty inventory. Preserve the established envelope and
+    # partial-row tolerance: usable rows still count, only ALL-junk is outage.
+    if ctx.provider_id == "deepseek" and not rows and _raw_entry_list(body, "data", "models"):
+        return None
+    return rows
 
 
 def _anthropic_models_url(base_url: str) -> str:
@@ -1857,6 +1875,18 @@ def invalidate_listing(provider_id: str, *, cache_dir: Path | None = None) -> in
     return invalidate_documents(storage_id, cache_dir=cache_dir)
 
 
+def _listing_replaces_static(
+    provider_id: str, rows: list[DiscoveredModel] | None, *, account_scoped: bool = False
+) -> bool:
+    """One inventory policy for live, stale and first-frame cache reads.
+
+    Native DeepSeek publishes the complete set, including a genuine empty
+    inventory. Preserve other providers' established union/account semantics.
+    An unavailable or invalid payload never gets deletion authority.
+    """
+    return rows is not None and (provider_id == "deepseek" or (account_scoped and bool(rows)))
+
+
 def cached_available_models(
     provider_id: str,
     *,
@@ -1889,10 +1919,11 @@ def cached_available_models(
     listing = peek_listing(key, cache_dir=cache_dir)
     capture = listing_capture_version(storage_id)
     live_rows = _rows_from_payload(listing.payload, capture)
-    if not live_rows:
+    authoritative = _listing_replaces_static(storage_id, live_rows)
+    if live_rows is None or (not live_rows and not authoritative):
         return merge_models(rows, None), "static"
 
-    return merge_models(rows, live_rows, include_static_only=True), "cached"
+    return merge_models(rows, live_rows, include_static_only=not authoritative), "cached"
 
 
 def available_models(
@@ -2140,7 +2171,9 @@ def _available_models(
     # DeepSeek documents /models as its complete current inventory, not a partial
     # entitlement snapshot. Keep legacy aliases only for offline fallback/manual
     # selectors; unioning them here resurrects retired models after a good fetch.
-    authoritative_live = (account_scoped and bool(live_rows)) or provider_id == "deepseek"
+    authoritative_live = _listing_replaces_static(
+        provider_id, live_rows, account_scoped=account_scoped
+    )
     merged = merge_models(
         rows,
         live_rows,

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -385,6 +385,9 @@ class DiscoveredModel:
     #: the point of use when its own listing declines to price it.
     routed: bool = False
     supports_images: bool | None = None
+    # Valid fields explicitly supplied by a native endpoint. This distinguishes
+    # zero prices/false flags from omissions through a JSON cache round-trip.
+    authoritative_fields: tuple[str, ...] = ()
     supports_tools: bool | None = None
     reasoning: bool | None = None
     active_context_window: int | None = None
@@ -595,7 +598,7 @@ def _stated_bool(value: object) -> bool | None:
     return value if isinstance(value, bool) else None
 
 
-def _effort_ladder(value: object) -> tuple[str, ...] | None:
+def _effort_ladder(value: object, *, preserve_empty: bool = False) -> tuple[str, ...] | None:
     """A listing's effort list as an ASCENDING ladder, or ``None`` when unstated.
 
     Sorted HERE, at ingest, rather than at each reader. ``EFFORT_ORDER`` is the
@@ -632,6 +635,11 @@ def _effort_ladder(value: object) -> tuple[str, ...] | None:
     """
     if not isinstance(value, (list, tuple)):
         return None
+    # An explicitly empty allowlist is a denial, unlike an unrecognised ladder.
+    # Preserve it through disk serialization instead of silently restoring a
+    # static effort knob the provider did not offer.
+    if not value:
+        return () if preserve_empty else None
     known = {
         word.lower() for word in value if isinstance(word, str) and word.lower() in EFFORT_ORDER
     }
@@ -913,8 +921,10 @@ def _row_from_openai_entry(
     reasoning = _mapping(entry.get("reasoning"))
 
     cache_read_price = _per_million(pricing.get("input_cache_read"))
-    effort_ladder = _effort_ladder(reasoning.get("supported_efforts"))
-    return DiscoveredModel(
+    effort_ladder = _effort_ladder(
+        reasoning.get("supported_efforts"), preserve_empty=provider_id == "deepseek"
+    )
+    row = DiscoveredModel(
         id=model_id,
         name=_first_str(entry.get("name"), entry.get("display_name")),
         # OpenRouter also publishes ``input_cache_write_1h`` for the one-hour
@@ -955,7 +965,15 @@ def _row_from_openai_entry(
         ),
         routed=_is_meta_route(model_id, provider_id, pricing),
         cache_read_price=cache_read_price,
-        supports_images=_has_image_input(architecture),
+        supports_images=(
+            _stated_bool(entry.get("supports_images"))
+            if provider_id == "deepseek" and _stated_bool(entry.get("supports_images")) is not None
+            else _has_image_input(architecture)
+        ),
+        supports_tools=(
+            _stated_bool(entry.get("supports_tools")) if provider_id == "deepseek" else None
+        ),
+        reasoning=(_stated_bool(entry.get("reasoning")) if provider_id == "deepseek" else None),
         # A priced cache-read leg is the only machine-readable evidence of prompt
         # caching in these listings; there is no capability flag for it.
         supports_prompt_cache=cache_read_price > 0,
@@ -970,6 +988,24 @@ def _row_from_openai_entry(
         reasoning_efforts=effort_ladder,
         reasoning_default_effort=_effort_default(reasoning.get("default_effort"), effort_ladder),
     )
+    if provider_id != "deepseek":
+        return row
+    # DeepSeek's live /models currently omits all of these. Only PRESENT,
+    # valid fields in the established compatibility schema can replace docs.
+    fields = [name for name in ("context_window", "max_tokens") if getattr(row, name) > 0]
+    for wire, name in (
+        ("prompt", "input_price"),
+        ("completion", "output_price"),
+        ("input_cache_read", "cache_read_price"),
+        ("input_cache_write", "cache_write_price"),
+    ):
+        if _per_million(pricing.get(wire)) > 0 or _stated_zero_price(pricing.get(wire)):
+            fields.append(name)
+    cache_support = _stated_bool(entry.get("supports_prompt_cache"))
+    if cache_support is not None:
+        fields.append("supports_prompt_cache")
+        row = dataclasses.replace(row, supports_prompt_cache=cache_support)
+    return dataclasses.replace(row, authoritative_fields=tuple(fields))
 
 
 def _serves_account_scoped_catalogue(
@@ -1513,6 +1549,8 @@ def _from_static(model_id: str, info: ModelInfo) -> DiscoveredModel:
         cache_read_price=_positive_float(info.cache_reads_price),
         cache_write_price=_positive_float(info.cache_writes_price),
         supports_images=_stated_bool(info.supports_images),
+        supports_tools=info.supports_tools,
+        reasoning=info.reasoning,
         supports_prompt_cache=bool(info.supports_prompt_cache),
     )
 
@@ -1559,8 +1597,9 @@ def _merge_one(row: DiscoveredModel, info: ModelInfo | None) -> DiscoveredModel:
     else:
         max_tokens = live_max or static_max
 
-    return DiscoveredModel(
+    merged = DiscoveredModel(
         id=row.id,
+        authoritative_fields=row.authoritative_fields,
         name=_merge_name(row.name, info.name, row.id),
         # Only a positive live window beats the registry. A listing that omits the
         # field (a lean OpenAI-compatible gateway, or an Anthropic proxy on an API
@@ -1625,7 +1664,16 @@ def _merge_one(row: DiscoveredModel, info: ModelInfo | None) -> DiscoveredModel:
         # of what the wire said and exactly one function owns the fallback.
         reasoning_efforts=row.reasoning_efforts,
         reasoning_default_effort=row.reasoning_default_effort,
+        supports_tools=(
+            row.supports_tools if row.supports_tools is not None else info.supports_tools
+        ),
+        reasoning=row.reasoning if row.reasoning is not None else info.reasoning,
     )
+    # Native facts beat gateway heuristics (including a real 4096 output cap).
+    overrides = {field: getattr(row, field) for field in row.authoritative_fields}
+    if "input_price" in overrides and "output_price" in overrides:
+        overrides["free"] = row.free
+    return dataclasses.replace(merged, **overrides)
 
 
 def _merge_name(live_name: str, static_name: str, model_id: str) -> str:
@@ -1723,11 +1771,25 @@ def _rows_from_payload(
             continue
         # Computed ONCE and handed to both fields: the default is only valid
         # against its own ladder, so re-deriving it would let the two disagree.
-        stored_ladder = _effort_ladder(entry.get("reasoning_efforts"))
+        stored_ladder = _effort_ladder(entry.get("reasoning_efforts"), preserve_empty=True)
         rows.append(
             DiscoveredModel(
                 id=model_id,
                 name=_first_str(entry.get("name")),
+                authoritative_fields=tuple(
+                    field
+                    for field in (entry.get("authoritative_fields") or [])
+                    if field
+                    in {
+                        "context_window",
+                        "max_tokens",
+                        "input_price",
+                        "output_price",
+                        "cache_read_price",
+                        "cache_write_price",
+                        "supports_prompt_cache",
+                    }
+                ),
                 context_window=_positive_int(entry.get("context_window")),
                 default_context_window=_positive_int(entry.get("default_context_window")) or None,
                 max_context_window=_positive_int(entry.get("max_context_window")) or None,
@@ -2075,7 +2137,10 @@ def _available_models(
     # all and no request issued to recover. Before this path existed the same
     # answer still offered every bundled id, which is the behaviour to keep:
     # upstream schema drift should cost "no new models", never "no models".
-    authoritative_live = account_scoped and bool(live_rows)
+    # DeepSeek documents /models as its complete current inventory, not a partial
+    # entitlement snapshot. Keep legacy aliases only for offline fallback/manual
+    # selectors; unioning them here resurrects retired models after a good fetch.
+    authoritative_live = (account_scoped and bool(live_rows)) or provider_id == "deepseek"
     merged = merge_models(
         rows,
         live_rows,

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -236,6 +236,11 @@ class ModelInfo(BaseModel):
     max_tokens: Optional[int] = None
     context_window: Optional[int] = None
     supports_images: Optional[bool] = None
+    # Unknown differs from a provider's explicit denial; the spec builder must
+    # not manufacture tool/reasoning support after a live listing denies it.
+    supports_tools: Optional[bool] = None
+    reasoning: Optional[bool] = None
+    reasoning_default_effort: Optional[str] = None
     supports_prompt_cache: bool = False
     supports_responses_api: bool = False
     cache_writes_price: Optional[float] = None
@@ -1339,22 +1344,28 @@ google_models: Dict[str, ModelInfo] = {
 }
 
 deepseek_models: Dict[str, ModelInfo] = {
-    # V4 family (2026): 1M context, implicit prompt caching, an order of
-    # magnitude cheaper than the V3 line. `-latest` floats to the newest
-    # snapshot; the dated ids pin a snapshot so a rollout cannot silently
-    # change behaviour under a long-running agent.
-    "deepseek-v4-flash": ModelInfo(
-        id="deepseek-v4-flash",
-        name="DeepSeek V4 Flash",
-        max_tokens=32_768,
-        context_window=1_048_576,
-        supports_images=False,
+    # /models is authoritative for inventory but currently returns ONLY ids,
+    # object and owner. These omitted-field fallbacks come from DeepSeek's
+    # pricing and create-chat-completion docs (2026-09-12), not an aggregator:
+    # https://api-docs.deepseek.com/quick_start/pricing
+    # https://api-docs.deepseek.com/api/create-chat-completion
+    # 384K is 393216 OUTPUT tokens, not a default request budget. Prices below
+    # are conservative PEAK estimates; off-peak is half (weekdays 01-04/06-10
+    # UTC are peak). Usage accounting has no time-of-use tariff model.
+    "deepseek-flash": ModelInfo(
+        id="deepseek-flash",
+        name="DeepSeek Flash",
+        max_tokens=393_216,
+        context_window=1_000_000,
+        supports_images=True,
+        supports_tools=True,
+        reasoning=True,
         supports_prompt_cache=True,
-        input_price=0.14,
-        output_price=0.28,
-        cache_writes_price=0.14,
-        cache_reads_price=0.014,
-        description="Fast, cheap agentic workhorse with a 1M context window",
+        input_price=0.30,
+        output_price=1.20,
+        cache_writes_price=0.30,
+        cache_reads_price=0.006,
+        description="DeepSeek V4.1 Flash with vision; peak price estimate (off-peak half)",
         recommended=True,
     ),
     "deepseek-v4-flash-0731": ModelInfo(
@@ -1379,15 +1390,17 @@ deepseek_models: Dict[str, ModelInfo] = {
     "deepseek-v4-pro": ModelInfo(
         id="deepseek-v4-pro",
         name="DeepSeek V4 Pro",
-        max_tokens=65_536,
-        context_window=1_048_576,
+        max_tokens=393_216,
+        context_window=1_000_000,
         supports_images=False,
+        supports_tools=True,
+        reasoning=True,
         supports_prompt_cache=True,
-        input_price=0.435,
-        output_price=0.87,
-        cache_writes_price=0.435,
-        cache_reads_price=0.0435,
-        description="Stronger V4 tier for harder reasoning and long refactors",
+        input_price=1.32,
+        output_price=3.96,
+        cache_writes_price=1.32,
+        cache_reads_price=0.044,
+        description="DeepSeek V4 Pro (0813); peak price estimate (off-peak half)",
         recommended=False,
     ),
     "deepseek-chat": ModelInfo(
@@ -1419,6 +1432,17 @@ deepseek_models: Dict[str, ModelInfo] = {
         recommended=False,
     ),
 }
+
+# Officially documented floating aliases now serve V4.1 Flash. Keep manual
+# selectors working offline, but a successful /models listing hides aliases.
+# Do NOT copy current vision/pricing onto the old pinned 0731 snapshot.
+for _deepseek_alias, _deepseek_label in (
+    ("deepseek-v4-flash", "DeepSeek V4 Flash"),
+    ("deepseek-v4-flash-vision-exp", "DeepSeek V4 Flash Vision (legacy alias)"),
+):
+    deepseek_models[_deepseek_alias] = deepseek_models["deepseek-flash"].model_copy(
+        update={"id": _deepseek_alias, "name": _deepseek_label, "recommended": False}
+    )
 
 qwen_models: Dict[str, ModelInfo] = {
     # No row here carries a cache price, and their absence is a correction rather

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1288,6 +1288,15 @@ def _effective_max_tokens(request: ChatRequest) -> int:
             rather than sending a doomed cap.
     """
     requested = request.max_tokens or request.model.max_output_tokens
+    if request.model.provider == "deepseek":
+        # The documented 384K maximum is a capability, not a default budget.
+        # Match native defaults (8K disabled, 64K thinking, 128K max) while
+        # respecting explicit small errands and the advertised maximum.
+        effort = _reasoning_effort(request)
+        default_budget = 8192 if effort == "none" else 131072 if effort == "max" else 65536
+        requested = request.max_tokens or default_budget
+        if request.model.max_output_tokens > 0:
+            requested = min(requested, request.model.max_output_tokens)
     if not requested or requested <= 0:
         # No cap asked for anywhere: the caller omits the key entirely and lets
         # the provider apply its own default. Clamping a value nobody set would
@@ -1669,6 +1678,48 @@ def _is_empty_assistant(message: Message) -> bool:
     if any(isinstance(block, ImageContent) for block in message.content):
         return False
     return not message.text.strip()
+
+
+def _deepseek_tool_images(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep tool results strings and project images after their complete group.
+
+    DeepSeek's vision guide restricts image input to user messages; its official
+    harness serializes tool screenshots this way too. Do not insert a user turn
+    between parallel tool results: that breaks assistant/tool pairing. A stable
+    synthetic user turn also keeps all prior request prefixes byte-identical as
+    further turns append (unlike merging into the latest mutable user message).
+    """
+    output: list[dict[str, Any]] = []
+    images: list[dict[str, Any]] = []
+
+    def flush() -> None:
+        if images:
+            output.append({"role": "user", "content": list(images)})
+            images.clear()
+
+    for entry in messages:
+        if entry.get("role") != "tool":
+            flush()
+        content = entry.get("content")
+        if entry.get("role") == "tool" and isinstance(content, list):
+            texts = []
+            for block in content:
+                if block.get("type") == "image_url":
+                    images.extend(
+                        [
+                            {
+                                "type": "text",
+                                "text": f"Image from tool result {entry.get('tool_call_id', '')}:",
+                            },
+                            block,
+                        ]
+                    )
+                elif block.get("type") == "text":
+                    texts.append(block.get("text", ""))
+            entry = {**entry, "content": "\\n".join(texts)}
+        output.append(entry)
+    flush()
+    return output
 
 
 def _message_to_openai(message: Message) -> dict[str, Any]:
@@ -2146,18 +2197,24 @@ class OpenAICompatClient:
         request = bind_native_context(
             request, endpoint, "openai-chat", scope, _estimate_slope(request.model)
         )
-        messages = [
-            *self._system_messages(request),
-            # Empty assistant turns (errored/aborted model turns the harness
-            # persists) are dropped, not sent: Moonshot/Kimi 400s on them.
-            # See `_is_empty_assistant`.
-            *[
-                self._replay_chat_message(m, request.model, endpoint, scope)
-                for m in request.messages
-                if not _is_empty_assistant(m)
-            ],
-        ]
-        if request.model.supports_prompt_cache:
+        direct_deepseek = request.model.provider == "deepseek"
+        messages = self._system_messages(request)
+        for message in request.messages:
+            entry = self._replay_chat_message(message, request.model, endpoint, scope)
+            # DeepSeek tool requests replay ALL prior native reasoning, even a
+            # reasoning-only turn. Validate provenance before retaining it: a
+            # display-only thought or another model/account's payload is not
+            # replayable state, and other providers still reject empty turns.
+            native_reasoning = direct_deepseek and any(
+                isinstance(entry.get(key), str) and entry[key]
+                for key in ("reasoning_content", "reasoning")
+            )
+            if _is_empty_assistant(message) and not native_reasoning:
+                continue
+            messages.append(entry)
+        if direct_deepseek:
+            messages = _deepseek_tool_images(messages)
+        elif request.model.supports_prompt_cache:
             self._message_cache_markers(messages)
         body: dict[str, Any] = {
             "model": request.model.model_id,
@@ -2198,7 +2255,14 @@ class OpenAICompatClient:
             # the extent of what was measured — an Anthropic model reached
             # through an aggregator, and the top rungs (`xhigh`/`max`), were not
             # exercised, so treat those as expected-to-work rather than proven.
-            body["reasoning_effort"] = effort
+            if direct_deepseek:
+                # Native Chat uses a separate toggle; 'none' is NOT a valid
+                # reasoning_effort. Never leak this dialect onto OpenRouter.
+                body["thinking"] = {"type": "disabled" if effort == "none" else "enabled"}
+                if effort != "none":
+                    body["reasoning_effort"] = effort
+            else:
+                body["reasoning_effort"] = effort
         fast = _fast_mode_support(request)
         if fast is not None and fast.dialect == DIALECT_SERVICE_TIER:
             # Top-level, the shape OpenAI defined and every OpenAI-shaped route
@@ -2208,7 +2272,7 @@ class OpenAICompatClient:
             body["service_tier"] = fast.value
         if request.stop_sequences:
             body["stop"] = list(request.stop_sequences)
-        if request.model.supports_prompt_cache and request.prompt_cache_key:
+        if request.model.supports_prompt_cache and request.prompt_cache_key and not direct_deepseek:
             # OpenRouter provider sticky routing expires after 10 minutes of
             # inactivity (https://openrouter.ai/docs/guides/best-practices/prompt-caching).
             # After expiry the next request can land on a different upstream
@@ -2310,7 +2374,14 @@ class OpenAICompatClient:
         out: list[dict[str, Any]] = []
         stable_cutoff = max(len(blocks) - 2, 0)
         for i, block in enumerate(blocks):
-            if request.model.supports_prompt_cache and i < stable_cutoff:
+            # DeepSeek caches complete persisted prefixes automatically. Explicit
+            # ephemeral markers are undocumented there and moving them each turn
+            # rewrites old prefixes, defeating the very cache they try to help.
+            if (
+                request.model.supports_prompt_cache
+                and request.model.provider != "deepseek"
+                and i < stable_cutoff
+            ):
                 out.append(
                     {
                         "role": "system",
@@ -2508,6 +2579,8 @@ class OpenAICompatClient:
         #: ``StreamEndEvent.served_provider`` for why the display name is kept
         #: verbatim and why this is not part of ``provider_payload``.
         served_provider: str | None = None
+        direct_deepseek = request.model.provider == "deepseek"
+        done_received = False
 
         headers = self._headers(api_key, oauth_access)
         headers.update(self._grok_conv_headers(request, url))
@@ -2522,11 +2595,20 @@ class OpenAICompatClient:
                 raise_for_status(response)
             async for data in _iter_sse_lines(response):
                 if data == "[DONE]":
+                    done_received = True
                     break
                 try:
                     chunk = json.loads(data)
-                except json.JSONDecodeError:
+                except json.JSONDecodeError as exc:
+                    if direct_deepseek:
+                        raise ProviderError(
+                            502, "DeepSeek returned malformed SSE JSON", retryable=True
+                        ) from exc
                     continue
+                if direct_deepseek and not isinstance(chunk, Mapping):
+                    raise ProviderError(
+                        502, "DeepSeek returned a non-object SSE chunk", retryable=True
+                    )
                 if isinstance(chunk.get("error"), (Mapping, str)):
                     # In-band mid-stream failure: the status line already said
                     # 200, so this chunk is the only channel the failure has.
@@ -2622,6 +2704,10 @@ class OpenAICompatClient:
                         yield StreamToolCallDelta(index=index, argument_delta=argument_delta)
                 if choice.get("finish_reason"):
                     finish_reason = str(choice["finish_reason"])
+                    if direct_deepseek and finish_reason == "insufficient_system_resource":
+                        raise ProviderError(
+                            503, "DeepSeek reported insufficient_system_resource", retryable=True
+                        )
                 if chunk.get("id") or chunk.get("system_fingerprint"):
                     provider_payload = {
                         "id": chunk.get("id"),
@@ -2641,6 +2727,17 @@ class OpenAICompatClient:
                 if candidate:
                     served_provider = candidate
 
+        # DeepSeek's protocol ends with [DONE] AND a recognized finish reason.
+        # Natural EOF is a truncated response, not a successful answer. Raising
+        # through the existing ProviderError path preserves retry/error handling;
+        # cancellation still propagates without manufacturing a terminal event.
+        if direct_deepseek:
+            if not done_received:
+                raise ProviderError(502, "DeepSeek stream ended before [DONE]", retryable=True)
+            if finish_reason not in {"stop", "length", "tool_calls", "content_filter"}:
+                raise ProviderError(
+                    502, "DeepSeek stream has no recognized finish reason", retryable=True
+                )
         stop_reason = _FINISH_TO_STOP_REASON.get(finish_reason or "", finish_reason or "stop")
         # A refusal delta with a non-filter finish (OpenAI sends
         # ``finish_reason=stop`` for its own refusals; only third-party filters

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -931,6 +931,53 @@ def _iter_sse_lines(response: httpx.Response) -> AsyncIterator[str]:
     return _gen()
 
 
+async def _iter_deepseek_sse_events(response: httpx.Response) -> AsyncIterator[str]:
+    """Dispatch complete SSE events, never physical lines or an EOF tail.
+
+    Native DeepSeek's DONE contract depends on the event's blank terminator.
+    Assemble multiline data and universal line endings here rather than changing
+    the permissive parser other compatibility providers already depend on. The
+    shared text decoder and stall watchdog still own UTF-8/chunk timing.
+    """
+    buffer = ""
+    data_lines: list[str] = []
+    skip_lf = False
+    first_text = True
+    async for chunk in _guarded_chunks(response):
+        if not chunk:
+            continue
+        if first_text:
+            chunk = chunk.removeprefix("\ufeff")
+            first_text = False
+        if skip_lf:
+            chunk = chunk.removeprefix("\n")
+            skip_lf = False
+        buffer += chunk
+        while match := re.search(r"\r\n|\r|\n", buffer):
+            line, buffer = buffer[: match.start()], buffer[match.end() :]
+            # A CR is itself a terminator. If its optional LF arrives in the
+            # next chunk, swallow that LF instead of inventing a blank event.
+            if match.group() == "\r" and not buffer:
+                skip_lf = True
+            if not line:
+                if data_lines:
+                    yield "\n".join(data_lines)
+                    data_lines.clear()
+            elif line.startswith("data:"):
+                value = line[5:]
+                data_lines.append(value[1:] if value.startswith(" ") else value)
+            elif line == "data":
+                data_lines.append("")
+            # Comments, event/id/retry and unknown SSE fields are not JSON data.
+    # No EOF flush: even a complete-looking DONE without the blank event
+    # terminator is truncation and is rejected by the native stream consumer.
+
+
+def _reject_json_constant(value: str) -> Any:
+    """Python's optional NaN/Infinity extension is not valid provider JSON."""
+    raise ValueError(f"non-standard JSON constant: {value}")
+
+
 async def _guarded_chunks(response: httpx.Response) -> AsyncIterator[str]:
     """``response.aiter_text()`` with a stall watchdog after the first chunk."""
     iterator = response.aiter_text().__aiter__()
@@ -1716,7 +1763,7 @@ def _deepseek_tool_images(messages: list[dict[str, Any]]) -> list[dict[str, Any]
                     )
                 elif block.get("type") == "text":
                     texts.append(block.get("text", ""))
-            entry = {**entry, "content": "\\n".join(texts)}
+            entry = {**entry, "content": "\n".join(texts)}
         output.append(entry)
     flush()
     return output
@@ -2593,13 +2640,22 @@ class OpenAICompatClient:
             if response.status_code >= 400:
                 await response.aread()
                 raise_for_status(response)
-            async for data in _iter_sse_lines(response):
+            payloads = (
+                _iter_deepseek_sse_events(response)
+                if direct_deepseek
+                else _iter_sse_lines(response)
+            )
+            async for data in payloads:
                 if data == "[DONE]":
                     done_received = True
                     break
                 try:
-                    chunk = json.loads(data)
-                except json.JSONDecodeError as exc:
+                    chunk = (
+                        json.loads(data, parse_constant=_reject_json_constant)
+                        if direct_deepseek
+                        else json.loads(data)
+                    )
+                except ValueError as exc:
                     if direct_deepseek:
                         raise ProviderError(
                             502, "DeepSeek returned malformed SSE JSON", retryable=True
@@ -2661,6 +2717,28 @@ class OpenAICompatClient:
                     continue
                 choice = choices[0]
                 delta = choice.get("delta") or {}
+                if direct_deepseek:
+                    # A finish seals the completion. Usage-only trailers may
+                    # still arrive before DONE, but later executable tools (or
+                    # text/reasoning) must never enter the assembled turn.
+                    if finish_reason is not None:
+                        new_finish = choice.get("finish_reason")
+                        if any(
+                            delta.get(field)
+                            for field in (
+                                "content",
+                                "reasoning_content",
+                                "reasoning",
+                                "reasoning_details",
+                                "tool_calls",
+                                "refusal",
+                            )
+                        ) or (new_finish is not None and new_finish != finish_reason):
+                            raise ProviderError(
+                                502,
+                                "DeepSeek returned completion data after its finish reason",
+                                retryable=True,
+                            )
                 for reasoning_key in ("reasoning_content", "reasoning"):
                     fragment = delta.get(reasoning_key)
                     if isinstance(fragment, str) and fragment:

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -1413,7 +1413,7 @@ class ProviderController:
         return entries
 
     def initial_catalogue(self, *, cache_dir: Any = None) -> list[CatalogueEntry]:
-        """First frame catalogue: shipped models layered with cached aggregator listings.
+        """First frame catalogue: shipped models and authoritative cached listings.
 
         Synchronous, non-blocking, and network-free. While direct providers have
         stable shipped static models in the registry, aggregator providers
@@ -1421,13 +1421,16 @@ class ProviderController:
         dynamic catalogues. When a previous live listing exists on disk, reading it
         via :func:`cached_available_models` allows hundreds of available models to
         paint on the very first frame rather than appearing only after a network
-        round trip.
+        round trip. DeepSeek's native inventory also owns its selectable set:
+        using the shipped rows here would flash retired ids even when the live
+        catalogue was already cached. Its cache reader supplies the ordinary
+        static fallback when no trustworthy native listing exists.
         """
         entries: list[CatalogueEntry] = []
         usable = self.usable_providers()
         for definition in PROVIDER_REGISTRY:
             connected = usable is None or definition.id in usable
-            if definition.id in AGGREGATOR_PROVIDERS:
+            if definition.id in AGGREGATOR_PROVIDERS or definition.id == "deepseek":
                 models, _status = cached_available_models(definition.id, cache_dir=cache_dir)
                 for model in models:
                     entries.append(
@@ -1441,7 +1444,7 @@ class ProviderController:
                             input_price=_price(model.input_price, definition, free=model.free),
                             output_price=_price(model.output_price, definition, free=model.free),
                             connected=connected,
-                            aggregated=True,
+                            aggregated=definition.id in AGGREGATOR_PROVIDERS,
                             routed=model.routed,
                         )
                     )

--- a/local_operator/server/routes/models.py
+++ b/local_operator/server/routes/models.py
@@ -14,6 +14,7 @@ from local_operator.clients.openrouter import OpenRouterClient
 from local_operator.clients.radient import RadientClient
 from local_operator.credentials import CredentialManager
 from local_operator.env import EnvConfig
+from local_operator.model.configure import info_from_discovered_model
 from local_operator.model.discovery import available_models
 from local_operator.model.registry import (
     ProviderDetail,
@@ -234,14 +235,18 @@ async def list_models(
                         )
                     )
             elif provider_detail.id == "deepseek":
-                for model_name, model_info in deepseek_models.items():
+                # Share native discovery's authenticated inventory/cache with
+                # the picker. Never resurrect retired static ids on this older
+                # HTTP surface or resolve metadata under a second credential.
+                api_key = await provider_auth_store.get_api_key("deepseek")
+                rows, _ = await asyncio.to_thread(available_models, "deepseek", api_key=api_key)
+                for row in rows:
+                    fallback = deepseek_models.get(row.id) or ModelInfo(
+                        id=row.id, name=row.name or row.id, description="Unknown model"
+                    )
+                    info = info_from_discovered_model("deepseek", row.id, row, fallback)
                     models.append(
-                        ModelEntry(
-                            id=model_name,
-                            name=model_info.name,
-                            provider=provider_detail.id,
-                            info=model_info,
-                        )
+                        ModelEntry(id=row.id, name=info.name, provider="deepseek", info=info)
                     )
             elif provider_detail.id == "google":
                 for model_name, model_info in google_models.items():

--- a/tests/unit/providers/test_deepseek.py
+++ b/tests/unit/providers/test_deepseek.py
@@ -18,12 +18,16 @@ from local_operator.harness.types import (
     Message,
     ModelSpec,
     StreamEndEvent,
+    StreamTextDelta,
+    StreamToolCallDelta,
     TextContent,
     ToolCall,
 )
-from local_operator.model import configure, discovery
+from local_operator.model import catalogue, configure, discovery
 from local_operator.model.registry import deepseek_models
+from local_operator.providers.auth_store import AuthStore
 from local_operator.providers.clients import OpenAICompatClient
+from local_operator.providers.controller import ProviderController
 from local_operator.providers.failover import ProviderError
 from local_operator.providers.replay import credential_scope
 
@@ -300,6 +304,251 @@ async def test_cancellation_does_not_become_truncated_stream_failure():
         with pytest.raises(asyncio.CancelledError):
             async for event in client.stream(request(), "fixture"):
                 assert not isinstance(event, StreamEndEvent)
+
+
+@pytest.mark.parametrize(
+    "bad", [[{}], [None], [{"name": "missing id"}], [None, {"name": "missing id"}]]
+)
+def test_malformed_native_inventory_uses_stale_or_static(tmp_path, bad):
+    payload = {"data": [{"id": "deepseek-flash"}]}
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, json=payload))
+    ) as client:
+        first, _ = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path / "warm"
+        )
+        payload = {"data": bad}
+        warm, status = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path / "warm", ttl_s=-1
+        )
+        assert status == "stale"
+        assert [row.id for row in warm] == [row.id for row in first] == ["deepseek-flash"]
+        cold, status = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path / "cold"
+        )
+        assert status == "static"
+        assert {row.id for row in cold} == set(deepseek_models)
+
+
+def test_untrusted_historic_empty_cache_is_refetched_only_for_deepseek(tmp_path):
+    # Exact old capture reproduced from data:[null]: no raw provenance remains.
+    key = discovery._cache_key("deepseek")
+    catalogue.cached_listing(key, lambda: {"capture": 1, "models": []}, cache_dir=tmp_path)
+    calls = []
+
+    def serve(req):
+        calls.append(req.url.path)
+        return httpx.Response(200, json={"data": [{"id": "deepseek-flash"}]})
+
+    with httpx.Client(transport=httpx.MockTransport(serve)) as client:
+        rows, status = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path
+        )
+    assert status == "ok"
+    assert [row.id for row in rows] == ["deepseek-flash"]
+    assert calls == ["/v1/models"]
+    stored = catalogue.peek_listing(key, cache_dir=tmp_path).payload
+    assert stored is not None
+    assert stored["capture"] == 2
+    # The same historical stamp remains valid for an untouched native route.
+    catalogue.cached_listing(
+        discovery._cache_key("mistral"),
+        lambda: {"capture": 1, "models": [{"id": "qa-mistral"}]},
+        cache_dir=tmp_path,
+    )
+    with httpx.Client(transport=httpx.MockTransport(serve)) as client:
+        other, status = discovery.available_models(
+            "mistral", api_key="fixture", client=client, cache_dir=tmp_path
+        )
+    assert status == "cached"
+    assert "qa-mistral" in {row.id for row in other}
+    assert calls == ["/v1/models"]
+
+
+@pytest.mark.asyncio
+async def test_native_sse_assembles_multiline_bom_crlf_and_split_utf8():
+    payload = (
+        "\ufeff: heartbeat\r\nevent: message\r\nid: 7\r\n"
+        'data: {"choices": [\r\n'
+        'data: {"index": 0, "delta": {"content": "café"}, "finish_reason": null}]}\r\n\r\n'
+        + sse(finish="stop")
+        + "data: [DONE]\r\n\r\n"
+    ).encode()
+
+    class SplitBytes(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            # Every possible byte boundary, including UTF-8 and CR/LF pairs.
+            for byte in payload:
+                yield bytes([byte])
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, stream=SplitBytes()))
+    ) as http:
+        client = OpenAICompatClient("https://api.deepseek.com/v1", http_client=http)
+        events = [event async for event in client.stream(request(), "fixture")]
+    assert "".join(e.delta for e in events if isinstance(e, StreamTextDelta)) == "café"
+    assert isinstance(events[-1], StreamEndEvent)
+    assert events[-1].stop_reason == "stop"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tail", ["data: [DONE]", "data: [DONE]\n", "data: [DONE]\r\n"])
+async def test_native_done_requires_blank_event_terminator(tail):
+    payload = sse({"content": "answer"}, "stop") + tail
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, content=payload))
+    ) as http:
+        client = OpenAICompatClient("https://api.deepseek.com/v1", http_client=http)
+        with pytest.raises(ProviderError, match="before \\[DONE\\]"):
+            async for event in client.stream(request(), "fixture"):
+                assert not isinstance(event, StreamEndEvent)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+async def test_native_sse_rejects_nonstandard_json_constants(constant):
+    payload = (
+        'data: {"unused": '
+        + constant
+        + ', "choices": []}\n\n'
+        + sse(finish="stop")
+        + "data: [DONE]\n\n"
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, content=payload))
+    ) as http:
+        client = OpenAICompatClient("https://api.deepseek.com/v1", http_client=http)
+        with pytest.raises(ProviderError) as caught:
+            async for event in client.stream(request(), "fixture"):
+                assert not isinstance(event, StreamEndEvent)
+        assert caught.value.retryable
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delta,finish",
+    [
+        ({"content": "late text"}, None),
+        ({"reasoning_content": "late thought"}, None),
+        (
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "late",
+                        "type": "function",
+                        "function": {"name": "write", "arguments": "{}"},
+                    }
+                ]
+            },
+            "tool_calls",
+        ),
+        ({}, "length"),
+    ],
+)
+async def test_native_finish_seals_text_reasoning_and_executable_tools(delta, finish):
+    payload = sse({"content": "safe"}, "stop") + sse(delta, finish) + "data: [DONE]\n\n"
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, content=payload))
+    ) as http:
+        client = OpenAICompatClient("https://api.deepseek.com/v1", http_client=http)
+        with pytest.raises(ProviderError, match="after its finish reason") as caught:
+            async for event in client.stream(request(), "fixture"):
+                assert not isinstance(event, (StreamEndEvent, StreamToolCallDelta))
+                if isinstance(event, StreamTextDelta):
+                    assert event.delta == "safe"
+        assert caught.value.retryable
+
+
+@pytest.mark.asyncio
+async def test_native_finish_allows_usage_only_trailer():
+    payload = (
+        sse({"content": "safe"}, "stop")
+        + 'data: {"choices": [], "usage": {"prompt_tokens": 10, "completion_tokens": 2}}\n\n'
+        + "data: [DONE]\n\n"
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, content=payload))
+    ) as http:
+        client = OpenAICompatClient("https://api.deepseek.com/v1", http_client=http)
+        events = [event async for event in client.stream(request(), "fixture")]
+    assert isinstance(events[-1], StreamEndEvent)
+    assert events[-1].usage is not None
+    assert events[-1].usage.input_tokens == 10
+
+
+@pytest.mark.parametrize("state", ["fresh", "stale", "empty", "cold", "historic-invalid"])
+def test_first_frame_uses_authoritative_native_cache_without_fetching(monkeypatch, tmp_path, state):
+    cache_dir = tmp_path / "listing"
+    key = discovery._cache_key("deepseek")
+    if state == "historic-invalid":
+        catalogue.cached_listing(key, lambda: {"capture": 1, "models": []}, cache_dir=cache_dir)
+    elif state != "cold":
+        payload = {
+            "data": (
+                []
+                if state == "empty"
+                else [
+                    {"id": "deepseek-flash", "context_length": 200_000},
+                    {"id": "deepseek-v4-pro"},
+                ]
+            )
+        }
+        with httpx.Client(
+            transport=httpx.MockTransport(lambda _: httpx.Response(200, json=payload))
+        ) as client:
+            discovery.available_models(
+                "deepseek", api_key="fixture", client=client, cache_dir=cache_dir
+            )
+        if state == "stale":
+            path = catalogue._cache_path(key, cache_dir)
+            raw = json.loads(path.read_text())
+            raw["fetched_at"] -= 2 * 86400
+            path.write_text(json.dumps(raw))
+
+    def no_network(*args, **kwargs):
+        raise AssertionError("first frame must only peek at cache")
+
+    monkeypatch.setattr(discovery, "fetch_models", no_network)
+    rows, status = discovery.cached_available_models("deepseek", cache_dir=cache_dir)
+    expected = (
+        set(deepseek_models)
+        if state in {"cold", "historic-invalid"}
+        else set() if state == "empty" else {"deepseek-flash", "deepseek-v4-pro"}
+    )
+    assert {row.id for row in rows} == expected
+    assert status == ("static" if state in {"cold", "historic-invalid"} else "cached")
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("deepseek", {"type": "api_key", "key": "synthetic-firstframe-only"})
+    try:
+        controller = ProviderController(store)
+        entries = [
+            entry
+            for entry in controller.initial_catalogue(cache_dir=cache_dir)
+            if entry.provider == "deepseek"
+        ]
+        assert {entry.model_id for entry in entries} == expected
+        assert all(entry.connected and not entry.aggregated for entry in entries)
+        if state in {"fresh", "stale"}:
+            assert (
+                next(
+                    entry for entry in entries if entry.model_id == "deepseek-flash"
+                ).context_window
+                == 200_000
+            )
+    finally:
+        store.close()
+
+
+def test_native_tool_text_uses_real_newlines():
+    tool = Message(
+        role="tool",
+        tool_call_id="sample",
+        content=[TextContent(text="alpha"), TextContent(text="beta"), ImageContent(data="YWJj")],
+    )
+    client = OpenAICompatClient("https://api.deepseek.com/v1")
+    body = client._build_body(request([tool]))
+    assert next(m for m in body["messages"] if m["role"] == "tool")["content"] == "alpha\nbeta"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_deepseek.py
+++ b/tests/unit/providers/test_deepseek.py
@@ -1,0 +1,316 @@
+"""Native DeepSeek contract: live inventory, explicit metadata and stable replay.
+
+The real /models response captured 2026-09-12 contains ids/object/owner ONLY.
+Richer fixtures exercise precedence if that endpoint later supplies recognized
+compatibility fields, not a claim that it advertises those capabilities today.
+"""
+
+import asyncio
+import json
+from dataclasses import asdict
+
+import httpx
+import pytest
+
+from local_operator.harness.types import (
+    ChatRequest,
+    ImageContent,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    TextContent,
+    ToolCall,
+)
+from local_operator.model import configure, discovery
+from local_operator.model.registry import deepseek_models
+from local_operator.providers.clients import OpenAICompatClient
+from local_operator.providers.failover import ProviderError
+from local_operator.providers.replay import credential_scope
+
+
+@pytest.fixture(autouse=True)
+def isolated_metadata(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    configure.invalidate_model_info_cache()
+    yield
+    configure.invalidate_model_info_cache()
+
+
+def spec(effort="high"):
+    return ModelSpec(
+        provider="deepseek",
+        model_id="deepseek-flash",
+        context_window=1_000_000,
+        max_output_tokens=393_216,
+        supports_images=True,
+        supports_prompt_cache=True,
+        reasoning_efforts=("none", "low", "high", "max"),
+        reasoning_effort=effort,
+    )
+
+
+def request(messages=None, effort="high", **kwargs):
+    return ChatRequest(
+        model=spec(effort),
+        messages=messages or [Message.user("hello")],
+        system_blocks=["Stable system", "Stable context"],
+        prompt_cache_key="synthetic-deepseek",
+        **kwargs,
+    )
+
+
+def sse(delta=None, finish=None):
+    return (
+        "data: "
+        + json.dumps({"choices": [{"index": 0, "delta": delta or {}, "finish_reason": finish}]})
+        + "\n\n"
+    )
+
+
+def test_authoritative_inventory_cache_and_offline(tmp_path):
+    calls = []
+
+    def serve(req):
+        calls.append(req.url.path)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {"id": "deepseek-flash", "object": "model", "owned_by": "deepseek"},
+                    {"id": "deepseek-v4-pro", "object": "model", "owned_by": "deepseek"},
+                ],
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(serve)) as client:
+        rows, status = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path / "live"
+        )
+        assert status == "ok"
+        assert {r.id for r in rows} == {"deepseek-flash", "deepseek-v4-pro"}
+        assert next(r for r in rows if r.id == "deepseek-flash").supports_images is True
+        _, status = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path / "live"
+        )
+        assert status == "cached"
+        assert len(calls) == 1
+    with httpx.Client(transport=httpx.MockTransport(lambda _: httpx.Response(503))) as client:
+        rows, status = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path / "cold"
+        )
+        assert status == "static"
+        assert {r.id for r in rows} == set(deepseek_models)
+
+
+def test_successful_empty_inventory_does_not_resurrect_static_models(tmp_path):
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, json={"data": []}))
+    ) as client:
+        rows, status = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path
+        )
+    assert rows == []
+    assert status == "empty"
+
+
+@pytest.mark.parametrize("value", [True, False, None])
+def test_live_capabilities_override_complete_rows(monkeypatch, value):
+    payload = {"id": "deepseek-flash"}
+    if value is not None:
+        payload.update(
+            supports_images=value,
+            supports_tools=value,
+            reasoning=value,
+            supports_prompt_cache=value,
+        )
+    row = discovery._row_from_openai_entry(payload, "deepseek")
+    assert row is not None
+    rows = discovery.merge_models(deepseek_models, [row], include_static_only=False)
+    monkeypatch.setattr(discovery, "available_models", lambda *a, **k: (rows, "ok"))
+    cfg = configure.configure_model("deepseek", "deepseek-flash")
+    expected = value is not False
+    assert cfg.spec.supports_images is expected
+    assert cfg.spec.supports_tools is expected
+    assert cfg.spec.reasoning is expected
+    assert cfg.spec.supports_prompt_cache is expected
+    assert cfg.spec.reasoning_efforts == (() if value is False else ("none", "low", "high", "max"))
+
+
+def test_live_limits_zero_prices_and_empty_effort_survive_cache(monkeypatch, tmp_path):
+    payload = {
+        "id": "deepseek-flash",
+        "context_length": 200_000,
+        "max_output_tokens": 4096,
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "input_cache_read": "0",
+            "input_cache_write": "0",
+        },
+        "reasoning": {"supported_efforts": []},
+        "supports_prompt_cache": False,
+    }
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, json={"data": [payload]}))
+    ) as client:
+        first, _ = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path / "listing"
+        )
+        rows, status = discovery.available_models(
+            "deepseek", api_key="fixture", client=client, cache_dir=tmp_path / "listing"
+        )
+    assert status == "cached"
+    assert asdict(rows[0]) == asdict(first[0])
+    monkeypatch.setattr(discovery, "available_models", lambda *a, **k: (rows, "cached"))
+    cfg = configure.configure_model("deepseek", "deepseek-flash")
+    assert cfg.spec.context_window == 200_000
+    assert cfg.spec.max_output_tokens == 4096
+    assert cfg.info.input_price == cfg.info.output_price == cfg.info.cache_reads_price == 0
+    assert cfg.spec.reasoning_efforts == ()
+    assert cfg.spec.reasoning_effort is None
+    assert cfg.spec.supports_prompt_cache is False
+
+
+@pytest.mark.parametrize(
+    "model,images",
+    [("deepseek-flash", True), ("deepseek-v4-pro", False), ("deepseek-v4-flash", True)],
+)
+def test_documented_fallbacks_and_provider_effort(monkeypatch, model, images):
+    monkeypatch.setattr(discovery, "available_models", lambda *a, **k: ([], "static"))
+    cfg = configure.configure_model("deepseek", model)
+    assert cfg.spec.context_window == 1_000_000
+    assert cfg.spec.max_output_tokens == 393_216
+    assert cfg.spec.supports_images is images
+    assert cfg.spec.reasoning_efforts == ("none", "low", "high", "max")
+    assert cfg.spec.reasoning_effort == "high"
+    assert "peak price estimate" in cfg.info.description
+    other = configure.build_model_spec(
+        "openrouter", "deepseek/deepseek-flash", info=deepseek_models[model]
+    )
+    assert other.reasoning_efforts != cfg.spec.reasoning_efforts
+
+
+@pytest.mark.parametrize(
+    "effort,budget", [("none", 8192), ("low", 65536), ("high", 65536), ("max", 131072)]
+)
+def test_native_effort_and_budget(effort, budget):
+    client = OpenAICompatClient("https://api.deepseek.com/v1")
+    body = client._build_body(request(effort=effort))
+    assert body["thinking"] == {"type": "disabled" if effort == "none" else "enabled"}
+    assert body.get("reasoning_effort") == (None if effort == "none" else effort)
+    assert body["max_tokens"] == budget
+    assert client._build_body(request(effort=effort, max_tokens=24))["max_tokens"] == 24
+    assert client._build_body(request(effort=effort, max_tokens=500_000))["max_tokens"] == 393_216
+
+
+def test_implicit_cache_prefix_is_unchanged_and_tool_images_are_user_only():
+    client = OpenAICompatClient("https://api.deepseek.com/v1")
+    history = [Message.user("first"), Message.assistant("first answer"), Message.user("second")]
+    first = client._build_body(request(history))
+    calls = [
+        ToolCall(id="a", name="inspect", arguments={}),
+        ToolCall(id="b", name="inspect", arguments={}),
+    ]
+    history += [Message.assistant(tool_calls=calls)]
+    for call in calls:
+        history.append(
+            Message(
+                role="tool",
+                tool_call_id=call.id,
+                content=[TextContent(text="found"), ImageContent(data="YWJj")],
+            )
+        )
+    second = client._build_body(request(history))
+    assert second["messages"][: len(first["messages"])] == first["messages"]
+    assert [m["role"] for m in second["messages"][-4:]] == ["assistant", "tool", "tool", "user"]
+    assert all(isinstance(m["content"], str) for m in second["messages"] if m["role"] == "tool")
+    assert len([b for b in second["messages"][-1]["content"] if b["type"] == "image_url"]) == 2
+    history += [Message.assistant("seen"), Message.user("third")]
+    third = client._build_body(request(history))
+    assert third["messages"][: len(second["messages"])] == second["messages"]
+    assert "cache_control" not in json.dumps(third)
+    assert "prompt_cache_key" not in third
+    assert all(isinstance(m["content"], str) for m in third["messages"] if m["role"] == "system")
+
+
+@pytest.mark.asyncio
+async def test_native_reasoning_only_replay_is_scoped():
+    response = (
+        sse({"reasoning_content": "opaque native thought"})
+        + sse(finish="stop")
+        + "data: [DONE]\n\n"
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, content=response))
+    ) as http:
+        client = OpenAICompatClient("https://api.deepseek.com/v1", http_client=http)
+        events = [e async for e in client.stream(request(), "fixture")]
+        end = next(e for e in events if isinstance(e, StreamEndEvent))
+        native = Message.assistant(provider_payload=end.provider_payload)
+        native = Message.model_validate_json(native.model_dump_json())
+        req = request([Message.user("hello"), native, Message.user("continue")])
+        body = client._build_body(req, scope=credential_scope("fixture", None))
+        assert body["messages"][3]["reasoning_content"] == "opaque native thought"
+        changed = client._build_body(req, scope="other-account")
+        assert not any(m["role"] == "assistant" for m in changed["messages"])
+        req.model = req.model.model_copy(update={"model_id": "deepseek-v4-pro"})
+        assert not any(
+            m["role"] == "assistant"
+            for m in client._build_body(req, scope=credential_scope("fixture", None))["messages"]
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "",
+        sse({"content": "partial"}, "stop"),
+        sse({"content": "partial"}) + "data: [DONE]\n\n",
+        "data: {bad}\n\n",
+        "data: []\n\n",
+        sse(finish="unknown") + "data: [DONE]\n\n",
+        sse(finish="insufficient_system_resource") + "data: [DONE]\n\n",
+    ],
+)
+async def test_invalid_native_terminal_is_retryable_failure(payload):
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, content=payload))
+    ) as http:
+        client = OpenAICompatClient("https://api.deepseek.com/v1", http_client=http)
+        with pytest.raises(ProviderError) as caught:
+            async for event in client.stream(request(), "fixture"):
+                assert not isinstance(event, StreamEndEvent)
+        assert caught.value.retryable
+
+
+@pytest.mark.asyncio
+async def test_cancellation_does_not_become_truncated_stream_failure():
+    class CancelStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield sse({"content": "partial"}).encode()
+            raise asyncio.CancelledError
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, stream=CancelStream()))
+    ) as http:
+        client = OpenAICompatClient("https://api.deepseek.com/v1", http_client=http)
+        with pytest.raises(asyncio.CancelledError):
+            async for event in client.stream(request(), "fixture"):
+                assert not isinstance(event, StreamEndEvent)
+
+
+@pytest.mark.asyncio
+async def test_other_compat_routes_keep_terminal_tolerance():
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _: httpx.Response(200, content=sse({"content": "ok"}, "stop"))
+        )
+    ) as http:
+        client = OpenAICompatClient("https://other.invalid/v1", http_client=http)
+        req = request()
+        req.model = req.model.model_copy(update={"provider": "openrouter"})
+        events = [e async for e in client.stream(req, "fixture")]
+        assert isinstance(events[-1], StreamEndEvent)

--- a/tests/unit/server/test_server_models.py
+++ b/tests/unit/server/test_server_models.py
@@ -14,7 +14,8 @@ from local_operator.clients.openrouter import (
     OpenRouterModelPricing,
 )
 from local_operator.env import get_env_config
-from local_operator.model.discovery import DiscoveredModel
+from local_operator.model.discovery import DiscoveredModel, merge_models
+from local_operator.model.registry import deepseek_models
 from local_operator.server.app import app
 
 
@@ -49,7 +50,11 @@ def client(monkeypatch):
     # Local runtime integration has its own owned-HTTP tests. Enumeration
     # tests must not inspect whichever server a developer has running today.
     monkeypatch.setattr(
-        "local_operator.server.routes.models.available_models", lambda *a, **kw: ([], "static")
+        "local_operator.server.routes.models.available_models",
+        lambda provider, **kw: (
+            merge_models(deepseek_models, None) if provider == "deepseek" else [],
+            "static",
+        ),
     )
     had_env_config = hasattr(app.state, "env_config")
     previous = getattr(app.state, "env_config", None)
@@ -62,6 +67,37 @@ def client(monkeypatch):
             app.state.env_config = previous
         elif hasattr(app.state, "env_config"):
             delattr(app.state, "env_config")
+
+
+def test_deepseek_http_catalogue_uses_authenticated_live_inventory(
+    client, mock_credential_manager, monkeypatch
+):
+    """The older HTTP surface must not reintroduce retired picker entries."""
+    seen = []
+
+    def listing(provider, **kwargs):
+        seen.append((provider, kwargs))
+        return [
+            DiscoveredModel(
+                id="deepseek-flash",
+                name="Live Flash",
+                context_window=200_000,
+                supports_images=False,
+                supports_tools=False,
+                reasoning=False,
+            )
+        ], "ok"
+
+    monkeypatch.setattr("local_operator.server.routes.models.available_models", listing)
+    response = client.get("/v1/models?provider=deepseek")
+    assert response.status_code == 200
+    rows = response.json()["result"]["models"]
+    assert [row["id"] for row in rows] == ["deepseek-flash"]
+    assert rows[0]["info"]["supports_images"] is False
+    assert rows[0]["info"]["supports_tools"] is False
+    assert rows[0]["info"]["context_window"] == 200_000
+    assert seen[0][0] == "deepseek"
+    assert "api_key" in seen[0][1]
 
 
 def test_list_providers_with_ollama_active(client):


### PR DESCRIPTION
Release: **patch** — fixes the direct DeepSeek provider's discovery, metadata and wire-contract defects. `pyproject.toml` unchanged; no version bump.

**Independent code, QA and design convergence rounds are clean on a6988551e31c1ac519139bc9543067a4b8d38ce5.** All initial findings were recorded before one unified remediation commit and answered per finding. **Final hosted CI is green.** The PR is ready for the documented code-owner merge path; no further head changes were made after the clean independent rounds.

- [Agent review2 — clean/terminal](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647487623) · [acknowledged](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647516516)
- [Independent QA2 — PASS, no findings](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647504337) · [acknowledged](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647516595)
- [Design2 — clean/terminal](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647485990) · [acknowledged](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647516674)
- [Final-head hosted CI](https://github.com/damianvtran/local-operator/actions/runs/34707876327): **SUCCESS**, all checks. Actual five-shard footers total **19,150passed /88skipped**; actual Linux and macOS E2E footers each **119passed /7optional-extension skips**. Pre-PR run34705194022 also finished fully green after rerunning only its documented failed timing job; that older-head result is not substituted for this final-head proof.

## Delivery contract

**C1 correctness/optimization fix**, authorized by the operator. Direct `deepseek` inventory must follow the live models API; present valid capabilities override static guesses, including explicit false. Omitted fields use documented native metadata, not another host's route. Preserve native reasoning and serialized prefixes so automatic context caching can work. Match the official native tool-image and stream-terminal contracts without altering OpenRouter's affinity work from #995.

Acceptance:
- Successful native `/models` inventories (including empty) replace static selectable IDs; existing cache/offline fallback remains usable. The picker and older `/v1/models` HTTP catalogue agree.
- Canonical Flash resolves to V4.1 Flash with images, Pro to non-vision V4 Pro; 1,000,000 context and 393,216 output maximum. Present tools/images/reasoning/cache booleans, limits, prices and empty effort allowlists survive discovery → cache → ModelInfo → ModelSpec.
- Native none/low/high/max, high default; none disables thinking. Maximum capability does not become a 384K default request budget.
- All provenance-valid previous native reasoning replays, including reasoning-only assistant turns. Raw tool argument bytes and assistant/tool pairing survive.
- Direct caching is automatic, without moving ephemeral cache markers or unsupported prompt_cache_key. Tool images become a stable following user message after the full tool-result group.
- Missing DONE, missing/unknown finish reasons, malformed SSE and insufficient_system_resource cannot silently succeed. Existing cancellation and retry paths remain intact; other compatibility providers retain their behavior.

Non-goals: Responses migration, Files API uploads, a server user_id policy, the official tokenizer, unrelated provider redesign, or a universal claim of parity with optional APIs. No new tickets. No config/schema migrations. Prices below are conservative **peak estimates**, not billed time-of-use cost.

## Ground truth and diagnosis

Authenticated `GET https://api.deepseek.com/models` returned HTTP200:

```json
{"object":"list","data":[{"id":"deepseek-flash","object":"model","owned_by":"deepseek"},{"id":"deepseek-v4-pro","object":"model","owned_by":"deepseek"}]}
```

**No capability, context or pricing fields are present in today's response.** Documentation supplies omitted-field fallbacks; richer test fixtures prove precedence if recognized fields are supplied later.

Before, assembled discovery advertised six IDs including retired static entries. `deepseek-flash` resolved to images=false, max384000, no effort ladder; Pro had 1048576 context and 65536 max. After, the picker advertises exactly the two live IDs, both 1M context/393216 max, Flash images=true, Pro=false, native high-default effort ladder. The documented legacy floating aliases remain manually resolvable; the pinned 0731 snapshot is not speculatively relabelled as current vision.

## Sources and official harness comparison

Full native contract and constraints: [docs/DEEPSEEK.md](docs/DEEPSEEK.md).

| Surface | Authoritative reference | Result |
| --- | --- | --- |
| Inventory | [List models](https://api-docs.deepseek.com/api/list-models) | Live native inventory plus existing cache, rather than official harness's configured static listModels |
| Capabilities/prices | [Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing) | Current canonical native fallbacks; peak estimates explicitly labelled, off-peak half |
| Effort and replay | [Thinking mode](https://api-docs.deepseek.com/guides/thinking_mode) | Native toggle/ladder; all valid prior reasoning with tools |
| Cache continuity | [Context caching](https://api-docs.deepseek.com/guides/kv_cache) | Complete persisted-prefix model; implicit caching; measured native hit counters |
| Tool screenshots | [Vision](https://api-docs.deepseek.com/guides/vision), official serialize.ts | User-only projection after a complete tool-result group |
| Stream terminal/errors | Official sse.ts/translate.ts | Requires DONE plus recognized terminal; malformed/resource failures are retryable errors |

Official audit pinned to [`deepseek-ai/deepseek-harness@c291e7961a515f6d7af9304e7fd1d257929aef26`](https://github.com/deepseek-ai/deepseek-harness/tree/c291e7961a515f6d7af9304e7fd1d257929aef26), not a moving branch.

## Testing evidence

All app/test runs redirect HOME, config and cache and remove every inherited CMUX_* variable. Synthetic session IDs only; the live DeepSeek key was read through a read-only auth handle, stayed in memory, and was never copied into a fixture/config or log.

### Live assembled native path

Real `SessionStreamFn` → `OpenAICompatClient` → DeepSeek; native low thinking, stable synthetic prefix and tool schema. The model called `inspect_sample({"sample":"red-square"})`. Its result generated a 358-byte red-square.png in an isolated directory and returned an image. The next completion answered **Red.** Later user turns answered **Red** while preserving all previous serialized message prefixes and native payloads through message JSON persistence.

| Request | Stop | Prompt | Output | Native reasoning tokens | Cache read tokens |
| --- | --- | ---: | ---: | ---: | ---: |
| Tool request | toolUse | 2254 | 75 | 35 | 0 |
| Tool-image follow-up | stop, Red. | 2557 | 11 | 8 | 2304 |
| Next user | stop, Red | 2581 | 10 | 8 | 2432 |
| Next user | stop, Red | 2604 | 19 | 17 | 2432 |
| Next user | stop, Red | 2636 | 8 | 6 | 2432 |

Native negative-path probes through the actual client returned nonretryable HTTP401 for an invalid key and HTTP400 for an invalid model (the error named the same two supported native IDs). One image-bearing Pro request was accepted, but final-answer/image-understanding was not captured or established; acceptance alone does not override DeepSeek's documented Pro vision=false fallback.

Native cache counters are observed, not a guarantee of any fixed hit rate. A separate direct user-image request built by the actual client also returned HTTP200 **Red**, prompt201/output1 and DONE. An initial request encountered HTTP402 before account funds became available; it is not counted as successful validation. Final live calls succeeded.

Reproduction/verification runners and raw sanitized results provided to reviewers: `/tmp/lo_deepseek_evidence.py`, `/tmp/lo_deepseek_live_loop.py`, `/tmp/deepseek-before.log`, `/tmp/deepseek-after.log`, `/tmp/deepseek-live-loop.log`. Durable screenshots and QA/code/design rounds are attached below/on the PR.

### Unified review remediation

Commit `8928e31..a698855` fixes R1–R4/Q1–Q3 together: preserves raw inventory provenance and DeepSeek-only cache migration; shares inventory authority across live/cache-only/first-frame readers; assembles native SSE events with strict JSON/terminal sealing; fixes projected tool-text newlines.

- **1304 focused regressions passed**, plus whole-tree flake8/black/isort/pyright clean.
- Real-app post-finish tool reproduction: **no file/no write card**; valid tool flow still writes and renders normally.
- Real native strict-SSE tool/image smoke: **Red.**, then **Red**, unchanged prefixes; cache reads2048→2304→2432→2432→2432. First request reused an earlier prefix and is not labelled cold.
- Actual first-frame `/model deepseek` before8928e31/aftera698855: fresh/stale7→2 native rows; valid empty cache→0 catalogue entries; cold fallback before/after PNGs byte-identical. The existing TUI retains its explicit current-session selector row independently of an empty catalogue; it does not restore the other static entries.
- [Per-finding code response](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647481190), [QA response](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647481255), [design acknowledgement](https://github.com/damianvtran/local-operator/pull/1021#issuecomment-5647481330). New SVGs, geometry and sanitized results are in the same [evidence gist](https://gist.github.com/damianvtran/5d0ecd9a45cde6d714176b7dc1cba1a2).

### Automated quality gates

- Whole-tree flake8: PASS.
- Pinned black26.1.0 --check .: PASS (1258 files).
- isort5.13.2 --check .: PASS.
- Whole-tree pyright: PASS (0errors, 0warnings).
- Scoped provider/discovery/naming/HTTP catalogue tests: 191passed.
- Full Python3.12 unit gate: **19,084passed, 88skipped**, all5 hosted shards verified from their actual completion footers in [pre-PR workflow_dispatch run](https://github.com/damianvtran/local-operator/actions/runs/34705194022), pinned to8928e31. Hosted lint/types/audit and Linux/macOS E2E are also green.
- The local full run reached95% without a failure but hit its3600s ceiling under shared-host load; **it is not counted as a pass**.
- Python3.13 shard2 initially had4086passed/1failed on the unchanged snapshot-persistence timing test. Five normal repetitions pass on both immutable base and candidate; a controlled parent-delivery barrier reproduces the same transcript-growth assumption failure on both (base1790→2267bytes, candidate1790→2269bytes, provider=test, no DeepSeek path). The file already documents the quiescence race in `wait_for_settled_delivery`. Only the failed hosted job was rerun and the pre-PR workflow is now **fully green**. The classified first-attempt failure remains disclosed; no unrelated source/test patch or failure waiver. Final-head PR CI is tracked separately above.
- Independent code/QA/design round2: **clean**, exact head a6988551e, all acknowledged. QA's original full E2E result was113passed/7optional-extension skips; remediation QA re-exercised the actual delta paths. Final-head hosted full unit suite, Linux/macOS E2E, coverage, CLI/server sanity, lint, types, dependency audit and version guard are all green.

### Rendered validation

Real OperatorApp with its stylesheet, not a bare widget host; immutable base494ad221 versus candidate8928e31. Before/after model picker plus `/effort` and shift-tab capture. Picker geometry80x6 →80x2 tracks the six incorrect IDs becoming two live IDs. Effort changes from 'not adjustable' to auto/none/low/high/max, high default, shift-tab max. Existing row widths fit without horizontal overflow. Images were rasterized and visually inspected; no CSS/layout change.

[Durable unlisted evidence gist — SVG captures, geometry and sanitized native results](https://gist.github.com/damianvtran/5d0ecd9a45cde6d714176b7dc1cba1a2). SVG files are downloadable; local PNG rasterizations were inspected by the implementing agent and provided to design/QA. No evidence files are committed to the repository.

- [Picker before (SVG)](https://gist.githubusercontent.com/damianvtran/5d0ecd9a45cde6d714176b7dc1cba1a2/raw/82e2ffb6742ca8f3737d8c88d9bd049b55d98221/deepseek-before-picker.svg) · [Picker after (SVG)](https://gist.githubusercontent.com/damianvtran/5d0ecd9a45cde6d714176b7dc1cba1a2/raw/c9c79a5e0dd39312d1147c95f512fb520e12f64f/deepseek-after-picker.svg)
- [Effort before (SVG)](https://gist.githubusercontent.com/damianvtran/5d0ecd9a45cde6d714176b7dc1cba1a2/raw/b3eec050b97ffae6103b0c841791e4ad984fbf76/deepseek-before-effort.svg) · [Effort after (SVG)](https://gist.githubusercontent.com/damianvtran/5d0ecd9a45cde6d714176b7dc1cba1a2/raw/e22965030d3ef67170c3fc9c53c12b2950830ba7/deepseek-after-effort.svg)
- [Shift-tab selects max (SVG)](https://gist.githubusercontent.com/damianvtran/5d0ecd9a45cde6d714176b7dc1cba1a2/raw/5fe43eb387395700839dec476894d8e2a1ed0dde/deepseek-after-effort-cycle.svg)

## Rollout / rollback

Normal combined patch release after fresh code, QA and design rounds and green CI. No provider credentials or live sessions are modified by installation. Rollback is a normal revert of this PR followed by the release owner's standard update; it restores the previous direct provider behavior. Other providers' routing and cache-affinity remain untouched.
