### PR TITLE
fix(session): publish the child roster so the phone can read subagent transcripts

### DIFF
--- a/local_operator/mobile/web/src/agent-view.interaction.test.tsx
+++ b/local_operator/mobile/web/src/agent-view.interaction.test.tsx
@@ -418,8 +418,13 @@ describe("AgentConversation", () => {
 		/* A child the daemon cannot route has no transcript to serve: the route
 		   answers 404 forever. The body must say so and offer a way back to the
 		   parent instead of a Retry that can never succeed (the console error
-		   this replaced). */
+		   this replaced). The way back REPLACES the hierarchy fallback rather
+		   than pushing it, like the header's own "‹" (D2/MINOR-1): a pushed
+		   entry leaves the dead child as the predecessor the phone's Back key
+		   returns to. */
+		const replaceState = vi.spyOn(history, "replaceState");
 		const pushState = vi.spyOn(history, "pushState");
+		history.replaceState({}, "", "#/s/root/a/current");
 		const { detail, projection } = fixture();
 		const settled = {
 			...detail,
@@ -436,10 +441,125 @@ describe("AgentConversation", () => {
 		render(
 			<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={settled} />,
 		);
-		await waitFor(() => expect(screen.getByText("Conversation not available.")).toBeTruthy());
+		await waitFor(() => expect(screen.getByText("No transcript for this agent.")).toBeTruthy());
 		expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
 		fireEvent.click(screen.getByRole("button", { name: "Back to parent" }));
-		expect(pushState).toHaveBeenCalledWith(expect.anything(), "", "#/s/root/a/parent");
+		expect(replaceState).toHaveBeenCalledWith(expect.anything(), "", "#/s/root/a/parent");
+		expect(pushState).not.toHaveBeenCalled();
+	});
+
+	it("renders the terminal 404 notice for a child that carries a launch prompt (D1/Q1)", async () => {
+		/* The shape the phone actually receives for a launched child: the roster
+		   push fills ``prompt``, ``agentConversationEntries`` synthesizes a head
+		   row from it, and the history route 404s. The notice must therefore not
+		   be gated on an empty body — it renders under that row and above the
+		   result tail, with the launch row kept as context. */
+		const { detail, projection } = fixture();
+		const settled = {
+			...detail,
+			status: "completed" as const,
+			result_text: "Found the seam.",
+			transcript: [],
+		};
+		expect(settled.prompt).not.toBe("");
+		const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+		getSubagentHistory.mockReset();
+		getSubagentHistory.mockRejectedValue(
+			new api.HttpError(404, "subagent history unavailable"),
+		);
+		render(
+			<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={settled} />,
+		);
+		await waitFor(() => expect(screen.getByText("No transcript for this agent.")).toBeTruthy());
+		expect(
+			screen.getByText(
+				"Its conversation steps couldn't be read, so only the result and activity below are shown.",
+			),
+		).toBeTruthy();
+		// The launch row is kept, not suppressed to make room for the notice.
+		const launchRow = screen.getAllByText(/One request/)[0];
+		expect(launchRow).toBeTruthy();
+		// Terminal: no Retry that cannot succeed.
+		expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+		// Order matters: launch row, then the notice, then the result tail.
+		const order = Array.from(document.querySelectorAll("*"));
+		expect(order.indexOf(launchRow)).toBeLessThan(
+			order.indexOf(screen.getByText("No transcript for this agent.")),
+		);
+		expect(order.indexOf(screen.getByText("No transcript for this agent."))).toBeLessThan(
+			order.indexOf(screen.getByText(/Result from current-agent/)),
+		);
+	});
+
+	it("keeps the retry card for a prompt-carrying child when the fetch drops (Q2)", async () => {
+		/* The same suppression hit the transient branch: a dropped fetch on a
+		   launched child (rows on screen from the synthesized head) must still
+		   surface the error and recover in place, exactly as the prompt-less
+		   control does. */
+		const { detail, projection } = fixture();
+		const settled = {
+			...detail,
+			status: "completed" as const,
+			result_text: "Found the seam.",
+			transcript: [],
+		};
+		const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+		getSubagentHistory.mockReset();
+		getSubagentHistory
+			.mockRejectedValueOnce(new Error("network down"))
+			.mockResolvedValueOnce({
+				entries: [entry("recovered", "assistant", "Recovered step")],
+				has_more: false,
+			});
+		render(
+			<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={settled} />,
+		);
+		await waitFor(() => expect(screen.getByText("Couldn't load the transcript.")).toBeTruthy());
+		expect(screen.getAllByText(/One request/).length).toBeGreaterThan(0);
+		// The live region carries the words only — never the control (D4).
+		expect(screen.getByRole("alert").querySelector("button")).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		await waitFor(() => expect(screen.getByText("Recovered step")).toBeTruthy());
+		expect(screen.queryByText("Couldn't load the transcript.")).toBeNull();
+	});
+
+	it("keeps the terminal notice's live region off its action (D4)", async () => {
+		/* ``role="alert"`` wrapped the whole card, so the AX tree announced an
+		   unnamed alert containing a button. The region is the text; the action
+		   is its sibling. */
+		const { detail, projection } = fixture();
+		const settled = { ...detail, status: "completed" as const, transcript: [] };
+		const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+		getSubagentHistory.mockReset();
+		getSubagentHistory.mockRejectedValue(
+			new api.HttpError(404, "subagent history unavailable"),
+		);
+		render(
+			<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={settled} />,
+		);
+		await waitFor(() => expect(screen.getByText("No transcript for this agent.")).toBeTruthy());
+		const alert = screen.getByRole("alert");
+		expect(alert.textContent).toContain("No transcript for this agent.");
+		expect(alert.textContent).not.toContain("Back to parent");
+		expect(alert.querySelector("button")).toBeNull();
+		expect(screen.getByRole("button", { name: "Back to parent" })).toBeTruthy();
+	});
+
+	it("shows the loading affordance under the launch row while the tail is in flight", async () => {
+		/* Same guard, third state: a prompt-carrying child whose first fetch has
+		   not landed renders its synthesized launch row AND the loading
+		   affordance — not a launch row alone that reads like a complete
+		   conversation (U2). */
+		const { detail, projection } = fixture();
+		const empty = { ...detail, transcript: [] };
+		const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+		getSubagentHistory.mockReset();
+		getSubagentHistory.mockReturnValueOnce(new Promise(() => undefined));
+		render(
+			<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={empty} />,
+		);
+		expect(screen.getAllByText(/One request/).length).toBeGreaterThan(0);
+		expect(screen.getByText("Loading agent activity…")).toBeTruthy();
 	});
 
 	it("re-pulls a settled child's transcript when the link reconnects (U1)", async () => {

--- a/local_operator/mobile/web/src/agent-view.interaction.test.tsx
+++ b/local_operator/mobile/web/src/agent-view.interaction.test.tsx
@@ -699,6 +699,100 @@ describe("AgentConversation", () => {
 		}
 	});
 
+	it("keeps a running child's dropped polls quiet once a prompt-carrying tail has landed", async () => {
+		/* The same rule as the test above, in the shape the daemon actually
+		   sends: ``prompt`` set (so ``agentConversationEntries`` synthesizes a
+		   ``parent_message`` head) AND running AND polling. That head is a label
+		   for the child, not a landed transcript row — the gate has to read what
+		   the FETCH returned, or this shape would be silent about a drop it must
+		   not report; a landed row still suppresses the card, and the poll still
+		   recovers without the user asking. */
+		vi.useFakeTimers();
+		try {
+			const { detail, projection } = fixture();
+			// ``launch_message_id`` kept: the roster row for a launched child
+			// carries both fields, and the entry it names is not in the wire tail.
+			const running = { ...detail, status: "running" as const, transcript: [] };
+			expect(running.prompt).not.toBe("");
+			const live = entry("live", "assistant", "Live step one");
+			const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+			getSubagentHistory.mockReset();
+			// A mode rather than a call counter: the number of ticks a virtual
+			// interval produces is an implementation detail of the timer, and the
+			// property under test is "every tick since the landing one failed".
+			let mode: "live" | "broken" | "recovered" = "live";
+			getSubagentHistory.mockImplementation(async () => {
+				if (mode === "broken") throw new Error("poll dropped");
+				return {
+					entries: mode === "live" ? [live] : [live, entry("tail", "assistant", "Live step two")],
+					has_more: false,
+				};
+			});
+			render(
+				<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={running} />,
+			);
+			await vi.waitFor(() => expect(screen.getByText("Live step one")).toBeTruthy());
+			// Every tick from here fails: the landed row stays and no card is painted.
+			mode = "broken";
+			await vi.advanceTimersByTimeAsync(3200);
+			expect(getSubagentHistory.mock.calls.length).toBeGreaterThanOrEqual(3);
+			expect(screen.getByText("Live step one")).toBeTruthy();
+			expect(screen.getAllByText(/One request/).length).toBeGreaterThan(0);
+			expect(screen.queryByText("Couldn't load the transcript.")).toBeNull();
+			expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+			mode = "recovered";
+			await vi.advanceTimersByTimeAsync(1600);
+			await vi.waitFor(() => expect(screen.getByText("Live step two")).toBeTruthy());
+			expect(screen.queryByText("Couldn't load the transcript.")).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("tells the user when a running child's launch-prompted tail never lands (MAJOR-1)", async () => {
+		/* The production shape for a launched child — ``prompt`` set, running,
+		   and the history route failing on EVERY poll — with nothing landed. The
+		   synthesized head row is a label, not content: gating the exemption on
+		   the painted list let it stand in for the transcript, so this child
+		   painted its launch row and a live "running" header with no error, no
+		   Retry and no loading affordance for as long as it ran. The card is the
+		   only signal anything failed, and it is honest here because nothing is
+		   in flight; a later tick that lands content clears it in place. */
+		vi.useFakeTimers();
+		try {
+			const { detail, projection } = fixture();
+			const running = { ...detail, status: "running" as const, transcript: [] };
+			expect(running.prompt).not.toBe("");
+			const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+			getSubagentHistory.mockReset();
+			// Released on demand: the assertion is that the route fails on every
+			// poll for a while and then recovers, not that it fails N times.
+			let released = false;
+			getSubagentHistory.mockImplementation(async () => {
+				if (!released) throw new Error("history route dropped");
+				return { entries: [entry("landed", "assistant", "Landed at last")], has_more: false };
+			});
+			render(
+				<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={running} />,
+			);
+			await vi.waitFor(() => expect(getSubagentHistory).toHaveBeenCalledTimes(1));
+			// ~6 s of polls, every one of them failing: the launch row is there,
+			// the body is not silent about it.
+			await vi.advanceTimersByTimeAsync(6800);
+			expect(getSubagentHistory.mock.calls.length).toBeGreaterThanOrEqual(4);
+			expect(screen.getAllByText(/One request/).length).toBeGreaterThan(0);
+			expect(screen.getByText("Couldn't load the transcript.")).toBeTruthy();
+			expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+			// The next tick lands rows; the card clears without the user asking.
+			released = true;
+			await vi.advanceTimersByTimeAsync(1600);
+			await vi.waitFor(() => expect(screen.getByText("Landed at last")).toBeTruthy());
+			expect(screen.queryByText("Couldn't load the transcript.")).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("keeps the retry card when a settled child's later fetch fails (U1)", async () => {
 		/* The mirror of the rule above, and the reason it keys on ``running``
 		   rather than on rows alone: a settled child has NO poll, so nothing

--- a/local_operator/mobile/web/src/agent-view.interaction.test.tsx
+++ b/local_operator/mobile/web/src/agent-view.interaction.test.tsx
@@ -7,7 +7,12 @@ import * as api from "./api";
 import * as store from "./store";
 import type { SessionProjection, SubagentDetail, SubagentRow, TranscriptEntry } from "./types";
 
-vi.mock("./api", () => ({
+/* Spreads the ACTUAL api module so class exports keep their identity: the
+   screen distinguishes a terminal 404 by `instanceof HttpError`, which a
+   partial factory would replace with `undefined`. Network functions are
+   still stubbed per test. */
+vi.mock("./api", async (importOriginal) => ({
+	...(await importOriginal<typeof api>()),
 	getHistory: vi.fn(async () => ({ entries: [], has_more: false })),
 	getSubagentHistory: vi.fn(async () => ({ entries: [], has_more: false })),
 	getSubagentDetail: vi.fn(),
@@ -407,6 +412,34 @@ describe("AgentConversation", () => {
 		fireEvent.click(retry);
 		await waitFor(() => expect(screen.getByText("Recovered step")).toBeTruthy());
 		expect(screen.queryByText("Couldn't load the transcript.")).toBeNull();
+	});
+
+	it("treats a 404 child history as terminal, not a retry loop", async () => {
+		/* A child the daemon cannot route has no transcript to serve: the route
+		   answers 404 forever. The body must say so and offer a way back to the
+		   parent instead of a Retry that can never succeed (the console error
+		   this replaced). */
+		const pushState = vi.spyOn(history, "pushState");
+		const { detail, projection } = fixture();
+		const settled = {
+			...detail,
+			status: "completed" as const,
+			transcript: [],
+			prompt: "",
+			launch_message_id: "",
+		};
+		const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+		getSubagentHistory.mockReset();
+		getSubagentHistory.mockRejectedValue(
+			new api.HttpError(404, "subagent history unavailable"),
+		);
+		render(
+			<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={settled} />,
+		);
+		await waitFor(() => expect(screen.getByText("Conversation not available.")).toBeTruthy());
+		expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: "Back to parent" }));
+		expect(pushState).toHaveBeenCalledWith(expect.anything(), "", "#/s/root/a/parent");
 	});
 
 	it("re-pulls a settled child's transcript when the link reconnects (U1)", async () => {

--- a/local_operator/mobile/web/src/agent-view.interaction.test.tsx
+++ b/local_operator/mobile/web/src/agent-view.interaction.test.tsx
@@ -650,6 +650,133 @@ describe("AgentConversation", () => {
 		expect(screen.getByText(/reviewer · high/)).toBeTruthy();
 	});
 
+	it("keeps a running child's dropped poll quiet while its rows are on screen", async () => {
+		/* A running child polls every 1.5 s, so its own poll is the recovery path
+		   for a dropped tick (see the catch block): the transient card must not
+		   paint over rows that are still live — on the flaky link this surface
+		   exists for it would flash an error once per drop over a transcript the
+		   user can read — and the next successful tick restores the tail. The row
+		   has to LAND first, so the first fetch succeeds and the failure is the
+		   tick after it. */
+		vi.useFakeTimers();
+		try {
+			const { detail, projection } = fixture();
+			const running = {
+				...detail,
+				status: "running" as const,
+				transcript: [],
+				prompt: "",
+				launch_message_id: "",
+			};
+			const live = entry("live", "assistant", "Live step one");
+			const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+			getSubagentHistory.mockReset();
+			getSubagentHistory
+				.mockResolvedValueOnce({ entries: [live], has_more: false })
+				.mockRejectedValueOnce(new Error("poll dropped"))
+				.mockResolvedValueOnce({
+					entries: [live, entry("tail", "assistant", "Live step two")],
+					has_more: false,
+				});
+			render(
+				<AgentConversation sessionId="root" jobId="current" projection={projection} connected detail={running} />,
+			);
+			await vi.waitFor(() => expect(screen.getByText("Live step one")).toBeTruthy());
+			// One dropped poll tick: the fetch really ran and really failed...
+			await vi.advanceTimersByTimeAsync(1600);
+			expect(getSubagentHistory).toHaveBeenCalledTimes(2);
+			await vi.advanceTimersByTimeAsync(10);
+			// ...the rows are still there, and the drop is not announced over them.
+			expect(screen.getByText("Live step one")).toBeTruthy();
+			expect(screen.queryByText("Couldn't load the transcript.")).toBeNull();
+			expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+			// The next tick lands the tail with no card in between, no retry needed.
+			await vi.advanceTimersByTimeAsync(1600);
+			await vi.waitFor(() => expect(screen.getByText("Live step two")).toBeTruthy());
+			expect(screen.queryByText("Couldn't load the transcript.")).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps the retry card when a settled child's later fetch fails (U1)", async () => {
+		/* The mirror of the rule above, and the reason it keys on ``running``
+		   rather than on rows alone: a settled child has NO poll, so nothing
+		   recovers a dropped fetch — not even when rows from an earlier fetch are
+		   still on screen, where a rows-only gate would lose the transcript
+		   silently. Here the first fetch lands, the link drops, the effect re-runs
+		   (``connected`` is a dependency) and fails: the card must be back under
+		   the row that is still there. */
+		const { detail, projection } = fixture();
+		const settled = {
+			...detail,
+			status: "completed" as const,
+			transcript: [],
+			prompt: "",
+			launch_message_id: "",
+		};
+		const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+		getSubagentHistory.mockReset();
+		getSubagentHistory
+			.mockResolvedValueOnce({
+				entries: [entry("landed", "assistant", "Landed step")],
+				has_more: false,
+			})
+			.mockRejectedValueOnce(new Error("link dropped"));
+		const view = (connected: boolean) => (
+			<AgentConversation sessionId="root" jobId="current" projection={projection} connected={connected} detail={settled} />
+		);
+		const { rerender } = render(view(true));
+		await waitFor(() => expect(screen.getByText("Landed step")).toBeTruthy());
+		rerender(view(false));
+		await waitFor(() => expect(screen.getByText("Couldn't load the transcript.")).toBeTruthy());
+		expect(screen.getByText("Landed step")).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+	});
+
+	it("gives both notice cards the app's 8 px title/body pair gap (D6)", async () => {
+		/* The D4 wrapper took the pair spacing over from the card's own
+		   ``flex … gap-2``, so the title and body sat flush at 0 px where the
+		   app's equivalent pair (``AgentUnavailable`` → ``InlineState``) is 8 px.
+		   Layout is not measurable in happy-dom, so this pins the utility the
+		   designer specified rather than the rendered geometry; the two branches
+		   are one component and must not drift apart on it. */
+		const { detail, projection } = fixture();
+		const getSubagentHistory = vi.mocked(api.getSubagentHistory);
+		getSubagentHistory.mockReset();
+		getSubagentHistory.mockRejectedValue(
+			new api.HttpError(404, "subagent history unavailable"),
+		);
+		const { unmount } = render(
+			<AgentConversation
+				sessionId="root"
+				jobId="current"
+				projection={projection}
+				connected
+				detail={{ ...detail, status: "completed" as const, transcript: [] }}
+			/>,
+		);
+		await waitFor(() => expect(screen.getByText("No transcript for this agent.")).toBeTruthy());
+		const terminal = screen.getByRole("alert");
+		expect(terminal.classList.contains("gap-2")).toBe(true);
+		expect(terminal.className).toContain("flex-col");
+		unmount();
+		// The transient branch takes the same class: same title/body pair rhythm.
+		getSubagentHistory.mockReset();
+		getSubagentHistory.mockRejectedValue(new Error("transient drop"));
+		render(
+			<AgentConversation
+				sessionId="root"
+				jobId="current"
+				projection={projection}
+				connected
+				detail={{ ...detail, status: "completed" as const, transcript: [], prompt: "" }}
+			/>,
+		);
+		await waitFor(() => expect(screen.getByText("Couldn't load the transcript.")).toBeTruthy());
+		expect(screen.getByRole("alert").classList.contains("gap-2")).toBe(true);
+	});
+
 	it("keeps a running child's sheet live by polling its transcript", async () => {
 		/* status===running means the sheet must re-pull the transcript on an
 		   interval so an open sheet stays real-time; a settled child fetches once. */

--- a/local_operator/mobile/web/src/screens/agent-view.tsx
+++ b/local_operator/mobile/web/src/screens/agent-view.tsx
@@ -467,7 +467,8 @@ interface LazyTranscript {
 	 * body paints depends on whether a poll can recover it — a SETTLED child
 	 * has no poll, so its single dropped fetch must surface an error + retry
 	 * rather than a silent blank (U1), while a running child's drop stays quiet
-	 * over the rows already on screen (see ``transientCard``). Mutually
+	 * over the rows its earlier fetches LANDED (see ``transientCard`` — the
+	 * synthesized launch head does not count as a landed row). Mutually
 	 * exclusive with ``unavailable``, so the newest fetch decides. */
 	failed: boolean;
 	/** The route answered 404: this child has no readable transcript (the daemon
@@ -723,17 +724,32 @@ export function AgentConversation({
 	// shape (D1/Q1, Q2), so ``emptyContent`` is now only for a body with nothing
 	// in it at all and the rows get the state underneath them.
 	const hasRows = entries.length > 0;
-	// A dropped poll on a RUNNING child whose rows are already on screen must NOT
-	// paint the transient card: that child's own 1.5 s poll is its recovery path
-	// (see the hook's catch block), so the drop self-heals on the next tick while
-	// the card would contradict rows that are still live — and on a flaky link
-	// flash an error once per drop over a transcript the user can read. It stays
-	// quiet until a tick lands. Two shapes keep the card, and neither has a poll
-	// to recover it: a SETTLED child's single fetch (U1), and a running child with
-	// nothing on screen yet, where the card is the only signal anything failed.
+	// ``transcript`` — the entries the FETCH landed — and never ``entries``, the
+	// painted list. ``entries`` carries synthesized rows: ``agentConversationEntries``
+	// prepends a ``prompt:<job_id>`` head whenever ``detail.prompt`` is non-empty,
+	// and the daemon sends that prompt for every launched child
+	// (``mobile/daemon.py:623``, ``run_subagent`` → ``record_launch``). So for the
+	// production shape — running, launched, transcript never fetched — the painted
+	// list is non-empty with ZERO transcript rows on screen, and gating on it
+	// swallowed the error surface for exactly the child this screen exists for: a
+	// persistent non-404 failure (5xx, unparseable body, a throw in the fetch path)
+	// painted the launch row and the running header and nothing else, for as long as
+	// the child ran, while the comment below promised the opposite (MAJOR-1).
+	// The trap is the head row: it is a durable label for the child, not evidence
+	// that content arrived.
+	const landedRows = transcript.length > 0;
+	// A dropped poll on a RUNNING child whose rows have already been FETCHED must
+	// NOT paint the transient card: that child's own 1.5 s poll is its recovery
+	// path (see the hook's catch block), so the drop self-heals on the next tick
+	// while the card would contradict rows that are still live — and on a flaky
+	// link flash an error once per drop over a transcript the user can read. It
+	// stays quiet until a tick lands. Two shapes keep the card: a SETTLED child's
+	// single fetch (U1), and a child with no landed rows, running or not — while
+	// its poll is live the card is the only signal anything failed, and if the poll
+	// never lands the body must not stay silent forever.
 	// The terminal 404 card is deliberately not gated: a 404 is a verdict about
 	// the child, not a transient fact about the link (D3).
-	const transientCard = failed && !(running && hasRows);
+	const transientCard = failed && !(running && landedRows);
 	const fetchState = unavailable ? (
 		<TranscriptFetchError
 			connected={connected}

--- a/local_operator/mobile/web/src/screens/agent-view.tsx
+++ b/local_operator/mobile/web/src/screens/agent-view.tsx
@@ -9,6 +9,7 @@ import {
 import { Markdown } from "../components/markdown";
 import { TodosPanel } from "../components/todos-panel";
 import { Transcript } from "../components/transcript";
+import { Button } from "../components/ui/button";
 import { WorkingLine } from "../components/working-line";
 import { DetailRequestCoordinator } from "../detail-loader";
 import { cn } from "../lib/cn";
@@ -461,12 +462,14 @@ interface LazyTranscript {
 	/** A fetch is in flight and nothing has landed yet: the body shows its
 	 * loading affordance instead of a blank window (U2). */
 	loading: boolean;
-	/** The (single, for a settled child) fetch failed and no entries are shown:
-	 * the body must surface an error + retry rather than a silent blank (U1). */
+	/** The (single, for a settled child) fetch failed: the body must surface an
+	 * error + retry under whatever rows exist, rather than a silent blank (U1).
+	 * Mutually exclusive with ``unavailable``, so the newest fetch decides. */
 	failed: boolean;
 	/** The route answered 404: this child has no readable transcript (the daemon
 	 * could not resolve its session dir). Terminal, not a link drop — a retry
-	 * can never succeed, so the body must say so instead of offering one. */
+	 * can never succeed, so the body must say so instead of offering one.
+	 * Mutually exclusive with ``failed`` (see the catch branch). */
 	unavailable: boolean;
 	/** Imperative re-pull for the retry affordance. */
 	retry: () => void;
@@ -545,7 +548,13 @@ function useLazySubagentTranscript(
 					setFailed(false);
 					return;
 				}
+				/* The two flags are mutually exclusive so neither sticks: a transient
+				   drop is a fact about this link, not about the child, and the LAST
+				   fetch is what the body must describe (NIT-1). Without this clear a
+				   child that 404'd once kept the terminal card — and lost its Retry —
+				   even after the route started answering again. */
 				setFailed(true);
+				setUnavailable(false);
 			}
 		};
 		void pull();
@@ -566,6 +575,7 @@ function useLazySubagentTranscript(
 	const retry = () => {
 		setLoading(true);
 		setFailed(false);
+		setUnavailable(false);
 		setAttempt((n) => n + 1);
 	};
 	if (inlined) {
@@ -574,12 +584,12 @@ function useLazySubagentTranscript(
 	return { entries: fetched, loading, failed, unavailable, retry };
 }
 
-/** The body shown when a settled child's single transcript fetch failed and no
- * entries are on screen (U1). Without this the body was a permanent blank on a
- * transient link drop, with no signal anything failed and no way to recover
- * short of navigating away — the exact flaky-link case this surface targets.
- * The Outcome/todos tail still renders below via ``tailContent``; this only
- * fills the empty transcript window with a reason and an in-place retry.
+/** The body shown when the child's own transcript is not on screen, whether
+ * that is a fetch in flight, a dropped fetch, or a terminal 404 (U1/U2).
+ * Without this the body was a permanent blank on a transient link drop, with no
+ * signal anything failed and no way to recover short of navigating away — the
+ * exact flaky-link case this surface targets. The Outcome/todos tail still
+ * renders below it, because that tail is detail, not transcript.
  *
  * ``unavailable`` is the terminal sibling: a 404 means there is nothing to
  * fetch, so the same card must not offer a Retry that cannot succeed — it says
@@ -598,36 +608,38 @@ function TranscriptFetchError({
 }) {
 	if (unavailable) {
 		return (
-			<div role="alert" className="flex flex-col items-start gap-2 py-4">
-				<p className="text-body-sm font-medium text-ink">Conversation not available.</p>
-				<p className="text-meta text-ink-dim">
-					This agent has no saved transcript to show.
-				</p>
-				<button
-					type="button"
-					onClick={() => navigate(parentPath)}
-					className="min-h-11 rounded-sm border border-control px-3 text-body-sm active:bg-elevated"
-				>
-					Back to parent
-				</button>
+			<div className="flex flex-col items-start gap-2 py-4">
+				{/* The live region is the TEXT, not the card: wrapping the card put
+				   the button inside an alert with an empty accessible name (D4),
+				   which announces a control as part of the message. The same shape
+				   ``AgentUnavailable`` uses. */}
+				<div role="alert">
+					<p className="text-body-sm font-medium text-ink">No transcript for this agent.</p>
+					<p className="text-meta text-ink-dim">
+						Its conversation steps couldn't be read, so only the result and activity below
+						are shown.
+					</p>
+				</div>
+				{/* ``navigateUp``, not ``navigate``: the identically-labelled control in
+				   the header replaces the hierarchy fallback rather than pushing it
+				   (router.ts documents the rule), so on a deep-linked child the dead
+				   child must not stay as the predecessor the phone's Back key returns
+				   to (D2). */}
+				<Button onClick={() => navigateUp(parentPath)}>Back to parent</Button>
 			</div>
 		);
 	}
 	return (
-		<div role="alert" className="flex flex-col items-start gap-2 py-4">
-			<p className="text-body-sm font-medium text-ink">Couldn't load the transcript.</p>
-			<p className="text-meta text-ink-dim">
-				{connected
-					? "The conversation steps didn't load. Retry to pull them again."
-					: "You're offline. Reconnecting will retry automatically."}
-			</p>
-			<button
-				type="button"
-				onClick={onRetry}
-				className="min-h-11 rounded-sm border border-control px-3 text-body-sm active:bg-elevated"
-			>
-				Retry
-			</button>
+		<div className="flex flex-col items-start gap-2 py-4">
+			<div role="alert">
+				<p className="text-body-sm font-medium text-ink">Couldn't load the transcript.</p>
+				<p className="text-meta text-ink-dim">
+					{connected
+						? "The conversation steps didn't load. Retry to pull them again."
+						: "You're offline. Reconnecting will retry automatically."}
+				</p>
+			</div>
+			<Button onClick={onRetry}>Retry</Button>
 		</div>
 	);
 }
@@ -669,12 +681,22 @@ export function AgentConversation({
 		[detail, transcript],
 	);
 	const entries = useMemo(() => agentConversationEntries(detailForRender), [detailForRender]);
-	// The transcript body owns three off-happy-path states when the wire carries
-	// no entries: a fetch in flight (loading affordance, not a blank window —
-	// U2), a settled child whose one fetch failed (visible error + retry so it is
-	// recoverable in place, never a silent blank — U1), or genuinely empty. The
-	// header/outcome above stay put; only the BODY reflects these.
-	const emptyBody = unavailable ? (
+	// The transcript body owns three off-happy-path states when the child's own
+	// transcript is not on screen: a fetch in flight (loading affordance, not a
+	// blank window — U2), a settled child whose one fetch failed (visible error +
+	// retry so it is recoverable in place, never a silent blank — U1), or
+	// genuinely empty. The header/outcome above stay put; only the BODY reflects
+	// these.
+	//
+	// Keyed on the FETCH, never on whether rows are on screen. The parent's
+	// launch prompt is synthesized into a ``parent_message`` head row by
+	// ``agentConversationEntries``, so a launched child — i.e. nearly every child
+	// this screen exists for — renders a row even while its transcript is
+	// unreadable or still in flight. Deriving these states from an empty body
+	// made the terminal card and the Retry card unreachable for exactly that
+	// shape (D1/Q1, Q2), so ``emptyContent`` is now only for a body with nothing
+	// in it at all and the rows get the state underneath them.
+	const fetchState = unavailable ? (
 		<TranscriptFetchError
 			connected={connected}
 			unavailable
@@ -693,6 +715,7 @@ export function AgentConversation({
 			<TranscriptLoading connected={connected} />
 		</div>
 	) : null;
+	const hasRows = entries.length > 0;
 	return (
 		<>
 			<AgentHeader
@@ -710,8 +733,16 @@ export function AgentConversation({
 				pid={sessionId}
 				jobId={jobId}
 				entries={entries}
-				tailContent={<ConversationTail detail={detail} sessionId={sessionId} projection={projection} />}
-				emptyContent={emptyBody}
+				tailContent={
+					<>
+						{/* The notice belongs to the rows it explains, so it sits after them
+						   and above the result/activity tail (D1); the launch row stays as
+						   context rather than being suppressed to make room for it. */}
+						{hasRows ? fetchState : null}
+						<ConversationTail detail={detail} sessionId={sessionId} projection={projection} />
+					</>
+				}
+				emptyContent={hasRows ? null : fetchState}
 			/>
 			{detail.status === "running" ? (
 				<footer className="flex min-h-11 items-center justify-between border-t border-hairline bg-surface px-3 pb-[max(env(safe-area-inset-bottom),0.25rem)] text-meta">

--- a/local_operator/mobile/web/src/screens/agent-view.tsx
+++ b/local_operator/mobile/web/src/screens/agent-view.tsx
@@ -462,9 +462,13 @@ interface LazyTranscript {
 	/** A fetch is in flight and nothing has landed yet: the body shows its
 	 * loading affordance instead of a blank window (U2). */
 	loading: boolean;
-	/** The (single, for a settled child) fetch failed: the body must surface an
-	 * error + retry under whatever rows exist, rather than a silent blank (U1).
-	 * Mutually exclusive with ``unavailable``, so the newest fetch decides. */
+	/** The newest fetch failed for a reason a retry could clear. Recorded for
+	 * both kinds of child because it is a fact about the LAST fetch; what the
+	 * body paints depends on whether a poll can recover it — a SETTLED child
+	 * has no poll, so its single dropped fetch must surface an error + retry
+	 * rather than a silent blank (U1), while a running child's drop stays quiet
+	 * over the rows already on screen (see ``transientCard``). Mutually
+	 * exclusive with ``unavailable``, so the newest fetch decides. */
 	failed: boolean;
 	/** The route answered 404: this child has no readable transcript (the daemon
 	 * could not resolve its session dir). Terminal, not a link drop — a retry
@@ -473,6 +477,11 @@ interface LazyTranscript {
 	unavailable: boolean;
 	/** Imperative re-pull for the retry affordance. */
 	retry: () => void;
+	/** Whether the addressed child is still running, i.e. whether the 1.5 s poll
+	 * will pull again. Exposed rather than re-derived by the caller so the
+	 * body's recovery rule and the poll itself cannot disagree about which
+	 * children own a poll: they read the same value the interval is built from. */
+	running: boolean;
 }
 
 function useLazySubagentTranscript(
@@ -533,9 +542,12 @@ function useLazySubagentTranscript(
 			} catch (err) {
 				/* An aborted request is a teardown/replacement, not a failure:
 				   the successor pull owns the state. A real drop for a RUNNING
-				   child self-heals on the next poll tick, so it only reflects as
-				   loading; for a SETTLED child there is no poll, so the single
-				   dropped fetch is terminal and must surface a retry (U1). */
+				   child self-heals on the next poll tick, so it is recorded here
+				   but must not be painted over that child's live rows; for a
+				   SETTLED child there is no poll, so the single dropped fetch is
+				   terminal and must surface a retry (U1). The flag describes the
+				   LAST fetch for both; ``transientCard`` owns the rendering side
+				   of that distinction. */
 				if (!alive || (err instanceof DOMException && err.name === "AbortError")) return;
 				setLoading(false);
 				/* A 404 is the daemon saying this child has no transcript to serve
@@ -579,9 +591,16 @@ function useLazySubagentTranscript(
 		setAttempt((n) => n + 1);
 	};
 	if (inlined) {
-		return { entries: detail.transcript, loading: false, failed: false, unavailable: false, retry };
+		return {
+			entries: detail.transcript,
+			loading: false,
+			failed: false,
+			unavailable: false,
+			running,
+			retry,
+		};
 	}
-	return { entries: fetched, loading, failed, unavailable, retry };
+	return { entries: fetched, loading, failed, unavailable, running, retry };
 }
 
 /** The body shown when the child's own transcript is not on screen, whether
@@ -612,8 +631,11 @@ function TranscriptFetchError({
 				{/* The live region is the TEXT, not the card: wrapping the card put
 				   the button inside an alert with an empty accessible name (D4),
 				   which announces a control as part of the message. The same shape
-				   ``AgentUnavailable`` uses. */}
-				<div role="alert">
+				   ``AgentUnavailable`` uses. ``gap-2`` because the wrapper took the
+				   pair spacing over from the card's own ``flex … gap-2``: without it
+				   title and body sit flush at 0 px where this app's equivalent pair
+				   (``AgentUnavailable`` → ``InlineState``) is 8 px (D6). */}
+				<div role="alert" className="flex flex-col gap-2">
 					<p className="text-body-sm font-medium text-ink">No transcript for this agent.</p>
 					<p className="text-meta text-ink-dim">
 						Its conversation steps couldn't be read, so only the result and activity below
@@ -631,7 +653,10 @@ function TranscriptFetchError({
 	}
 	return (
 		<div className="flex flex-col items-start gap-2 py-4">
-			<div role="alert">
+			{/* Same live-region shape and pair gap as the terminal branch above (D4,
+			   D6) — the two cards are one component so a design pass edits one place,
+			   and both must read with the same title/body rhythm. */}
+			<div role="alert" className="flex flex-col gap-2">
 				<p className="text-body-sm font-medium text-ink">Couldn't load the transcript.</p>
 				<p className="text-meta text-ink-dim">
 					{connected
@@ -667,7 +692,8 @@ export function AgentConversation({
 	const parentPath = detail.parent_job_id
 		? agentPath(sessionId, detail.parent_job_id)
 		: rootPath;
-	const { entries: transcript, loading, failed, unavailable, retry } = useLazySubagentTranscript(
+	const { entries: transcript, loading, failed, unavailable, running, retry } =
+		useLazySubagentTranscript(
 		sessionId,
 		jobId,
 		detail,
@@ -683,7 +709,7 @@ export function AgentConversation({
 	const entries = useMemo(() => agentConversationEntries(detailForRender), [detailForRender]);
 	// The transcript body owns three off-happy-path states when the child's own
 	// transcript is not on screen: a fetch in flight (loading affordance, not a
-	// blank window — U2), a settled child whose one fetch failed (visible error +
+	// blank window — U2), a child whose newest fetch failed (visible error +
 	// retry so it is recoverable in place, never a silent blank — U1), or
 	// genuinely empty. The header/outcome above stay put; only the BODY reflects
 	// these.
@@ -696,6 +722,18 @@ export function AgentConversation({
 	// made the terminal card and the Retry card unreachable for exactly that
 	// shape (D1/Q1, Q2), so ``emptyContent`` is now only for a body with nothing
 	// in it at all and the rows get the state underneath them.
+	const hasRows = entries.length > 0;
+	// A dropped poll on a RUNNING child whose rows are already on screen must NOT
+	// paint the transient card: that child's own 1.5 s poll is its recovery path
+	// (see the hook's catch block), so the drop self-heals on the next tick while
+	// the card would contradict rows that are still live — and on a flaky link
+	// flash an error once per drop over a transcript the user can read. It stays
+	// quiet until a tick lands. Two shapes keep the card, and neither has a poll
+	// to recover it: a SETTLED child's single fetch (U1), and a running child with
+	// nothing on screen yet, where the card is the only signal anything failed.
+	// The terminal 404 card is deliberately not gated: a 404 is a verdict about
+	// the child, not a transient fact about the link (D3).
+	const transientCard = failed && !(running && hasRows);
 	const fetchState = unavailable ? (
 		<TranscriptFetchError
 			connected={connected}
@@ -703,7 +741,7 @@ export function AgentConversation({
 			parentPath={parentPath}
 			onRetry={retry}
 		/>
-	) : failed ? (
+	) : transientCard ? (
 		<TranscriptFetchError
 			connected={connected}
 			unavailable={false}
@@ -715,7 +753,6 @@ export function AgentConversation({
 			<TranscriptLoading connected={connected} />
 		</div>
 	) : null;
-	const hasRows = entries.length > 0;
 	return (
 		<>
 			<AgentHeader

--- a/local_operator/mobile/web/src/screens/agent-view.tsx
+++ b/local_operator/mobile/web/src/screens/agent-view.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react";
-import { getSubagentDetail, getSubagentHistory } from "../api";
+import { HttpError, getSubagentDetail, getSubagentHistory } from "../api";
 import { AgentsSheet } from "../components/agents-sheet";
 import {
 	AGENT_GLYPH,
@@ -464,6 +464,10 @@ interface LazyTranscript {
 	/** The (single, for a settled child) fetch failed and no entries are shown:
 	 * the body must surface an error + retry rather than a silent blank (U1). */
 	failed: boolean;
+	/** The route answered 404: this child has no readable transcript (the daemon
+	 * could not resolve its session dir). Terminal, not a link drop — a retry
+	 * can never succeed, so the body must say so instead of offering one. */
+	unavailable: boolean;
 	/** Imperative re-pull for the retry affordance. */
 	retry: () => void;
 }
@@ -481,6 +485,9 @@ function useLazySubagentTranscript(
 	const [fetched, setFetched] = useState<TranscriptEntry[]>([]);
 	const [loading, setLoading] = useState(!inlined);
 	const [failed, setFailed] = useState(false);
+	// Terminal 404 (see ``LazyTranscript.unavailable``). Held apart from
+	// ``failed`` so the transient branch keeps its retry affordance.
+	const [unavailable, setUnavailable] = useState(false);
 	// A monotonic nonce the retry button bumps to force the fetch effect to
 	// re-run even when nothing else in its dep list changed (a settled child on
 	// the same connection). Mirrors the detail loader's explicit retry signal.
@@ -492,6 +499,7 @@ function useLazySubagentTranscript(
 		setFetched([]);
 		setLoading(true);
 		setFailed(false);
+		setUnavailable(false);
 	}, [sessionId, jobId]);
 	useEffect(() => {
 		if (inlined) return;
@@ -517,6 +525,7 @@ function useLazySubagentTranscript(
 					setFetched((prev) => (sameTail(prev, entries) ? prev : entries));
 					setLoading(false);
 					setFailed(false);
+					setUnavailable(false);
 				}
 			} catch (err) {
 				/* An aborted request is a teardown/replacement, not a failure:
@@ -526,6 +535,16 @@ function useLazySubagentTranscript(
 				   dropped fetch is terminal and must surface a retry (U1). */
 				if (!alive || (err instanceof DOMException && err.name === "AbortError")) return;
 				setLoading(false);
+				/* A 404 is the daemon saying this child has no transcript to serve
+				   (its route resolved no session dir). No amount of retrying changes
+				   that answer, so the body must not offer one; only the transient
+				   branch keeps its retry. A running child's poll still ticks, so a
+				   route that later becomes readable clears this again. */
+				if (err instanceof HttpError && err.status === 404) {
+					setUnavailable(true);
+					setFailed(false);
+					return;
+				}
 				setFailed(true);
 			}
 		};
@@ -550,9 +569,9 @@ function useLazySubagentTranscript(
 		setAttempt((n) => n + 1);
 	};
 	if (inlined) {
-		return { entries: detail.transcript, loading: false, failed: false, retry };
+		return { entries: detail.transcript, loading: false, failed: false, unavailable: false, retry };
 	}
-	return { entries: fetched, loading, failed, retry };
+	return { entries: fetched, loading, failed, unavailable, retry };
 }
 
 /** The body shown when a settled child's single transcript fetch failed and no
@@ -560,14 +579,40 @@ function useLazySubagentTranscript(
  * transient link drop, with no signal anything failed and no way to recover
  * short of navigating away — the exact flaky-link case this surface targets.
  * The Outcome/todos tail still renders below via ``tailContent``; this only
- * fills the empty transcript window with a reason and an in-place retry. */
+ * fills the empty transcript window with a reason and an in-place retry.
+ *
+ * ``unavailable`` is the terminal sibling: a 404 means there is nothing to
+ * fetch, so the same card must not offer a Retry that cannot succeed — it says
+ * so and points back at the parent instead. All user-facing copy for both
+ * branches lives here, so a design pass edits one place. */
 function TranscriptFetchError({
 	connected,
+	unavailable,
+	parentPath,
 	onRetry,
 }: {
 	connected: boolean;
+	unavailable: boolean;
+	parentPath: string;
 	onRetry: () => void;
 }) {
+	if (unavailable) {
+		return (
+			<div role="alert" className="flex flex-col items-start gap-2 py-4">
+				<p className="text-body-sm font-medium text-ink">Conversation not available.</p>
+				<p className="text-meta text-ink-dim">
+					This agent has no saved transcript to show.
+				</p>
+				<button
+					type="button"
+					onClick={() => navigate(parentPath)}
+					className="min-h-11 rounded-sm border border-control px-3 text-body-sm active:bg-elevated"
+				>
+					Back to parent
+				</button>
+			</div>
+		);
+	}
 	return (
 		<div role="alert" className="flex flex-col items-start gap-2 py-4">
 			<p className="text-body-sm font-medium text-ink">Couldn't load the transcript.</p>
@@ -610,7 +655,7 @@ export function AgentConversation({
 	const parentPath = detail.parent_job_id
 		? agentPath(sessionId, detail.parent_job_id)
 		: rootPath;
-	const { entries: transcript, loading, failed, retry } = useLazySubagentTranscript(
+	const { entries: transcript, loading, failed, unavailable, retry } = useLazySubagentTranscript(
 		sessionId,
 		jobId,
 		detail,
@@ -629,8 +674,20 @@ export function AgentConversation({
 	// U2), a settled child whose one fetch failed (visible error + retry so it is
 	// recoverable in place, never a silent blank — U1), or genuinely empty. The
 	// header/outcome above stay put; only the BODY reflects these.
-	const emptyBody = failed ? (
-		<TranscriptFetchError connected={connected} onRetry={retry} />
+	const emptyBody = unavailable ? (
+		<TranscriptFetchError
+			connected={connected}
+			unavailable
+			parentPath={parentPath}
+			onRetry={retry}
+		/>
+	) : failed ? (
+		<TranscriptFetchError
+			connected={connected}
+			unavailable={false}
+			parentPath={parentPath}
+			onRetry={retry}
+		/>
 	) : loading ? (
 		<div className="py-4">
 			<TranscriptLoading connected={connected} />

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -1304,6 +1304,14 @@ class ServingSessionHandle(SessionHandle):
         # saw the AgentStartEvent). After this the fold's own lifecycle events
         # own ``streaming`` — see ``_reconcile_streaming``.
         self._reconcile_streaming()
+        # Seed the state (and with it the child roster) ONCE at attach. Until
+        # the next event arrives this push is all a freshly attached phone
+        # renders, and a settled turn never sends another: without this an
+        # already-finished child stays unroutable (``session_id=None``) for as
+        # long as the session is quiet. ``_refresh_state`` is idempotent and
+        # only fills non-None fields, so seeding here cannot clobber the
+        # identity fields the projection already carries.
+        self._refresh_state()
         return unsubscribe
 
     async def prompt(
@@ -4123,6 +4131,21 @@ class ServingSessionHandle(SessionHandle):
             # lifecycle events are authoritative; ``_reconcile_streaming``
             # covers attach and command boundaries.
         )
+        # Publish the child roster beside the session state, the way the TUI
+        # host does (``mobile/tui_handle.py::_refresh_state``). The folded
+        # projection's per-child ``session_id`` is the ONLY route to
+        # ``/api/sessions/{sid}/agents/{job}/history``: the event path cannot
+        # learn a child's session directory (``SubagentStartEvent`` carries no
+        # session id, so those rows are born with ``session_id=None``), and the
+        # registry in ``SubagentComms`` is the only place that knows it. Both
+        # hosts must therefore agree about the same row, or a runtime-hosted
+        # session 404s every child transcript while a TUI-hosted one serves it.
+        # The cost is the one the TUI already pays per folded event (one
+        # registry walk plus a bounded copy); no child transcript ever leaves
+        # with it.
+        comms = getattr(self._session, "_subagent_comms", None)
+        if comms is not None:
+            self._fold.set_subagent_details(comms)
 
     def _reconcile_streaming(self) -> None:
         """Seed/align ``streaming`` from the session flag at attach and command

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -1308,9 +1308,14 @@ class ServingSessionHandle(SessionHandle):
         # the next event arrives this push is all a freshly attached phone
         # renders, and a settled turn never sends another: without this an
         # already-finished child stays unroutable (``session_id=None``) for as
-        # long as the session is quiet. ``_refresh_state`` is idempotent and
-        # only fills non-None fields, so seeding here cannot clobber the
-        # identity fields the projection already carries.
+        # long as the session is quiet. Seeding cannot clobber the identity
+        # fields the projection already carries, but not because of
+        # ``set_state``'s None-skipping — ``set_subagent_details`` assigns every
+        # roster field unconditionally, ``row.session_id`` included, and bumps
+        # the version. It is safe because both sides read the SAME registry: the
+        # fold's rows and the seed's nodes each describe one child from
+        # ``SubagentComms``, so the republish writes the values the row already
+        # held.
         self._refresh_state()
         return unsubscribe
 

--- a/tests/unit/mobile/test_daemon.py
+++ b/tests/unit/mobile/test_daemon.py
@@ -341,6 +341,104 @@ def test_subagent_summary_detail_and_child_history_are_isolated(tmp_path, monkey
     assert client.get("/api/sessions/root-session/agents/not-related").status_code == 404
 
 
+def test_runtime_hosted_roster_routes_the_child_history_end_to_end(tmp_path, monkeypatch) -> None:
+    """A runtime-hosted session must publish its children's session dirs.
+
+    ``/agents/{job}/history`` resolves a child through the folded roster's
+    ``session_id``, and the ONLY writer of that field is
+    ``ProjectionFold.set_subagent_details``. Since the viewer/runtime split the
+    phone's sessions are hosted by ``ServingSessionHandle``, which mirrored the
+    TUI handle's state push but not its roster push -- and the event path can
+    never learn a child's session dir (``SubagentStartEvent`` carries no session
+    id), so every runtime-hosted session published ``session_id: null`` for
+    every child and the route 404'd for all of them. The summary/detail test
+    above HAND-BUILDS that row, which is why nothing caught it; this drives the
+    real producer and walks it out to the HTTP route.
+    """
+    from local_operator.harness.comms import SubagentComms
+    from local_operator.harness.types import Message, SubagentStartEvent
+    from local_operator.mobile.daemon import _projection_frame
+    from local_operator.mobile.types import _projection_from_json
+    from local_operator.session.runtime.serving import ServingSessionHandle
+    from local_operator.session.transcript import Transcript
+    from tests.unit.harness.test_comms import FakeChild, FakeJobs, FakeParent
+    from tests.unit.session.runtime.test_serving import FakeSession
+
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    child_dir = cfg / "sessions" / "child-session"
+    grandchild_dir = cfg / "sessions" / "grandchild-session"
+    for directory, text, row_id in (
+        (child_dir, "child-only", "child-row"),
+        (grandchild_dir, "grandchild-only", "grandchild-row"),
+    ):
+        directory.mkdir(parents=True)
+        asyncio.run(Transcript(directory).append_message(Message.user(text, id=row_id)))
+
+    jobs = FakeJobs()
+    jobs.add("child-job", status="running")
+    jobs.add("grandchild-job", status="running")
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    comms.record_launch("child-job", "child", prompt="Inspect it.")
+    comms.attach("child-job", FakeChild(), child_dir)  # type: ignore[arg-type]
+    comms.record_launch("grandchild-job", "grandchild", parent_job_id="child-job")
+    comms.attach("grandchild-job", FakeChild(), grandchild_dir)  # type: ignore[arg-type]
+
+    async def build() -> tuple[SessionProjection, FakeSession]:
+        session = FakeSession()
+        session.session_id = "root-session"
+        session._subagent_comms = comms  # type: ignore[attr-defined]
+        handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+        handle.subscribe(lambda: None)
+        # The attach seed alone must publish the roster: a settled child sends
+        # no further event, so an event-only push leaves it unroutable for as
+        # long as the session stays quiet.
+        return handle.session_projection_seed, session
+
+    projection, session = asyncio.run(build())
+    rows = {row.job_id: row.session_id for row in projection.subagents}
+    # Nested children live only in the shared registry, so the walk must reach
+    # them too -- the phone opens a grandchild from the roster's Children.
+    assert rows == {"child-job": "child-session", "grandchild-job": "grandchild-session"}
+
+    record = SessionRecord(
+        pid=9,
+        kind="daemon",
+        session_id="root-session",
+        conversation_name="root",
+        cwd=str(tmp_path),
+        model_label="",
+        control_port=1,
+        control_key="k",
+        started_at=0.0,
+        heartbeat_at=0.0,
+    )
+    # The same boundary the daemon's dial loop crosses: the registrant
+    # serializes the frame and the daemon rebuilds it before capturing.
+    incoming = _projection_from_json(json.loads(json.dumps(_projection_frame(projection))), record)
+    daemon = MobileDaemon(port=0, password="pw123")
+    daemon.capture_subagent_details(incoming, record=record)
+
+    client = TestClient(build_app(daemon), follow_redirects=False)
+    client.post("/login", data={"password": "pw123"})
+    history = client.get(
+        "/api/sessions/root-session/agents/child-job/history", params={"limit": 10}
+    )
+    assert history.status_code == 200
+    assert [entry["text"] for entry in history.json()["entries"]] == ["child-only"]
+    nested = client.get(
+        "/api/sessions/root-session/agents/grandchild-job/history", params={"limit": 10}
+    )
+    assert nested.status_code == 200
+    assert [entry["text"] for entry in nested.json()["entries"]] == ["grandchild-only"]
+
+    # A live child announcing itself through the root event stream must keep
+    # the same row (the event path rebuilds it without a session id).
+    session.emit(SubagentStartEvent(job_id="child-job", label="child"))
+    assert {row.job_id: row.session_id for row in projection.subagents} == rows
+
+
 def test_retained_summary_recapture_preserves_rich_detail_and_monotonic_version() -> None:
     """Wake/reconnect may recapture only the already-stripped retained summary."""
     daemon = MobileDaemon(port=0, password="pw123")


### PR DESCRIPTION
# PR Description

## Summary of Changes

The phone could not open **any** subagent transcript. Tapping a child agent showed
"Couldn't load the transcript. / The conversation steps didn't load. Retry to pull them again."
with a Retry that could never succeed.

Two defects, one per surface:

- **Server (root cause):** a runtime-hosted session never published its child roster into the
  phone projection, so the daemon had no child session dir to page and the route answered 404.
- **Client:** a 404 from the child-history route was treated as a transient link drop, so the
  view offered a Retry that could never succeed.

Release: patch — child-agent transcripts are reachable on the phone again

## Related Issue(s)

- Related: none (found from the live phone view)

## The mechanism

The phone's child view fetches `/api/sessions/{session_id}/agents/{job_id}/history`. The daemon
handler (`mobile/daemon.py::api_subagent_history`) resolves the child's own session-dir name from
`detail["session_id"]`, and 404s `{"error":"subagent history unavailable"}` without it.

`detail` comes from the projection roster rows (`SubagentRow`). The **only** writer of
`row.session_id` is `ProjectionFold.set_subagent_details(comms)`
(`mobile/projection.py`), sourced from `comms.node(job_id).session_id`
(`harness/comms.py`) — the registry is the only place that knows a child's session dir.

That method had exactly one caller: `TuiSessionHandle._refresh_state`. Since the viewer/runtime
split the phone's sessions are hosted by `ServingSessionHandle`
(`session/runtime/serving.py`), whose own `_refresh_state` mirrored the TUI's **state** push but
not its **roster** push. The event path cannot make up the difference: `SubagentStartEvent`
carries no session id, so event-born rows are created with `session_id=None` and nothing ever
filled it in. Every runtime-hosted session therefore published `"session_id": null` for every
child — live and settled — and the route 404'd for all of them. The client then rendered the
futile Retry state.

## What changed

- `local_operator/session/runtime/serving.py`
  - `_refresh_state()` now publishes the child roster exactly as the TUI host does
    (`comms = getattr(self._session, "_subagent_comms", None)` →
    `self._fold.set_subagent_details(comms)`), so both hosts agree about the same row. The cost is
    the one the TUI already pays per folded event (one registry walk plus a bounded copy); no
    child transcript ever leaves with it.
  - `subscribe()` seeds `_refresh_state()` once at attach, mirroring `TuiSessionHandle.subscribe`.
    Without it a *settled* child stays unroutable until the next event — and a settled turn never
    sends one.
- `local_operator/mobile/web/src/screens/agent-view.tsx`
  - `useLazySubagentTranscript` distinguishes an `HttpError` 404 (terminal: this child has no
    readable transcript) from network/5xx failures (retryable).
  - `TranscriptFetchError` gains the terminal branch: honest copy plus a **Back to parent**
    control instead of a Retry. Copy lives in this one component for a later design pass.
- `tests/unit/mobile/test_daemon.py`
  - New `test_runtime_hosted_roster_routes_the_child_history_end_to_end` drives the **real**
    producer — a real `ServingSessionHandle` over a real `SubagentComms` holding an attached
    child (and an attached grandchild, pinning the nested walk) — through the daemon's real
    serialization boundary (`_projection_frame` → `_projection_from_json` →
    `capture_subagent_details`) out to a real `MobileDaemon` + `TestClient`, asserting the child's
    transcript entries come back. It also asserts the attach seed alone publishes the roster and
    that a later `SubagentStartEvent` keeps the same row.
- `local_operator/mobile/web/src/agent-view.interaction.test.tsx`
  - New test: a 404 shows the terminal card, offers no Retry, and navigates back to the parent.
  - The api mock now spreads the actual module so `HttpError` keeps its identity (a partial
    factory replaced the class with `undefined`).

## Testing Details

### 1. Route-level reproduction with the real producer (isolated config/HOME)

Before the fix (`origin/main` code), a runtime-hosted session with a real attached child:

```
projection rows (job_id, session_id): [('child-job', None)]
GET /api/sessions/root-session/agents/child-job         -> 200 {... "session_id":null ...}
GET /api/sessions/root-session/agents/child-job/history -> 404 {"error":"subagent history unavailable"}
```

After:

```
projection rows (job_id, session_id): [('child-job', 'child-session')]
GET /api/sessions/root-session/agents/child-job         -> 200 {... "session_id":"child-session" ...}
GET /api/sessions/root-session/agents/child-job/history -> 200 {"entries":[{"id":"child-row","kind":"user","text":"child-only",...}]}
```

### 2. The new test fails on the unfixed code

Reverting only the `serving.py` hunks (targeted reverse edit, then restored) and running the new
test:

```
>       assert rows == {"child-job": "child-session", "grandchild-job": "grandchild-session"}
E       AssertionError: assert {} == {'child-job': 'child-session', 'grandchild-job': 'grandchild-session'}
1 failed, 30 deselected, 3 warnings in 0.76s
```

With the fix: `1 passed, 30 deselected`. The old test could not catch this because it hand-built
`SubagentRow(..., session_id="child-session", ...)`; nothing exercised the producer.

### 3. Real daemon, real HTTP, two processes

A real `RuntimeServer` wrapping a real `ServingSessionHandle` (child attached, its transcript on
disk) registers; a real `python -m local_operator.mobile.service` daemon starts as a subprocess
with an isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`, scans the registry, dials the registrant,
adopts the pushed projection, and is then driven over real HTTP with the portal login:

| | unfixed tree (temp worktree at `494ad221d`) | this branch |
|---|---|---|
| `GET /agents/{job}` | `200`, `"session_id": null` | `200`, `"session_id": "child-session"` |
| `GET /agents/{job}/history?limit=10` | `404 {"error":"subagent history unavailable"}` | `200 {"entries":[{"id":"child-user",...},{"id":"child-reply","text":"Found the seam."...}]}` |

### 4. Rendered frames (real browser, real daemon, isolated config/HOME)

Both frames come from the same scenario (a child whose transcript is on disk), served by a real
daemon on a real port and driven in the paired browser at `#/s/root-session/a/child-job`:

- **Before:** the child view reads "Couldn't load the transcript. / The conversation steps didn't
  load. Retry to pull them again." with a **Retry** button, and no conversation.
- **After:** the child's conversation renders — the `Parent / Inspect it.` launch row and
  `Found the seam.` — with no error card.

The 404 case was also captured as a before/after pair (child with no readable transcript): the
unfixed client offers the futile **Retry**; the fixed client reads "Conversation not available. /
This agent has no saved transcript to show." with **Back to parent**, which navigates to the
parent route (verified by clicking it).

Frames are hosted in a gist (the repo's convention: evidence on the PR, never in the tree).
The files are the browser PNGs base64-wrapped in SVG so the gist can carry them losslessly:

| state | frame |
|---|---|
| before (unfixed tree, child with a transcript) | [rendered frame](https://gist.githubusercontent.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d/raw/50e2e6e1cbaf8023ef5810b8247b6940116025e7/ct-bug-before.svg) |
| after (this branch, same child, same daemon) | [rendered frame](https://gist.githubusercontent.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d/raw/38a94ec708a3f39682738d09b810b3789b189111/ct-bug-after.svg) |
| before (fixed server, unfixed client; child with no readable transcript) | [rendered frame](https://gist.githubusercontent.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d/raw/50e2e6e1cbaf8023ef5810b8247b6940116025e7/ct-before.svg) |
| after (terminal card, this branch) | [rendered frame](https://gist.githubusercontent.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d/raw/bb3027b548331186490d9c62315d88568eacd2f6/ct-after.svg) |

<img src="https://gist.githubusercontent.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d/raw/50e2e6e1cbaf8023ef5810b8247b6940116025e7/ct-bug-before.svg" width="512">
<img src="https://gist.githubusercontent.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d/raw/38a94ec708a3f39682738d09b810b3789b189111/ct-bug-after.svg" width="512">
<img src="https://gist.githubusercontent.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d/raw/50e2e6e1cbaf8023ef5810b8247b6940116025e7/ct-before.svg" width="512">
<img src="https://gist.githubusercontent.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d/raw/bb3027b548331186490d9c62315d88568eacd2f6/ct-after.svg" width="512">

Gist: https://gist.github.com/damianvtran/3268eb3d119cd729e12c060863ea3c7d

### 5. Gates

Run from this worktree with its own venv, on the rebased head (`fb58ef971`):

```
.venv/bin/python -m flake8 .                                  # clean
uvx --from black==26.1.0 black --check .                      # 1258 files unchanged
uvx isort==5.13.2 --check .                                   # clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    # 0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q                       # 19128 passed, 18 skipped
.venv/bin/python -m pytest tests/unit/mobile/test_daemon.py -n0 \
    -k "runtime_hosted_roster or summary_detail_and_child_history or http_gate"
                                                               # 3 passed, 28 deselected
cd local_operator/mobile/web && pnpm build && pnpm test        # build ok; 15 files, 87 tests passed
```

The full unit suite was run on both heads: `19129 passed, 19 skipped` on the pre-rebase head
`197daffe7`, and `19128 passed, 18 skipped` on the rebased head `fb58ef971` (the count differs
because the upstream window it rebased onto adds and re-parametrizes its own tests). Zero
failures on both. The incoming commits touch none of the four files this PR changes.

### 6. Rebase onto the moved base

`origin/main` moved to `86ba40750` (v0.54.26, #1017) while this branch was open. Rebased cleanly:

```
$ git range-diff 494ad221d..197daffe7 86ba40750..fb58ef971
1:  e625fe47c = 1:  3f950b0e3 fix(session): publish the child roster from the runtime host
2:  197daffe7 = 2:  fb58ef971 fix(mobile): make a 404 child transcript terminal instead of retryable
```

Both commits are content-identical (`=`), and `git diff --stat 86ba40750..fb58ef971` is the same
four files / 219 insertions / 8 deletions as the pre-rebase diff. The upstream commits in the
window touch `session/attached.py`, `session/frontend_state.py`, `tui/*`, `pyproject.toml` and TUI
tests — none of them in this PR's files.

## Impact

- No dependency changes; no wire-format change (the roster row gains the `session_id` it was
  always meant to carry — the durable path already carried it).
- Per-event cost is unchanged for the TUI host and matches it for the runtime host: one registry
  walk plus a bounded copy per folded event. No child transcript rides the wire.
- `session_id` in a roster row is now populated for runtime-hosted sessions, so
  `/agents/{job}/history` works for live, settled, and nested children.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (no doc surface changed)
- [x] Security considerations are addressed (no new inputs or routes; the route's existing child
      isolation is unchanged).
- [x] I have linked all related issues.

## Not addressed

- The empty-body error card only renders when the child has no synthesized launch row: a child
  with `prompt` set and no transcript (or a 404) renders the launch row and no error at all.
  That is a pre-existing behaviour of `agentConversationEntries` + `Transcript.emptyContent` and
  is out of scope here; noted for the design pass.
- A running child whose route 404s keeps its poll ticking. It is harmless (the state is
  idempotent and a later success clears it), and stopping the poll would add a second mechanism.
- Design wording of the new copy is expected to be refined by the design round.
