### PR TITLE
chore(release): bump version to 0.54.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.27"
+version = "0.54.28"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window: post-v0.54.27 (claimed by session pid 36281, "Lopdev mobile subagents").

Window (all merged before this bump):
- #1022 — `fix(mobile): mobile child-agent transcripts were unreachable on the phone` (merge `3aec94b92be34aaa7fca9a57c7064e585f4990de`) · `Release: patch — child-agent transcripts are reachable on the phone again`

Bump: **PATCH → 0.54.28.** One PR in the window, a bug fix restoring broken behaviour, so nothing clears the step-function bar for a minor. Chosen version is `<last tag v0.54.27> + patch`.

Scope: `pyproject.toml` only, one line. No other PR in this window touched `pyproject.toml` (verified: the window contains only #1022, which changes 4 files, none of them `pyproject.toml`).