### PR TITLE
fix(session): a zombie owner no longer holds a transcript claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,19 @@ agree:
 env HOME=/tmp/iso-run LOCAL_OPERATOR_CONFIG_DIR=/tmp/iso-run/.local-operator ...
 ```
 
+**And strip what a `lop` parent exports, because two of its prefixes are read by
+the child product rather than only by a terminal.** `CMUX_*` is the one already
+known here (a headless TUI that inherits `CMUX_WORKSPACE_ID` renames the
+operator's real cmux workspaces). `LOP_*` is the other, and it is quieter:
+`session/runtime/process.py` reads `LOP_MOBILE_CHILD_PROVIDER`, `_MODEL`, `_CWD`
+and `_RESUME`, plus `LOP_RUNTIME_DEFER_MATERIALISE` and `_ADOPT_SESSION`, to
+decide what a child runtime is and what it works on. A cell run from inside
+another session therefore inherits *that* session's provider and model (so it
+silently runs on a provider the fixture never chose) and, with a deferral flag
+inherited, a child can idle-exit with no work at all — a plausible-looking cell
+that proves nothing. QA round 1 lost a cell to exactly this. Strip both prefixes,
+then set the names the cell means to set.
+
 This is worth spelling out because the failure is silent and it produces a
 *plausible* wrong answer rather than an error. It has now cost two separate QA
 rounds a false result in the same way: an "offline" cell resolved a provider

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,9 +299,12 @@ env HOME=/tmp/iso-run LOCAL_OPERATOR_CONFIG_DIR=/tmp/iso-run/.local-operator ...
 the child product rather than only by a terminal.** `CMUX_*` is the one already
 known here (a headless TUI that inherits `CMUX_WORKSPACE_ID` renames the
 operator's real cmux workspaces). `LOP_*` is the other, and it is quieter:
+
 `session/runtime/process.py` reads `LOP_MOBILE_CHILD_PROVIDER`, `_MODEL`, `_CWD`
-and `_RESUME`, plus `LOP_RUNTIME_DEFER_MATERIALISE` and `_ADOPT_SESSION`, to
-decide what a child runtime is and what it works on. A cell run from inside
+and `_RESUME` to decide what a child runtime is, and sets
+`LOP_RUNTIME_ADOPT_SESSION` for it; `session_factory` then reads that flag and
+`LOP_RUNTIME_DEFER_MATERIALISE` to decide whether the session is adopted as-is or
+materialised first. A cell run from inside
 another session therefore inherits *that* session's provider and model (so it
 silently runs on a provider the fixture never chose) and, with a deferral flag
 inherited, a child can idle-exit with no work at all — a plausible-looking cell

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -682,7 +682,7 @@ def _decode_quietly(data_b64: str) -> bytes:
 
 
 def find_runtime_record(
-    config_dir: Path, session_id: str
+    config_dir: Path, session_id: str, *, check_zombie: bool = True
 ) -> tuple[SessionRecord | None, int | None]:
     """Locate the discovery record of the live process hosting ``session_id``.
 
@@ -697,10 +697,17 @@ def find_runtime_record(
     ``(None, pid)`` means an owner exists but no usable record does (old
     binary, registrant failed to start): the caller degrades gracefully.
     ``(None, None)`` means no owner at all.
+
+    ``check_zombie`` is forwarded to :func:`resume.live_runtime_pid`, which owns
+    the decision and documents both modes. It is a parameter because this
+    function is on the engage loop's dense 10 ms path as well as on every attach
+    path, and only the former can afford to defer the proof: there the owner
+    answer can only cause a wait, while an attach turns it into a refusal the
+    user sees.
     """
     from local_operator.resume import live_runtime_pid
 
-    owner = live_runtime_pid(config_dir, session_id)
+    owner = live_runtime_pid(config_dir, session_id, check_zombie=check_zombie)
     if owner is None:
         return None, None
     best: SessionRecord | None = None

--- a/local_operator/procstate.py
+++ b/local_operator/procstate.py
@@ -62,10 +62,26 @@ def is_zombie(pid: int) -> bool:
 
     Deliberately NOT ``psutil``: this module is stdlib-only by contract and
     ``/proc`` does not exist on macOS, so on POSIX the fallback is a ``ps``
-    fork — measured at 3.9 ms against ~1 µs for signal-0. Callers therefore
-    spend it only where the answer changes what they do: ``session_lease``
-    after signal-0 has already said "live", ``registry.scan`` on a record
-    whose heartbeat has already gone quiet. Never once per healthy session.
+    fork — measured at 2.4-3.9 ms across runs on an M-series box, against
+    ~1 µs for signal-0. Callers therefore spend it only where the answer changes
+    what they do. Concretely, these are the places that may pay it:
+
+    - ``session_lease._pid_state`` — every acquisition and reaper decision, and
+      the legacy ``.session.pid``-only branch, all of which require a holder to
+      be *proven* dead before they move its claim.
+    - ``resume.live_runtime_pid`` — after signal 0 has already said "exists",
+      because that answer decides whether an interface refuses to open a
+      session at all.
+    - ``registry.pid_alive(check_zombie=True)`` — ``registry.scan`` spends it on
+      a record whose heartbeat has already gone quiet, so a healthy session's
+      row stays fork-free.
+
+    Two places deliberately do NOT, and both are latency trades rather than
+    safety ones: ``registry.pid_alive``'s default, which keeps ``scan``
+    fork-free for healthy records, and ``launch._lease_holder``'s dense-window
+    call, where the engage loop polls every 10 ms and the fork would cost more
+    than the wait it is trying to shorten. Neither can take a claim — only
+    ``session_lease`` does that, and it always asks.
     """
     if pid <= 0:
         return False

--- a/local_operator/procstate.py
+++ b/local_operator/procstate.py
@@ -1,0 +1,95 @@
+"""The one answer to "is this pid still a process?" — including zombies.
+
+WHY THIS IS ITS OWN MODULE
+--------------------------
+Three modules ask this question about a pid that some *other* process owns, and
+each asks it to decide whether something a dead owner left behind may be taken
+over:
+
+- :mod:`local_operator.session_lease` — may this transcript's sole-writer claim
+  be acquired, or is its holder still working?
+- :mod:`local_operator.session.runtime.registry` — may this discovery record be
+  reaped, or is its runtime still live?
+- :mod:`local_operator.resume` — should an attach be offered, or refused
+  because the session is already open in another process?
+
+They must agree, and the cost of disagreement is not a stale row: discovery
+reporting "gone" while the lease reports "held" is a session **no interface can
+open and no mechanism can recover**. That is not hypothetical — see
+:func:`is_zombie` for the incident that produced this module.
+
+All three callers are on the resume/attach/startup path and each documents that
+it must stay stdlib-only and import-light (``registry`` sits on the CLI startup
+path; ``session_lease`` and ``resume`` must be consultable without the engine
+or the mobile stack). A leaf module with no local imports is therefore the only
+home that satisfies all of them at once, which is exactly why the probe was
+written twice before and got the zombie case right in only one of the two.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def is_zombie(pid: int) -> bool:
+    """Whether this pid is an exited-but-unreaped process.
+
+    **A ZOMBIE IS NOT A LIVE PROCESS, AND ``kill(pid, 0)`` CANNOT TELL YOU
+    THAT.** Signal 0 succeeds against a process that has exited but has not
+    been reaped yet, so every probe built on it reports such a pid as alive
+    for as long as its parent fails to reap it — and for a runtime spawned by
+    a long-lived TUI, that parent may never reap it at all. The pid is not
+    reused while it lingers, so the wrong answer is stable, not a race.
+
+    Where the wrong answer costs a row: `registry` fixed this for discovery
+    records in round 3 (U10) — a SIGKILLed runtime reported ``live`` with
+    ``0B`` RSS in `lop sessions`. Where it costs the SESSION: the lease probe
+    kept calling such an owner live, so nothing could take its claim over —
+    ``acquire_session_lease`` refused every attempt and
+    ``reap_proven_dead_session_claim`` declined to remove it, because both
+    require the holder to be *proven dead*. An operator's session whose
+    runtime was killed while its TUI parent lived on was therefore
+    un-attachable from every interface (TUI ``/resume``, ``lop exec
+    --resume``, phone attach) with the message "already open in pid N", where
+    N was a corpse.
+
+    Fails CLOSED (returns False, i.e. "treat as alive") on any doubt: calling
+    a live process dead would let a second writer take a transcript a working
+    runtime is still appending to, and a forked trajectory is far worse than
+    the unrecovered claim this exists to remove.
+
+    Deliberately NOT ``psutil``: this module is stdlib-only by contract and
+    ``/proc`` does not exist on macOS, so on POSIX the fallback is a ``ps``
+    fork — measured at 3.9 ms against ~1 µs for signal-0. Callers therefore
+    spend it only where the answer changes what they do: ``session_lease``
+    after signal-0 has already said "live", ``registry.scan`` on a record
+    whose heartbeat has already gone quiet. Never once per healthy session.
+    """
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        # Windows has no zombie state at all: a terminated process is
+        # immediately reusable, and liveness there is a *handle* question
+        # (``OpenProcess``), not a process-table one. Returning False is the
+        # same answer the POSIX probe would reach through a doomed
+        # ``/bin/ps`` fork, without the fork.
+        return False
+    try:
+        proc_status = Path(f"/proc/{pid}/stat")
+        if proc_status.exists():  # Linux: no subprocess needed
+            # `comm` can contain spaces and parentheses; state is the field
+            # after the LAST ')'.
+            data = proc_status.read_text()
+            return data.rpartition(")")[2].strip().startswith("Z")
+        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["/bin/ps", "-o", "state=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001 — an unprobeable pid is treated as alive
+        return False
+    return result.stdout.strip().upper().startswith("Z")

--- a/local_operator/procstate.py
+++ b/local_operator/procstate.py
@@ -70,18 +70,22 @@ def is_zombie(pid: int) -> bool:
       the legacy ``.session.pid``-only branch, all of which require a holder to
       be *proven* dead before they move its claim.
     - ``resume.live_runtime_pid`` — after signal 0 has already said "exists",
-      because that answer decides whether an interface refuses to open a
-      session at all.
+      because at its user-facing call sites (the TUI's ``/resume``,
+      ``lop exec --resume``, the phone's attach) that answer decides whether
+      someone is refused the session they asked for. Its ``check_zombie=False``
+      mode exists for one caller, the engage loop's dense discovery pass, where
+      the same answer can only cost a wait.
     - ``registry.pid_alive(check_zombie=True)`` — ``registry.scan`` spends it on
       a record whose heartbeat has already gone quiet, so a healthy session's
       row stays fork-free.
 
     Two places deliberately do NOT, and both are latency trades rather than
     safety ones: ``registry.pid_alive``'s default, which keeps ``scan``
-    fork-free for healthy records, and ``launch._lease_holder``'s dense-window
-    call, where the engage loop polls every 10 ms and the fork would cost more
-    than the wait it is trying to shorten. Neither can take a claim — only
-    ``session_lease`` does that, and it always asks.
+    fork-free for healthy records, and the engage loop's two probes inside its
+    dense 10 ms grid (``find_runtime_record``'s owner lookup and
+    ``_lease_holder``), where a fork costs more than the wait it would shorten.
+    Neither can take a claim — only ``session_lease`` does that, and it always
+    asks.
     """
     if pid <= 0:
         return False

--- a/local_operator/procstate.py
+++ b/local_operator/procstate.py
@@ -62,8 +62,8 @@ def is_zombie(pid: int) -> bool:
 
     Deliberately NOT ``psutil``: this module is stdlib-only by contract and
     ``/proc`` does not exist on macOS, so on POSIX the fallback is a ``ps``
-    fork — measured at 2.4-3.9 ms across runs on an M-series box, against
-    ~1 µs for signal-0. Callers therefore spend it only where the answer changes
+    fork — measured at 2.4-4.6 ms across runs on an M-series box, tracking
+    host load, against ~1 µs for signal-0. Callers therefore spend it only where the answer changes
     what they do. Concretely, these are the places that may pay it:
 
     - ``session_lease._pid_state`` — every acquisition and reaper decision, and

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -23,6 +23,8 @@ import sys
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from local_operator.procstate import is_zombie
+
 #: ``--resume`` with no id. A sentinel rather than a second boolean flag so the
 #: whole "which session" decision stays ONE value threaded through one parameter.
 RESUME_LATEST = "@latest"
@@ -1132,8 +1134,20 @@ def live_runtime_pid(config_dir: Path, session_id: str) -> int | None:
     Consults the session directory's ``.session.pid`` liveness marker — the
     same file the retention sweep uses. Stdlib-only and import-light: this
     module must stay off the engine and the mobile package (see the module
-    docstring). A live TUI or phone-started child always writes that marker
-    when it claims the directory.
+    docstring); the shared probe it uses is the stdlib-only leaf module
+    :mod:`local_operator.procstate`, which is not part of either. A live TUI or
+    phone-started child always writes that marker when it claims the directory.
+
+    **A zombie is not an owner.** Signal 0 succeeds against an exited-but-
+    unreaped process, and this marker is written by the runtime that owns the
+    session — whose parent is often a long-lived TUI that may never reap it.
+    Reporting such a pid as the owner is what turned a killed runtime's session
+    into one that no interface would open: every attach path here refused with
+    "session X is already open in another process (pid N)", naming a corpse,
+    while the lease that decision agrees with kept the claim out of reach of
+    the one mechanism that recovers it. Discovery, the attach guard and the
+    lease all learn the same answer from one probe now; see
+    :func:`local_operator.procstate.is_zombie`.
     """
     if session_id in ("", ".", "..") or Path(session_id).name != session_id:
         return None
@@ -1148,7 +1162,8 @@ def live_runtime_pid(config_dir: Path, session_id: str) -> int | None:
     # Windows has no signal 0 — ``os.kill`` there TERMINATES the target
     # (see ``session.retention._process_alive``). A parseable marker is
     # treated as live rather than probed, so a ``/resume`` cannot kill
-    # the phone-started child it is trying to share (F2).
+    # the phone-started child it is trying to share (F2). Windows also has no
+    # zombie state, so there is nothing the probe below could add there.
     if sys.platform == "win32":
         return pid
     try:
@@ -1159,6 +1174,12 @@ def live_runtime_pid(config_dir: Path, session_id: str) -> int | None:
         return pid
     except OSError:
         return pid
+    if is_zombie(pid):
+        # The probe is spent only here, where signal 0 has already said
+        # "exists" and the difference between a working runtime and its
+        # corpse decides whether the user is told to go and steer a session
+        # that nobody is running.
+        return None
     return pid
 
 

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -1152,11 +1152,23 @@ def live_runtime_pid(config_dir: Path, session_id: str, *, check_zombie: bool = 
     ``check_zombie=False`` is for the engage loop's DISCOVERY path, which calls
     this on every pass of its dense 10 ms grid: the proof costs a `ps` fork
     (2.4-4.6 ms measured across runs on this host), which is more than the dead
-    time that grid exists to remove. There it may only ever cause a wait — the
-    loop's decision to attach or spawn still ends in a runtime that has to
-    acquire the lease, which always demands the proof — whereas at the three
-    user-facing call sites (the TUI's ``/resume``, ``lop exec --resume`` and the
-    phone's attach) the answer IS the decision, so they keep the default.
+    time that grid exists to remove. At the three user-facing call sites (the
+    TUI's ``/resume``, ``lop exec --resume`` and the phone's attach) the answer
+    IS the decision, so they keep the default.
+
+    Cheap mode is not merely a wait, and saying so would be wrong. It cannot
+    change ARBITRATION — the loop's decision to attach or spawn still ends in a
+    runtime that has to acquire the lease, and that path always demands the proof
+    — but its answer is also read by ``find_runtime_record`` to SELECT a record,
+    and the two errands that deliver nothing (``WarmErrand``, ``WakeErrand``)
+    treat reaching a live record as the completed errand. So on the one pass
+    where an owner published AND died between two dense polls, the cheap answer
+    can hand back a corpse's record and report that errand ready. The window is a
+    single dense pass (~10-25 ms) because any pass that sees a record ends the
+    grid, the next pass proves the owner dead, and a wake is retried rather than
+    lost (the schedule stays overdue until a runtime loads). It is also strictly
+    narrower than the behaviour before this branch, when such a record read as
+    live for the ~45 s until its heartbeat quieted.
     """
     if session_id in ("", ".", "..") or Path(session_id).name != session_id:
         return None

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -1121,7 +1121,7 @@ def resolve_resume_id(config_dir: Path, requested: str) -> str:
     return resume_dir(config_dir, requested).name
 
 
-def live_runtime_pid(config_dir: Path, session_id: str) -> int | None:
+def live_runtime_pid(config_dir: Path, session_id: str, *, check_zombie: bool = True) -> int | None:
     """Pid of the process currently hosting ``session_id``, or ``None``.
 
     Two writers on one transcript is how a TUI ``/resume`` of a phone-started
@@ -1148,6 +1148,15 @@ def live_runtime_pid(config_dir: Path, session_id: str) -> int | None:
     the one mechanism that recovers it. Discovery, the attach guard and the
     lease all learn the same answer from one probe now; see
     :func:`local_operator.procstate.is_zombie`.
+
+    ``check_zombie=False`` is for the engage loop's DISCOVERY path, which calls
+    this on every pass of its dense 10 ms grid: the proof costs a `ps` fork
+    (2.4-4.6 ms measured across runs on this host), which is more than the dead
+    time that grid exists to remove. There it may only ever cause a wait — the
+    loop's decision to attach or spawn still ends in a runtime that has to
+    acquire the lease, which always demands the proof — whereas at the three
+    user-facing call sites (the TUI's ``/resume``, ``lop exec --resume`` and the
+    phone's attach) the answer IS the decision, so they keep the default.
     """
     if session_id in ("", ".", "..") or Path(session_id).name != session_id:
         return None
@@ -1174,11 +1183,12 @@ def live_runtime_pid(config_dir: Path, session_id: str) -> int | None:
         return pid
     except OSError:
         return pid
-    if is_zombie(pid):
+    if check_zombie and is_zombie(pid):
         # The probe is spent only here, where signal 0 has already said
-        # "exists" and the difference between a working runtime and its
-        # corpse decides whether the user is told to go and steer a session
-        # that nobody is running.
+        # "exists". At the user-facing call sites the difference between a
+        # working runtime and its corpse decides whether someone is told to go
+        # and steer a session that nobody is running; on the engage loop's dense
+        # discovery path it is deferred, because there it can only cost a wait.
         return None
     return pid
 

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -227,13 +227,24 @@ def _session_dir(config_dir: Path, session_id: str) -> Path:
     return config_dir / "sessions" / session_id
 
 
-def _lease_holder(config_dir: Path, session_id: str) -> int | None:
+def _lease_holder(config_dir: Path, session_id: str, *, check_zombie: bool = True) -> int | None:
     """Pid currently holding the transcript lease, if it is alive.
 
     Read directly rather than through ``acquire_session_lease``: this is a
     PROBE, and acquiring in order to find out would take the very lease the
     runtime needs. Uses the lease's own claim reader so both agree on the
     format.
+
+    ``check_zombie=False`` is for the engage loop's dense regime. That probe
+    costs a ``ps`` fork (2.4-3.9 ms measured across runs on an M-series box,
+    against the
+    23-30 µs budget published for one poll iteration at ``_poll_delay``), so
+    spending it on every 10 ms pass would nearly double the dense period and
+    eat the dead time the dense grid exists to remove. The loop therefore asks
+    for the cheap answer while a construction is KNOWN to be in flight and for
+    the proof once that belief has expired — see the call site. A wrong "live"
+    there costs waiting, never arbitration: a zombie's claim is still only ever
+    taken over by the acquisition path, which always requires the proof.
     """
     from local_operator.session_lease import LEASE_NAME, _pid_state, _read_claim
 
@@ -243,7 +254,7 @@ def _lease_holder(config_dir: Path, session_id: str) -> int | None:
     _generation, pid = _read_claim(path)
     if pid is None:
         return None
-    return pid if _pid_state(pid) == "live" else None
+    return pid if _pid_state(pid, check_zombie=check_zombie) == "live" else None
 
 
 def _spawn_runtime(
@@ -602,7 +613,30 @@ async def engage_runtime(
 
         holder: int | None = None
         if not spawned or spawns < _MAX_SPAWNS:
-            holder = await asyncio.to_thread(_lease_holder, config_dir, session_id)
+            # Whether the PROOF that a holder is a corpse is due on this pass.
+            #
+            # The dense regime polls every 10 ms while a construction is KNOWN
+            # to be in flight, against a published budget of 23-30 µs for one
+            # iteration (see ``_poll_delay``); the zombie probe is a `ps` fork
+            # measured at 2.4-3.9 ms on this class of host, so asking for it
+            # here would nearly double the dense period and add that same ~3 ms
+            # to the attach dead time the dense grid exists to remove.
+            #
+            # So the cheap probe answers first and the proof is spent once the
+            # fast belief has expired. A claim that is STILL held with no
+            # record after a construction's own window is not a construction in
+            # flight: it is a wedged holder or a corpse (`_CONSTRUCTING_WINDOW_S`
+            # is 2.5x a full cold construction, measured). Past that point the
+            # grid is the open-ended backoff at 50 ms - 1 s, where one fork per
+            # pass is a bounded fraction of a core, and a corpse's session
+            # recovers a couple of seconds later instead of never.
+            probe_dead_holder = (
+                constructing_since is not None
+                and time.monotonic() - constructing_since > _CONSTRUCTING_WINDOW_S
+            )
+            holder = await asyncio.to_thread(
+                _lease_holder, config_dir, session_id, check_zombie=probe_dead_holder
+            )
             if holder is not None:
                 # STARTING: a contender holds the transcript but has not
                 # published yet. Spawning here would create a doomed candidate,
@@ -821,6 +855,19 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     threatens it.** ``scan()`` forks ``ps`` for any record whose heartbeat is
     older than ``HEARTBEAT_INTERVAL_S * 1.5``, and such a record is not reaped,
     so it pays that fork on every scan (review round 1, MINOR-1).
+
+    **The other `ps` fork on this path is now deferred rather than paid.** The
+    lease probe inside a dense iteration is ``_lease_holder``, and proving a
+    holder is a corpse (rather than merely a pid signal 0 accepts) costs that
+    same fork — measured at 2.4-3.9 ms here, against the 23-30 µs budget above.
+    Asking for it every pass would have nearly doubled the dense period and
+    added the fork straight onto the dead time this grid exists to remove, so
+    the loop asks for the cheap answer while a construction is KNOWN to be in
+    flight and only for the proof once ``_CONSTRUCTING_WINDOW_S`` has lapsed
+    (see the call site and ``session_lease._pid_state``). So the 23-30 µs
+    iteration figure above still holds, and it was measured with the dense regime
+    fork-free; a corpse's claim pays for that by stalling its own recovery a few
+    seconds instead, which is the trade the window is for.
 
     Where that lands is narrower than it first appears, because
     ``find_runtime_record`` returns BEFORE ``scan()`` when the session has no

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -235,16 +235,15 @@ def _lease_holder(config_dir: Path, session_id: str, *, check_zombie: bool = Tru
     runtime needs. Uses the lease's own claim reader so both agree on the
     format.
 
-    ``check_zombie=False`` is for the engage loop's dense regime. That probe
-    costs a ``ps`` fork (2.4-4.6 ms across runs on an M-series box, tracking
-    load, against the
-    23-30 µs budget published for one poll iteration at ``_poll_delay``), so
-    spending it on every 10 ms pass would stretch that period by 24-46% and eat
-    the dead time the dense grid exists to remove. The loop therefore asks
-    for the cheap answer while a construction is KNOWN to be in flight and for
-    the proof once that belief has expired — see the call site. A wrong "live"
-    there costs waiting, never arbitration: a zombie's claim is still only ever
-    taken over by the acquisition path, which always requires the proof.
+    ``check_zombie=False`` is for the engage loop's dense grid. That probe costs
+    a ``ps`` fork (2.4-4.6 ms across runs on an M-series box, against the
+    23-30 µs budget published for one dense poll iteration at ``_poll_delay``),
+    so paying it every 10 ms pass would stretch that period by 24-46% and eat the
+    dead time the grid exists to remove. The loop therefore passes False only
+    while that grid is in force and True on every coarser pass — see the cadence
+    note at the top of the loop. A wrong "live" there costs waiting, never
+    arbitration: a zombie's claim is still only ever taken over by the
+    acquisition path, which always requires the proof.
     """
     from local_operator.session_lease import LEASE_NAME, _pid_state, _read_claim
 
@@ -590,7 +589,37 @@ async def engage_runtime(
     defer = isinstance(work, WarmErrand)
 
     while time.monotonic() < _deadline():
-        record, _owner = await asyncio.to_thread(find_runtime_record, config_dir, session_id)
+        # Whether this pass may spend the CORPSE PROOF, or only the cheap probe.
+        #
+        # Two probes in this loop ask whether a holder is a live process rather
+        # than a pid signal 0 accepts: the owner lookup inside
+        # ``find_runtime_record`` and ``_lease_holder``. Proving a corpse costs a
+        # `ps` fork (2.4-4.6 ms measured across runs on this host) against the
+        # 23-30 µs budget published for one DENSE iteration, so the denses grid
+        # asks only the cheap question -- it already believes something is
+        # constructing, and being wrong about a corpse there costs waiting, never
+        # arbitration: only the spawned child's ``acquire_session_lease`` may
+        # take a claim, and that one always demands the proof.
+        #
+        # Outside the dense grid the passes are at least 50 ms apart (the
+        # open-ended backoff, up to 1 s), where a fork or two per pass is a
+        # fraction of a percent of a core -- and it is what lets a corpse's
+        # session be recovered on this very pass instead of waited on. So the
+        # deferral is deliberately tied to the CADENCE and not to elapsed time:
+        # a claim that reads "live" on pass one is proven on pass one, and the
+        # deferral only ever applies once the loop is already inside its dense
+        # belief that a contender is mid-construction.
+        #
+        # The condition mirrors ``_poll_delay``'s dense branch exactly, so
+        # "cheap" here is the same grid the budget above is quoted for.
+        dense_regime = (
+            constructing_since is not None
+            and time.monotonic() - constructing_since < _CONSTRUCTING_WINDOW_S
+        )
+        check_zombie = not dense_regime
+        record, _owner = await asyncio.to_thread(
+            find_runtime_record, config_dir, session_id, check_zombie=check_zombie
+        )
         if record is not None:
             try:
                 detail, duplicate = await _deliver(record, session_id, work)
@@ -613,29 +642,13 @@ async def engage_runtime(
 
         holder: int | None = None
         if not spawned or spawns < _MAX_SPAWNS:
-            # Whether the PROOF that a holder is a corpse is due on this pass.
-            #
-            # The dense regime polls every 10 ms while a construction is KNOWN
-            # to be in flight, against a published budget of 23-30 µs for one
-            # iteration (see ``_poll_delay``); the zombie probe is a `ps` fork
-            # measured at 2.4-4.6 ms on this class of host, so asking for it
-            # here would stretch the dense period by 24-46% and add that same
-            # cost to the attach dead time the dense grid exists to remove.
-            #
-            # So the cheap probe answers first and the proof is spent once the
-            # fast belief has expired. A claim that is STILL held with no
-            # record after a construction's own window is not a construction in
-            # flight: it is a wedged holder or a corpse (`_CONSTRUCTING_WINDOW_S`
-            # is 2.5x a full cold construction, measured). Past that point the
-            # grid is the open-ended backoff at 50 ms - 1 s, where one fork per
-            # pass is a bounded fraction of a core, and a corpse's session
-            # recovers a couple of seconds later instead of never.
-            probe_dead_holder = (
-                constructing_since is not None
-                and time.monotonic() - constructing_since > _CONSTRUCTING_WINDOW_S
-            )
+            # The same probe mode the discovery call above used, on the same
+            # pass and for the same reason: see the cadence note at the top of
+            # the loop. Deferring the proof is safe here because this branch can
+            # only ever decide to WAIT, and the spawn it defers to still has to
+            # win the lease against every other contender.
             holder = await asyncio.to_thread(
-                _lease_holder, config_dir, session_id, check_zombie=probe_dead_holder
+                _lease_holder, config_dir, session_id, check_zombie=check_zombie
             )
             if holder is not None:
                 # STARTING: a contender holds the transcript but has not
@@ -856,21 +869,21 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     older than ``HEARTBEAT_INTERVAL_S * 1.5``, and such a record is not reaped,
     so it pays that fork on every scan (review round 1, MINOR-1).
 
-    **The other `ps` fork on this path is now deferred rather than paid.** The
-    lease probe inside a dense iteration is ``_lease_holder``, and proving a
-    holder is a corpse (rather than merely a pid signal 0 accepts) costs that
-    same fork — measured at 2.4-4.6 ms across runs here, against the 23-30 µs
-    budget above. Asking for it every pass would have stretched the dense period
-    by 24-46% and added the fork straight onto the dead time this grid exists to
-    remove, so
-    the loop asks for the cheap answer while a construction is KNOWN to be in
-    flight and only for the proof once ``_CONSTRUCTING_WINDOW_S`` has lapsed
-    (see the call site and ``session_lease._pid_state``). So the 23-30 µs
-    iteration figure above is restored for the tidy store it was measured on —
-    the scan overlap carved out just above is unchanged by this, and a record
-    whose heartbeat has gone quiet still pays its fork per scan. A corpse's claim
-    pays for the deferral by stalling its own recovery a few seconds instead,
-    which is the trade the window is for.
+    **The other two `ps` forks on this path are deferred INSIDE the grid rather
+    than paid.** Two probes in a dense iteration ask whether a holder is a live
+    process rather than a pid signal 0 accepts: the owner lookup this loop's
+    ``find_runtime_record`` makes, and ``_lease_holder``. Proving a corpse costs
+    that same fork (2.4-4.6 ms across runs here) against the 23-30 µs budget
+    above, and asking every pass would have stretched the dense period by 24-46%
+    straight out of the dead time this grid exists to remove. So the grid asks
+    only the cheap question, keyed to the CADENCE rather than to elapsed time:
+    past the grid the passes are 50 ms-1 s apart, where one or two forks is a
+    fraction of a percent of a core, and there the proof is what recovers a
+    corpse's session on that very pass. The 23-30 µs iteration figure above is
+    therefore restored for the tidy store it was measured on, and the two `ps`
+    forks a dense iteration may still pay are the two this paragraph names: the
+    scan overlap carved out just above, and nothing else. See the cadence note at
+    the top of the engage loop.
 
     Where that lands is narrower than it first appears, because
     ``find_runtime_record`` returns BEFORE ``scan()`` when the session has no

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -239,7 +239,7 @@ def _lease_holder(config_dir: Path, session_id: str, *, check_zombie: bool = Tru
     costs a ``ps`` fork (2.4-4.6 ms across runs on an M-series box, tracking
     load, against the
     23-30 µs budget published for one poll iteration at ``_poll_delay``), so
-    spending it on every 10 ms pass would stretch that period by 24-39% and eat
+    spending it on every 10 ms pass would stretch that period by 24-46% and eat
     the dead time the dense grid exists to remove. The loop therefore asks
     for the cheap answer while a construction is KNOWN to be in flight and for
     the proof once that belief has expired — see the call site. A wrong "live"
@@ -619,7 +619,7 @@ async def engage_runtime(
             # to be in flight, against a published budget of 23-30 µs for one
             # iteration (see ``_poll_delay``); the zombie probe is a `ps` fork
             # measured at 2.4-4.6 ms on this class of host, so asking for it
-            # here would stretch the dense period by 24-39% and add that same
+            # here would stretch the dense period by 24-46% and add that same
             # cost to the attach dead time the dense grid exists to remove.
             #
             # So the cheap probe answers first and the proof is spent once the
@@ -861,7 +861,7 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     holder is a corpse (rather than merely a pid signal 0 accepts) costs that
     same fork — measured at 2.4-4.6 ms across runs here, against the 23-30 µs
     budget above. Asking for it every pass would have stretched the dense period
-    by 24-39% and added the fork straight onto the dead time this grid exists to
+    by 24-46% and added the fork straight onto the dead time this grid exists to
     remove, so
     the loop asks for the cheap answer while a construction is KNOWN to be in
     flight and only for the proof once ``_CONSTRUCTING_WINDOW_S`` has lapsed

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -236,11 +236,11 @@ def _lease_holder(config_dir: Path, session_id: str, *, check_zombie: bool = Tru
     format.
 
     ``check_zombie=False`` is for the engage loop's dense regime. That probe
-    costs a ``ps`` fork (2.4-3.9 ms measured across runs on an M-series box,
-    against the
+    costs a ``ps`` fork (2.4-4.6 ms across runs on an M-series box, tracking
+    load, against the
     23-30 µs budget published for one poll iteration at ``_poll_delay``), so
-    spending it on every 10 ms pass would nearly double the dense period and
-    eat the dead time the dense grid exists to remove. The loop therefore asks
+    spending it on every 10 ms pass would stretch that period by 24-39% and eat
+    the dead time the dense grid exists to remove. The loop therefore asks
     for the cheap answer while a construction is KNOWN to be in flight and for
     the proof once that belief has expired — see the call site. A wrong "live"
     there costs waiting, never arbitration: a zombie's claim is still only ever
@@ -618,9 +618,9 @@ async def engage_runtime(
             # The dense regime polls every 10 ms while a construction is KNOWN
             # to be in flight, against a published budget of 23-30 µs for one
             # iteration (see ``_poll_delay``); the zombie probe is a `ps` fork
-            # measured at 2.4-3.9 ms on this class of host, so asking for it
-            # here would nearly double the dense period and add that same ~3 ms
-            # to the attach dead time the dense grid exists to remove.
+            # measured at 2.4-4.6 ms on this class of host, so asking for it
+            # here would stretch the dense period by 24-39% and add that same
+            # cost to the attach dead time the dense grid exists to remove.
             #
             # So the cheap probe answers first and the proof is spent once the
             # fast belief has expired. A claim that is STILL held with no
@@ -859,15 +859,18 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     **The other `ps` fork on this path is now deferred rather than paid.** The
     lease probe inside a dense iteration is ``_lease_holder``, and proving a
     holder is a corpse (rather than merely a pid signal 0 accepts) costs that
-    same fork — measured at 2.4-3.9 ms here, against the 23-30 µs budget above.
-    Asking for it every pass would have nearly doubled the dense period and
-    added the fork straight onto the dead time this grid exists to remove, so
+    same fork — measured at 2.4-4.6 ms across runs here, against the 23-30 µs
+    budget above. Asking for it every pass would have stretched the dense period
+    by 24-39% and added the fork straight onto the dead time this grid exists to
+    remove, so
     the loop asks for the cheap answer while a construction is KNOWN to be in
     flight and only for the proof once ``_CONSTRUCTING_WINDOW_S`` has lapsed
     (see the call site and ``session_lease._pid_state``). So the 23-30 µs
-    iteration figure above still holds, and it was measured with the dense regime
-    fork-free; a corpse's claim pays for that by stalling its own recovery a few
-    seconds instead, which is the trade the window is for.
+    iteration figure above is restored for the tidy store it was measured on —
+    the scan overlap carved out just above is unchanged by this, and a record
+    whose heartbeat has gone quiet still pays its fork per scan. A corpse's claim
+    pays for the deferral by stalling its own recovery a few seconds instead,
+    which is the trade the window is for.
 
     Where that lands is narrower than it first appears, because
     ``find_runtime_record`` returns BEFORE ``scan()`` when the session has no

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -595,11 +595,23 @@ async def engage_runtime(
         # than a pid signal 0 accepts: the owner lookup inside
         # ``find_runtime_record`` and ``_lease_holder``. Proving a corpse costs a
         # `ps` fork (2.4-4.6 ms measured across runs on this host) against the
-        # 23-30 µs budget published for one DENSE iteration, so the denses grid
-        # asks only the cheap question -- it already believes something is
-        # constructing, and being wrong about a corpse there costs waiting, never
-        # arbitration: only the spawned child's ``acquire_session_lease`` may
-        # take a claim, and that one always demands the proof.
+        # 23-30 µs budget published for one DENSE iteration, so the grid asks
+        # only the cheap question -- it already believes something is
+        # constructing, and neither cheap answer can change ARBITRATION: only the
+        # spawned child's ``acquire_session_lease`` may take a claim, and that one
+        # always demands the proof.
+        #
+        # They are not equally harmless, and the difference is worth keeping
+        # straight. A cheap ``_lease_holder`` can only make this loop wait. A
+        # cheap ``find_runtime_record`` can also hand back a corpse's RECORD, and
+        # the two errands that deliver nothing (``WarmErrand``, ``WakeErrand``)
+        # treat reaching a record as the completed errand -- so on the one pass
+        # where an owner published and died between two dense polls, that errand
+        # is reported ready against a corpse. One pass later the proof lands and
+        # the loop corrects itself; a wake is retried rather than lost, and the
+        # pre-branch behaviour read such a record as live for as long as its
+        # heartbeat stayed fresh (~45 s). Bounded, documented, and the reason the
+        # proof is spent on every coarser pass.
         #
         # Outside the dense grid the passes are at least 50 ms apart (the
         # open-ended backoff, up to 1 s), where a fork or two per pass is a
@@ -880,10 +892,12 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     past the grid the passes are 50 ms-1 s apart, where one or two forks is a
     fraction of a percent of a core, and there the proof is what recovers a
     corpse's session on that very pass. The 23-30 µs iteration figure above is
-    therefore restored for the tidy store it was measured on, and the two `ps`
-    forks a dense iteration may still pay are the two this paragraph names: the
-    scan overlap carved out just above, and nothing else. See the cadence note at
-    the top of the engage loop.
+    therefore restored for the tidy store it was measured on, and the `ps` fork a
+    dense iteration may still pay is the one this paragraph names above: the scan
+    overlap. The two corpse proofs are no longer among them — they are deferred to
+    every coarser pass, where the fork costs a fraction of a percent of a core and
+    is what recovers a corpse's session. See the cadence note at the top of the
+    engage loop.
 
     Where that lands is narrower than it first appears, because
     ``find_runtime_record`` returns BEFORE ``scan()`` when the session has no

--- a/local_operator/session/runtime/registry.py
+++ b/local_operator/session/runtime/registry.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import tempfile
 import time
 from pathlib import Path
 
 from local_operator.paths import config_dir
+from local_operator.procstate import is_zombie
 from local_operator.session.runtime.types import (
     HEARTBEAT_INTERVAL_S,
     HEARTBEAT_TIMEOUT_S,
@@ -109,6 +109,11 @@ def pid_alive(pid: int, *, check_zombie: bool = False) -> bool:
     `scan()` runs on every `lop` invocation. Paying that per live session on
     startup would trade a rare stale row for a routine slowdown. `scan` asks
     for it only where the answer changes what a user is told.
+
+    The probe itself lives in :func:`local_operator.procstate.is_zombie`, which
+    is the one implementation the lease and the resume path share: a holder
+    that is a zombie must be reported dead by all three, or discovery reaps the
+    record while the claim that keeps the session un-attachable survives it.
     """
     if pid <= 0:
         return False
@@ -120,33 +125,7 @@ def pid_alive(pid: int, *, check_zombie: bool = False) -> bool:
         return True
     except OSError:
         return False
-    return not check_zombie or not _is_zombie(pid)
-
-
-def _is_zombie(pid: int) -> bool:
-    """Whether this pid is an exited-but-unreaped process.
-
-    Fails CLOSED (returns False, i.e. "treat as alive") on any doubt: calling
-    a live session dead would reap a record out from under a working runtime,
-    which is far worse than the stale row this exists to avoid.
-    """
-    try:
-        proc_status = Path(f"/proc/{pid}/stat")
-        if proc_status.exists():  # Linux: no subprocess needed
-            # `comm` can contain spaces and parentheses; state is the field
-            # after the LAST ')'.
-            data = proc_status.read_text()
-            return data.rpartition(")")[2].strip().startswith("Z")
-        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
-            ["/bin/ps", "-o", "state=", "-p", str(pid)],
-            capture_output=True,
-            text=True,
-            timeout=1.0,
-            check=False,
-        )
-    except Exception:  # noqa: BLE001 — an unprobeable pid is treated as alive
-        return False
-    return result.stdout.strip().upper().startswith("Z")
+    return not check_zombie or not is_zombie(pid)
 
 
 def scan(root: Path | None = None) -> list[tuple[SessionRecord, str]]:

--- a/local_operator/session_lease.py
+++ b/local_operator/session_lease.py
@@ -4,6 +4,12 @@ The compatibility ``.session.pid`` marker is useful for old readers but cannot
 be authoritative because replacing a text file is not acquisition.  This
 module stays stdlib-only so resume discovery can consult it without importing
 the engine or mobile stack.
+
+Liveness is asked through :func:`local_operator.procstate.is_zombie` rather
+than signal 0 alone, because the claim this module arbitrates is only ever
+taken over from a holder that is PROVEN dead, and a zombie is exactly the
+holder that looks alive forever.  The probe stays a leaf module so this one
+keeps its stdlib-only contract.
 """
 
 from __future__ import annotations
@@ -15,6 +21,8 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Literal
+
+from local_operator.procstate import is_zombie
 
 LEASE_NAME = ".execution-lease"
 MIRROR_NAME = ".session.pid"
@@ -35,7 +43,25 @@ class SessionLeaseHeldError(RuntimeError):
 
 
 def _pid_state(pid: int) -> Literal["live", "dead", "uncertain"]:
-    """Probe only what the platform can prove; uncertainty never permits theft."""
+    """Probe only what the platform can prove; uncertainty never permits theft.
+
+    **An exited-but-unreaped process is DEAD here, not live.** Signal 0
+    succeeds against a zombie, so a probe built on it alone reports the corpse
+    of a SIGKILLed runtime as a working owner — forever, because the pid is not
+    reused while it lingers and nothing may reap it on the owner's behalf. Both
+    readers of this verdict require a holder to be *proven dead* before they
+    move its claim, so the wrong answer here is not a misleading log line: it
+    is a transcript whose sole-writer claim can never be acquired. The operator
+    sees a session that no interface will open (`live_runtime_pid` refuses with
+    "already open in pid N", where N is the corpse) and no mechanism will
+    recover. :func:`local_operator.procstate.is_zombie` documents the incident.
+
+    The zombie probe is spent only after the cheap probe has already said
+    "live", so the two common answers — a live owner, and a pid that is simply
+    gone — stay fork-free. The remaining case costs one ``ps`` fork on macOS
+    (~3.9 ms) per call, which is why this function is called on acquisition and
+    on the engage loop's lease probe rather than once per session per pass.
+    """
     if pid <= 0:
         return "uncertain"
     if os.name == "nt":
@@ -58,10 +84,12 @@ def _pid_state(pid: int) -> Literal["live", "dead", "uncertain"]:
     except ProcessLookupError:
         return "dead"
     except PermissionError:
+        # Another account's process. It cannot be a zombie of ours, and an
+        # unverifiable holder must never lose its claim: fail closed.
         return "live"
     except OSError:
         return "uncertain"
-    return "live"
+    return "dead" if is_zombie(pid) else "live"
 
 
 def _read_claim(path: Path) -> tuple[str | None, int | None]:

--- a/local_operator/session_lease.py
+++ b/local_operator/session_lease.py
@@ -42,7 +42,7 @@ class SessionLeaseHeldError(RuntimeError):
         self.pid = pid
 
 
-def _pid_state(pid: int) -> Literal["live", "dead", "uncertain"]:
+def _pid_state(pid: int, *, check_zombie: bool = True) -> Literal["live", "dead", "uncertain"]:
     """Probe only what the platform can prove; uncertainty never permits theft.
 
     **An exited-but-unreaped process is DEAD here, not live.** Signal 0
@@ -56,11 +56,18 @@ def _pid_state(pid: int) -> Literal["live", "dead", "uncertain"]:
     "already open in pid N", where N is the corpse) and no mechanism will
     recover. :func:`local_operator.procstate.is_zombie` documents the incident.
 
-    The zombie probe is spent only after the cheap probe has already said
-    "live", so the two common answers — a live owner, and a pid that is simply
-    gone — stay fork-free. The remaining case costs one ``ps`` fork on macOS
-    (~3.9 ms) per call, which is why this function is called on acquisition and
-    on the engage loop's lease probe rather than once per session per pass.
+    **The zombie probe is not free, so the caller decides how often it is
+    worth spending.** Signal 0 costs ~1 µs and settles two of the three
+    answers (a live owner, a pid that is simply gone); the proof costs a `ps`
+    fork (2.4-3.9 ms measured across runs on this host) and is therefore spent
+    only after the cheap probe has already said "live". ``check_zombie=False``
+    skips it,
+    which is what the engage loop passes while it is polling every 10 ms
+    against a claim it believes is mid-construction (`launch._lease_holder`).
+    That choice is a LATENCY trade, never a safety one: the verdict it produces
+    can be "live" for a corpse only where the caller has already decided to
+    wait, and every acquisition still requires the proof before it may take a
+    claim.
     """
     if pid <= 0:
         return "uncertain"
@@ -89,6 +96,10 @@ def _pid_state(pid: int) -> Literal["live", "dead", "uncertain"]:
         return "live"
     except OSError:
         return "uncertain"
+    if not check_zombie:
+        # The caller is on a dense poll cadence and has already accepted that
+        # it will wait; see the docstring. A zombie reads as live here.
+        return "live"
     return "dead" if is_zombie(pid) else "live"
 
 

--- a/local_operator/session_lease.py
+++ b/local_operator/session_lease.py
@@ -59,7 +59,8 @@ def _pid_state(pid: int, *, check_zombie: bool = True) -> Literal["live", "dead"
     **The zombie probe is not free, so the caller decides how often it is
     worth spending.** Signal 0 costs ~1 µs and settles two of the three
     answers (a live owner, a pid that is simply gone); the proof costs a `ps`
-    fork (2.4-3.9 ms measured across runs on this host) and is therefore spent
+    fork (2.4-4.6 ms across runs on this host, tracking load) and is therefore
+    spent
     only after the cheap probe has already said "live". ``check_zombie=False``
     skips it,
     which is what the engage loop passes while it is polling every 10 ms

--- a/tests/e2e/test_fork_cold_e2e.py
+++ b/tests/e2e/test_fork_cold_e2e.py
@@ -50,7 +50,7 @@ async def test_cold_snapshot_live_preferences_overrides_and_cancel(
     # hosted in the test's process; only that discovery boundary is supplied.
     monkeypatch.setattr(
         "local_operator.mobile.attach_client.find_runtime_record",
-        lambda *_: (server._record, server._record.pid),
+        lambda *_, **_probe: (server._record, server._record.pid),
     )
     launches = []
 

--- a/tests/e2e/test_sidebar_display_e2e.py
+++ b/tests/e2e/test_sidebar_display_e2e.py
@@ -123,7 +123,7 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
             await server.start_in_process()
             servers[sid] = server
 
-        def find(_directory, sid):
+        def find(_directory, sid, **_probe):
             server = servers.get(sid)
             return (server._record, server._record.pid) if server else (None, None)
 

--- a/tests/e2e/test_sidebar_reconnect_e2e.py
+++ b/tests/e2e/test_sidebar_reconnect_e2e.py
@@ -151,7 +151,7 @@ async def test_an_evicted_viewer_reconnects_without_ever_looking_connected(
     config = headless_tui_env
     servers = {name: await _runtime(config, name) for name in ("origin", "target")}
 
-    def find_owner(_config_dir, session_id):
+    def find_owner(_config_dir, session_id, **_probe):
         server = servers.get(session_id)
         return (server._record, server._record.pid) if server else (None, None)
 
@@ -285,7 +285,7 @@ async def test_a_loss_in_the_bind_to_paint_window_heals_instead_of_latching(
     config = headless_tui_env
     servers = {name: await _runtime(config, name) for name in ("origin", "target")}
 
-    def find_owner(_config_dir, session_id):
+    def find_owner(_config_dir, session_id, **_probe):
         server = servers.get(session_id)
         return (server._record, server._record.pid) if server else (None, None)
 
@@ -384,7 +384,7 @@ async def test_a_plain_socket_loss_reconnects_with_no_attach_pressure(
     session_id = "target"
     server = await _runtime(config, session_id)
 
-    def find_owner(_config_dir, requested):
+    def find_owner(_config_dir, requested, **_probe):
         return (server._record, server._record.pid) if requested == session_id else (None, None)
 
     with patch("local_operator.mobile.attach_client.find_runtime_record", find_owner):

--- a/tests/e2e/test_sidebar_runtime_reap_e2e.py
+++ b/tests/e2e/test_sidebar_runtime_reap_e2e.py
@@ -92,7 +92,7 @@ async def test_visited_conversations_do_not_hold_their_runtimes_open(
     servers = await _stand_up(config, ids)
     _compress_idle_clock(monkeypatch)
 
-    def find(_directory, sid):
+    def find(_directory, sid, **_probe):
         server = servers.get(sid)
         return (server._record, server._record.pid) if server else (None, None)
 
@@ -176,7 +176,7 @@ async def test_an_empty_conversation_visited_and_left_retires_its_runtime(
 
     assert handle.is_pristine(), "the fixture must actually be an empty session"
 
-    def find(_directory, sid):
+    def find(_directory, sid, **_probe):
         server = servers.get(sid)
         return (server._record, server._record.pid) if server else (None, None)
 

--- a/tests/e2e/test_zombie_lease_recovery_e2e.py
+++ b/tests/e2e/test_zombie_lease_recovery_e2e.py
@@ -1,0 +1,149 @@
+"""A runtime recovers a session whose claim is held by a zombie, and runs.
+
+The incident, end to end and with every actor real: an operator's session whose
+runtime was killed while its parent — a long-lived TUI — lived on, so the
+transcript's sole-writer claim named a pid that had exited but never been
+reaped. `kill(pid, 0)` succeeds against such a pid, and every caller that asked
+only that question concluded the session was busy: `lop sessions` showed it as
+merely "stored" (discovery DOES probe for zombies, so it reaped the record)
+while the TUI's `/resume`, `lop exec --resume` and the phone all refused with
+"already open in another process (pid N)", N being the corpse. Neither
+`acquire_session_lease` nor `reap_proven_dead_session_claim` would touch the
+claim, because both require a holder to be PROVEN dead.
+
+This test drives the production child (`python -m
+local_operator.session.runtime.process`, the same argv ``launch._spawn_runtime``
+uses) against a session directory planted with exactly that state, and asserts
+on the durable transcript that the turn ran. Before the fix the child logged
+"runtime lost the lease for ... to pid <corpse>; exiting" and no turn ever
+landed — so the failure here is at the last step and for the right reason.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.unreaped import unreaped_child
+
+pytestmark = pytest.mark.e2e
+
+SESSION_ID = "zombieleas01"
+
+
+def _seed(config_dir: Path, session_id: str) -> None:
+    """A resumable session on the mock provider, as the cold-wake stage seeds it."""
+    directory = config_dir / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "transcript.jsonl").write_text(
+        json.dumps(
+            {
+                "id": "seed",
+                "ts": 1,
+                "type": "message",
+                "payload": {
+                    "kind": "message",
+                    "role": "user",
+                    "content": [{"type": "text", "text": "seed"}],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (config_dir / "config.yml").write_text(
+        "values:\n  hosting: test\n  model_name: mock\n", encoding="utf-8"
+    )
+
+
+def test_a_runtime_takes_over_a_claim_held_by_a_zombie(tmp_path: Path) -> None:
+    from local_operator.harness.wake import WAKE_SCHEDULES_CUSTOM_TYPE
+    from local_operator.session.transcript import Transcript
+    from local_operator.wakes.store import write_entry
+
+    _seed(tmp_path, SESSION_ID)
+    now = int(time.time() * 1000)
+    schedule = {
+        "id": "w1",
+        "message": "hello after the zombie",
+        "next_due_at": now - 5_000,
+        "created_at": now - 60_000,
+    }
+    transcript = Transcript(tmp_path / "sessions" / SESSION_ID)
+    asyncio.run(transcript.append_custom(WAKE_SCHEDULES_CUSTOM_TYPE, {"schedules": [schedule]}))
+    write_entry(tmp_path, SESSION_ID, cwd=str(tmp_path), schedules=[schedule])
+
+    session_dir = tmp_path / "sessions" / SESSION_ID
+    # HOME as well as the config dir: the cache root is derived from the home
+    # directory independently, so a run isolated by config dir alone still
+    # reads and writes the operator's real cache (see AGENTS.md).
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "LOCAL_OPERATOR_CONFIG_DIR": str(tmp_path),
+        "LOP_MOBILE_CHILD_CWD": str(tmp_path),
+        "LOP_MOBILE_CHILD_RESUME": SESSION_ID,
+    }
+
+    with unreaped_child() as zombie_pid:
+        claim = session_dir / ".execution-lease"
+        child_log = tmp_path / "runtime-child.log"
+        claim.write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "session_id": SESSION_ID,
+                    "generation": "c" * 32,
+                    "pid": zombie_pid,
+                },
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        (session_dir / ".session.pid").write_text(str(zombie_pid), encoding="utf-8")
+
+        child = subprocess.Popen(
+            [sys.executable, "-m", "local_operator.session.runtime.process"],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            # A FILE, not a pipe: nothing drains a pipe here, and 64 KB of
+            # runtime logging would block the child mid-boot.
+            stdout=child_log.open("wb"),
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            transcript_path = session_dir / "transcript.jsonl"
+            deadline = time.monotonic() + 45
+            text = ""
+            while time.monotonic() < deadline:
+                text = transcript_path.read_text(encoding="utf-8")
+                if "Hello from the mock provider!" in text and "wake_prompt" in text:
+                    break
+                if child.poll() is not None:
+                    break
+                time.sleep(0.5)
+            else:
+                raise AssertionError(f"the recovery turn never ran; transcript:\n{text}")
+            if child.poll() is not None and "Hello from the mock provider!" not in text:
+                raise AssertionError(
+                    f"the runtime child exited {child.returncode} without taking the "
+                    f"claim over; transcript:\n{text}\n"
+                    f"child output:\n{child_log.read_text(errors='replace')[-4000:]}"
+                )
+        finally:
+            child.kill()
+            child.wait(timeout=10)
+
+        # The claim that outlives this test is the runtime's, not the corpse's:
+        # the child rewrote it when it took over, so a later attach is refused by
+        # the live owner rather than recovering a dead one twice.
+        recovered = json.loads(claim.read_text(encoding="utf-8"))
+        assert recovered["pid"] != zombie_pid
+        assert recovered["generation"] != "c" * 32

--- a/tests/e2e/test_zombie_lease_recovery_e2e.py
+++ b/tests/e2e/test_zombie_lease_recovery_e2e.py
@@ -84,13 +84,24 @@ def test_a_runtime_takes_over_a_claim_held_by_a_zombie(tmp_path: Path) -> None:
     # HOME as well as the config dir: the cache root is derived from the home
     # directory independently, so a run isolated by config dir alone still
     # reads and writes the operator's real cache (see AGENTS.md).
-    env = {
-        **os.environ,
-        "HOME": str(tmp_path),
-        "LOCAL_OPERATOR_CONFIG_DIR": str(tmp_path),
-        "LOP_MOBILE_CHILD_CWD": str(tmp_path),
-        "LOP_MOBILE_CHILD_RESUME": SESSION_ID,
-    }
+    #
+    # And SCRUB the two prefixes a lop parent exports, because a runtime child
+    # reads `LOP_*` directly (`session/runtime/process.py::amain`): a cell run
+    # from inside another session otherwise inherits its provider, model and
+    # deferral flags, and is silently not the cell it claims to be. QA round 1
+    # hit exactly that — an inherited `LOP_MOBILE_CHILD_PROVIDER` resolved a
+    # provider the fixture never chose, and an inherited deferral flag made a
+    # child idle-exit with no work at all, which would have "proved" nothing.
+    # Only the names this test means to set are put back.
+    env = {key: value for key, value in os.environ.items() if not key.startswith(("LOP_", "CMUX_"))}
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "LOCAL_OPERATOR_CONFIG_DIR": str(tmp_path),
+            "LOP_MOBILE_CHILD_CWD": str(tmp_path),
+            "LOP_MOBILE_CHILD_RESUME": SESSION_ID,
+        }
+    )
 
     with unreaped_child() as zombie_pid:
         claim = session_dir / ".execution-lease"

--- a/tests/unit/mobile/test_phone_startup.py
+++ b/tests/unit/mobile/test_phone_startup.py
@@ -283,7 +283,7 @@ async def test_different_owner_is_never_acknowledged_as_spawned_pid(
 
     queries = 0
 
-    def swapped_owner(_config, session_id):
+    def swapped_owner(_config, session_id, **_probe):
         nonlocal queries
         queries += 1
         # No owner before spawn; another owner wins its lease before our

--- a/tests/unit/session/runtime/test_eager_runtime.py
+++ b/tests/unit/session/runtime/test_eager_runtime.py
@@ -481,7 +481,7 @@ async def test_an_engage_that_lands_after_dispose_does_not_bind(
         parked.set()
         await release.wait()
 
-    def fake_find(config_dir, session_id):  # noqa: ANN001
+    def fake_find(config_dir, session_id, **_probe):  # noqa: ANN001
         nonlocal looked_for_record
         looked_for_record = True
         return None, None

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -325,6 +325,12 @@ async def test_a_claim_held_by_a_zombie_is_recovered_not_waited_on(
     which is the phone's first message to such a session never starting a
     runtime. With the owner proven dead the loop spawns, and that candidate's
     real ``acquire_session_lease`` takes the claim over.
+
+    The recovery is not instant by design: the proof is deferred until the loop
+    has believed "constructing" for longer than ``_CONSTRUCTING_WINDOW_S`` (see
+    the fork-free dense test below), so a corpse's session comes back a couple
+    of seconds late rather than never. The 15 s cap is well clear of that and
+    still fails on the unfixed code, which waits out the whole 30 s.
     """
     from tests.unreaped import unreaped_child
 
@@ -356,6 +362,59 @@ async def test_a_claim_held_by_a_zombie_is_recovered_not_waited_on(
     assert fleet.winners == 1, "the zombie's claim was never taken over"
     assert fleet.losers == 0, "the corpse was read as a live contender"
     assert fleet.deferred == [True]
+
+
+@pytest.mark.asyncio
+async def test_the_dense_starting_window_pays_no_zombie_probe(tmp_path: Path, monkeypatch) -> None:
+    """The proof is DEFERRED so the densest cadence stays fork-free (MAJOR-1).
+
+    A claim that is held while no record exists is read as a construction in
+    flight, and the loop then polls every 10 ms against a published budget of
+    23-30 µs per iteration (``_poll_delay``). Proving that the holder is a
+    corpse — rather than a pid signal 0 merely accepts — costs a `ps` fork
+    measured at 2.4-3.0 ms on this class of host: nearly double the dense
+    period, paid straight out of the dead time the dense grid exists to remove.
+    So the loop asks for the cheap answer while that belief is fresh and spends
+    the proof only once ``_CONSTRUCTING_WINDOW_S`` has lapsed. This pins it: a
+    live holder that never publishes must produce ZERO zombie probes while the
+    loop is inside the window.
+
+    The deferral is a LATENCY trade and never a safety one — only
+    ``session_lease`` may move a claim, and it always demands the proof — so the
+    test above shows the other end: a corpse's claim IS taken over once the
+    window lapses.
+    """
+    from local_operator import session_lease
+
+    probes: list[int] = []
+    real_probe = session_lease.is_zombie
+    monkeypatch.setattr(
+        session_lease,
+        "is_zombie",
+        lambda pid: (probes.append(pid), real_probe(pid))[1],
+    )
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    session_dir = tmp_path / "sessions" / SESSION_ID
+    session_dir.mkdir(parents=True, exist_ok=True)
+    # A LIVE holder that never publishes: the loop's STARTING branch. The
+    # deadline is shorter than the window on purpose, so every pass under test
+    # is a dense one.
+    holder = acquire_session_lease(session_dir)
+    try:
+        with pytest.raises(TimeoutError):
+            await engage_runtime(
+                SESSION_ID,
+                str(tmp_path),
+                WarmErrand(),
+                config_dir=tmp_path,
+                deadline_s=1.0,
+            )
+    finally:
+        holder.release()
+
+    assert probes == [], "the dense regime forked a zombie probe on a pass"
+    assert _CONSTRUCTING_WINDOW_S > 1.0, "this test's deadline must sit inside the window"
 
 
 @pytest.mark.asyncio
@@ -994,7 +1053,14 @@ async def test_a_published_record_that_refuses_the_dial_is_not_polled_densely(
         "local_operator.mobile.attach_client.find_runtime_record",
         lambda config_dir, session_id: (record, os.getpid()),
     )
-    monkeypatch.setattr(launch_module, "_lease_holder", lambda config_dir, session_id: os.getpid())
+    monkeypatch.setattr(
+        launch_module,
+        "_lease_holder",
+        # Mirrors the real signature, including the probe-mode keyword the loop
+        # passes: a double that accepted fewer arguments than the function under
+        # test would fail the moment the loop's call shape changed.
+        lambda config_dir, session_id, **_probe: os.getpid(),
+    )
 
     dials = 0
 

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -326,11 +326,10 @@ async def test_a_claim_held_by_a_zombie_is_recovered_not_waited_on(
     runtime. With the owner proven dead the loop spawns, and that candidate's
     real ``acquire_session_lease`` takes the claim over.
 
-    The recovery is not instant by design: the proof is deferred until the loop
-    has believed "constructing" for longer than ``_CONSTRUCTING_WINDOW_S`` (see
-    the fork-free dense test below), so a corpse's session comes back a couple
-    of seconds late rather than never. The 15 s cap is well clear of that and
-    still fails on the unfixed code, which waits out the whole 30 s.
+    Recovery is on the FIRST pass, and that is the point of deferring only on the
+    dense grid rather than on elapsed time: a holder nobody can prove live yet is
+    proven dead immediately, so this pays neither the old 30 s wait nor a
+    window-sized stall. The 15 s cap is only a hang guard.
     """
     from tests.unreaped import unreaped_child
 
@@ -364,42 +363,80 @@ async def test_a_claim_held_by_a_zombie_is_recovered_not_waited_on(
     assert fleet.deferred == [True]
 
 
+def _count_every_corpse_probe(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Count calls to the zombie probe from EVERY module that has bound it.
+
+    Patching one caller is not enough, and that is a finding rather than a
+    nicety: the loop asks the same question twice per pass — once through
+    ``find_runtime_record``'s owner lookup and once through ``_lease_holder`` —
+    so a counter wired to one of them reports a fork-free grid while the other
+    forks (QA round 2, Q1). The carriers are discovered by identity from
+    ``sys.modules`` after the two modules are imported explicitly, so the
+    instrument names what it counts, and a third binding site would be counted
+    the day it is written. Residual, and deliberately visible: a module that
+    binds the probe for the FIRST time after this call would not be counted,
+    which is why the expected carriers are asserted below.
+
+    Counts INVOCATIONS, not forks: on Linux ``is_zombie`` answers from ``/proc``
+    without forking, but the expensive question is asked either way, and that is
+    the thing a dense grid must not do.
+    """
+    from local_operator import procstate
+    from local_operator import resume as resume_module  # binds the probe too
+    from local_operator import session_lease as lease_module  # and so does this
+
+    real = procstate.is_zombie
+    calls: list[int] = []
+
+    def counting(pid: int) -> bool:
+        calls.append(pid)
+        return real(pid)
+
+    holders = []
+    for module in list(sys.modules.values()):
+        try:
+            if getattr(module, "is_zombie", None) is real:
+                holders.append(module)
+        except Exception:  # noqa: BLE001 — a module with a raising __getattr__
+            continue
+    names = {module.__name__ for module in holders}
+    assert {
+        lease_module.__name__,
+        resume_module.__name__,
+    } <= names, f"not every carrier is imported, so this counter is partial: {sorted(names)}"
+    for module in holders:
+        monkeypatch.setattr(module, "is_zombie", counting)
+    return calls
+
+
 @pytest.mark.asyncio
-async def test_the_dense_starting_window_pays_no_zombie_probe(tmp_path: Path, monkeypatch) -> None:
-    """The proof is DEFERRED so the densest cadence stays fork-free (MAJOR-1).
+async def test_the_dense_starting_window_pays_no_corpse_probe(tmp_path: Path, monkeypatch) -> None:
+    """The proofs are DEFERRED so the densest cadence stays fork-free (MAJOR-1).
 
     A claim that is held while no record exists is read as a construction in
     flight, and the loop then polls every 10 ms against a published budget of
-    23-30 µs per iteration (``_poll_delay``). Proving that the holder is a
-    corpse — rather than a pid signal 0 merely accepts — costs a `ps` fork
-    measured at 2.4-3.0 ms on this class of host: nearly double the dense
-    period, paid straight out of the dead time the dense grid exists to remove.
-    So the loop asks for the cheap answer while that belief is fresh and spends
-    the proof only once ``_CONSTRUCTING_WINDOW_S`` has lapsed. This pins it: a
-    live holder that never publishes must produce ZERO zombie probes while the
-    loop is inside the window.
+    23-30 µs per iteration (``_poll_delay``). Proving that a holder is a corpse —
+    rather than a pid signal 0 merely accepts — costs a `ps` fork measured at
+    2.4-4.6 ms across runs on this class of host: 24-46% of the dense period,
+    paid straight out of the dead time the dense grid exists to remove. So the
+    grid asks only the cheap question, and this pins it: a live holder that never
+    publishes may cost ONE pass's worth of proof (the pass that first observes
+    the holder, before any grid is in force) and nothing thereafter, however long
+    the loop stays inside that grid.
 
-    The deferral is a LATENCY trade and never a safety one — only
-    ``session_lease`` may move a claim, and it always demands the proof — so the
-    test above shows the other end: a corpse's claim IS taken over once the
-    window lapses.
+    The deferral is a LATENCY trade and never a safety one — only the spawned
+    child's ``acquire_session_lease`` may take a claim, and it always demands the
+    proof — so the tests around this one show both other ends: a corpse's claim
+    IS taken over, and the proof IS spent once the grid goes coarse.
     """
-    from local_operator import session_lease
-
-    probes: list[int] = []
-    real_probe = session_lease.is_zombie
-    monkeypatch.setattr(
-        session_lease,
-        "is_zombie",
-        lambda pid: (probes.append(pid), real_probe(pid))[1],
-    )
+    probes = _count_every_corpse_probe(monkeypatch)
 
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     session_dir = tmp_path / "sessions" / SESSION_ID
     session_dir.mkdir(parents=True, exist_ok=True)
     # A LIVE holder that never publishes: the loop's STARTING branch. The
-    # deadline is shorter than the window on purpose, so every pass under test
-    # is a dense one.
+    # deadline is shorter than the window on purpose, so every pass under test is
+    # a dense one.
     holder = acquire_session_lease(session_dir)
     try:
         with pytest.raises(TimeoutError):
@@ -413,8 +450,50 @@ async def test_the_dense_starting_window_pays_no_zombie_probe(tmp_path: Path, mo
     finally:
         holder.release()
 
-    assert probes == [], "the dense regime forked a zombie probe on a pass"
+    # TWO probes is exactly one pass's worth: the first pass is not yet a DENSE
+    # one (nothing was believed to be constructing until it observed the holder),
+    # and it spends the proof on both of its probes. Every pass after it is dense
+    # and spends none — a grid that forked per pass would have made ~200 calls in
+    # this second, which is the number QA round 2 measured before this fix.
+    assert len(probes) <= 2, f"a dense pass spent the corpse proof: {probes[:5]}"
     assert _CONSTRUCTING_WINDOW_S > 1.0, "this test's deadline must sit inside the window"
+
+
+@pytest.mark.asyncio
+async def test_the_corpse_proof_is_spent_once_the_grid_goes_coarse(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The other half of the trade: the deferral is keyed to the CADENCE.
+
+    If it were keyed to elapsed time instead, the loop would keep asking the
+    cheap question while it waits for a construction that never comes — and a
+    corpse's claim would then be waited on rather than proven dead, which is the
+    wedge this branch exists to remove. So the proof must appear as soon as the
+    grid is the coarse one, and at the COARSE rate: a handful of probes across
+    0.6 s, not the ~60 passes a 10 ms grid would make.
+    """
+    probes = _count_every_corpse_probe(monkeypatch)
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    session_dir = tmp_path / "sessions" / SESSION_ID
+    session_dir.mkdir(parents=True, exist_ok=True)
+    holder = acquire_session_lease(session_dir)
+    try:
+        with pytest.raises(TimeoutError):
+            await engage_runtime(
+                SESSION_ID,
+                str(tmp_path),
+                WarmErrand(),
+                config_dir=tmp_path,
+                deadline_s=_CONSTRUCTING_WINDOW_S + 0.6,
+            )
+    finally:
+        holder.release()
+
+    assert probes, "the proof was never spent: a corpse would be waited on, not recovered"
+    # Two probes per pass on the coarse grid (discovery + lease), ~5 passes in
+    # 0.6 s; a dense grid would be ~60 passes.
+    assert len(probes) <= 25, f"{len(probes)} probes in a 0.6 s coarse tail is still a dense fork"
 
 
 @pytest.mark.asyncio
@@ -1051,7 +1130,11 @@ async def test_a_published_record_that_refuses_the_dial_is_not_polled_densely(
     # function-local import in the loop, so it is patched at its source module.
     monkeypatch.setattr(
         "local_operator.mobile.attach_client.find_runtime_record",
-        lambda config_dir, session_id: (record, os.getpid()),
+        # Mirrors the real signature, including the probe-mode keyword the loop
+        # passes on every call. A double that accepts fewer arguments than the
+        # function under test fails the moment the call shape changes, which is
+        # the point: the loop asks two probes per pass and both carry it.
+        lambda config_dir, session_id, **_probe: (record, os.getpid()),
     )
     monkeypatch.setattr(
         launch_module,

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -312,6 +312,53 @@ async def test_engaging_during_construction_waits_instead_of_spawning(
 
 
 @pytest.mark.asyncio
+async def test_a_claim_held_by_a_zombie_is_recovered_not_waited_on(
+    fleet: FakeRuntimeFleet, tmp_path: Path
+) -> None:
+    """A corpse is not a constructor: engage must spawn, and the spawn must win.
+
+    The loop reads "a lease with no record" as someone mid-construction and
+    waits for their record rather than spawning a doomed twin. That reading was
+    wrong for a claim whose owner had exited without being reaped — the pid is
+    still in the process table, so signal 0 called it a live constructor — and
+    the cost was the whole deadline (30 s) followed by a failure naming nobody,
+    which is the phone's first message to such a session never starting a
+    runtime. With the owner proven dead the loop spawns, and that candidate's
+    real ``acquire_session_lease`` takes the claim over.
+    """
+    from tests.unreaped import unreaped_child
+
+    session_dir = tmp_path / "sessions" / SESSION_ID
+    session_dir.mkdir(parents=True, exist_ok=True)
+    fleet.loop = asyncio.get_running_loop()
+    with unreaped_child() as zombie_pid:
+        (session_dir / ".execution-lease").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "session_id": SESSION_ID,
+                    "generation": "d" * 32,
+                    "pid": zombie_pid,
+                },
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        (session_dir / ".session.pid").write_text(str(zombie_pid), encoding="utf-8")
+
+        # Shorter than the loop's own 30 s deadline: if the corpse is read as a
+        # constructor, this raises TimeoutError rather than passing late.
+        await asyncio.wait_for(
+            engage_runtime(SESSION_ID, str(tmp_path), WarmErrand(), config_dir=tmp_path),
+            timeout=15,
+        )
+
+    assert fleet.winners == 1, "the zombie's claim was never taken over"
+    assert fleet.losers == 0, "the corpse was read as a live contender"
+    assert fleet.deferred == [True]
+
+
+@pytest.mark.asyncio
 async def test_warm_errand_defers_materialisation_and_others_do_not(
     fleet: FakeRuntimeFleet, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_cli_resume_guard.py
+++ b/tests/unit/test_cli_resume_guard.py
@@ -64,6 +64,48 @@ def test_exec_resume_unowned_proceeds_to_exec(config: Path, monkeypatch) -> None
     assert seen and seen[0][0] == "task"
 
 
+def test_exec_resume_zombie_owner_proceeds_to_exec(config: Path, monkeypatch) -> None:
+    """A killed runtime's corpse is not "another process".
+
+    The guard's premise is that a pid in the marker means someone is hosting
+    the session and this process must not become a second writer. Signal 0 is
+    not enough to establish that: it succeeds against an exited-but-unreaped
+    process, which is exactly what a SIGKILLed runtime leaves behind when its
+    parent (a long-lived TUI) never reaps it. The reported symptom was a
+    session refused by every interface with "already open in another process
+    (pid N)", where N was a corpse — so the guard must not fire here, and the
+    exec must proceed.
+    """
+    from tests.unreaped import unreaped_child
+
+    seen: list[tuple[object, object]] = []
+
+    def fake_run_exec(command, args):  # noqa: ANN001
+        seen.append((command, args))
+        return 0
+
+    monkeypatch.setattr(
+        "local_operator.exec_mode.resolve_hosting_model_dry",
+        lambda a: ("anthropic", "claude-x"),
+        raising=False,
+    )
+    import local_operator.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_preflight_api_key", lambda *a, **k: None)
+    monkeypatch.setattr("local_operator.exec_mode.run_exec", fake_run_exec)
+    # Held for the whole assertion: the marker must name a pid that is a zombie
+    # at the moment the guard probes it, not one that has been reaped since.
+    with unreaped_child() as zombie_pid:
+        _own(config, "sess-zombie", zombie_pid)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["local-operator", "exec", "--resume", "sess-zombie", "do the thing"],
+        )
+        code = cli_main()
+    assert code == 0
+    assert seen and seen[0][0] == "do the thing"
+
+
 def test_standalone_attach_modules_are_deleted() -> None:
     """Cold resume cannot regress to the projection screen or exit-75 shim."""
     import importlib.util

--- a/tests/unit/test_procstate.py
+++ b/tests/unit/test_procstate.py
@@ -1,0 +1,105 @@
+"""The shared liveness probe: a zombie is not a live process.
+
+Three modules act on this one answer, so the cost of getting it wrong is not a
+misleading log line but a disagreement between them: discovery reaping a record
+whose owner is gone while the lease keeps reporting that same owner as live is
+a session that `lop sessions` calls "stored" and no interface will open. The
+last test in this file asserts that agreement directly, because that, not the
+probe's return value, is what the incident was made of.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator import procstate
+from tests.unreaped import unreaped_child
+
+
+def test_a_live_process_is_not_a_zombie() -> None:
+    assert procstate.is_zombie(os.getpid()) is False
+    # pid 1 is this platform's init (launchd/systemd) and never a zombie.
+    assert procstate.is_zombie(1) is False
+
+
+def test_zero_and_negative_pids_are_not_zombies() -> None:
+    """Guarded rather than probed: ``ps -p 0`` would answer about a whole group."""
+    assert procstate.is_zombie(0) is False
+    assert procstate.is_zombie(-1) is False
+
+
+def test_a_pid_that_does_not_exist_is_not_a_zombie() -> None:
+    """Fails closed with no exception — the caller decides, the probe does not."""
+    assert procstate.is_zombie(2_147_483_600) is False
+
+
+def test_a_killed_child_is_a_zombie_until_it_is_reaped() -> None:
+    """Signal 0 cannot see the difference; this probe is what does.
+
+    The first assertion is the whole reason the module exists: it passes for a
+    process that has already exited.
+    """
+    with unreaped_child() as pid:
+        os.kill(pid, 0)  # succeeds against a corpse: no exception
+        assert procstate.is_zombie(pid) is True
+    # Reaped: the pid is genuinely gone, and the probe says so.
+    assert procstate.is_zombie(pid) is False
+
+
+def test_an_unprobeable_pid_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Doubt must read as "alive".
+
+    A probe that answered "zombie" because it could not look would let a second
+    writer take a transcript a working runtime is still appending to. That trade
+    is the one this module must never make.
+    """
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise OSError("cannot probe")
+
+    monkeypatch.setattr(procstate.subprocess, "run", _boom)
+    # A pid with no /proc entry (and none on macOS), so the POSIX fork is the
+    # path taken into the failure.
+    assert procstate.is_zombie(2_147_483_600) is False
+
+
+def test_the_lease_the_scan_and_the_attach_guard_agree_about_a_zombie(
+    tmp_path: Path,
+) -> None:
+    """THE REGRESSION, at the level it hurt: three callers, one answer.
+
+    Each of these knew a different thing about the same corpse. Discovery
+    already probed for zombies, so it reaped the record and `lop sessions`
+    showed the session as merely "stored"; the lease did not, so its claim
+    stayed held; and the attach guard read the claim marker and told the user
+    the session was "already open in pid N". The session was therefore
+    un-attachable from the TUI, from `lop exec --resume` and from the phone,
+    while appearing idle everywhere else.
+    """
+    from local_operator.resume import live_runtime_pid
+    from local_operator.session.runtime.registry import pid_alive
+    from local_operator.session_lease import _pid_state
+
+    session_id = "agreeszombie"
+    session_dir = tmp_path / "sessions" / session_id
+    session_dir.mkdir(parents=True)
+    (session_dir / "transcript.jsonl").write_text("")
+    with unreaped_child() as pid:
+        (session_dir / ".session.pid").write_text(str(pid), encoding="utf-8")
+        (session_dir / ".execution-lease").write_text(
+            json.dumps(
+                {"schema": 1, "session_id": session_id, "generation": "zombie", "pid": pid},
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        # Discovery: gone, so the record is reapable and the row is "stored".
+        assert pid_alive(pid, check_zombie=True) is False
+        # The lease: proven dead, so the claim may be taken over.
+        assert _pid_state(pid) == "dead"
+        # The attach guard: nobody is running it, so offer the session.
+        assert live_runtime_pid(tmp_path, session_id) is None

--- a/tests/unit/test_session_lease.py
+++ b/tests/unit/test_session_lease.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import multiprocessing
 import os
 import threading
 from pathlib import Path
+
+import pytest
 
 from local_operator import session_lease as lease_mod
 from local_operator.session_lease import (
@@ -159,6 +162,68 @@ def test_daemon_reap_never_removes_live_successor(tmp_path: Path) -> None:
     assert not reap_proven_dead_session_claim(session_dir, dead_pid)
     assert (session_dir / LEASE_NAME).exists()
     successor.release()
+
+
+def test_a_zombie_owner_does_not_hold_the_claim(tmp_path: Path) -> None:
+    """An exited-but-unreaped owner is a dead owner, and its claim is takeable.
+
+    ``os.kill(pid, 0)`` succeeds against a zombie, so a liveness probe built on
+    it alone reported the corpse of a killed runtime as a working owner — and
+    because both acquisition and the recovery helper require a holder to be
+    PROVEN dead, nothing could ever move that claim. The operator's session was
+    then un-attachable from every interface while its transcript sat intact.
+    """
+    from tests.unreaped import unreaped_child
+
+    session_dir = tmp_path / "sessions" / "zombie-owner"
+    with unreaped_child() as zombie_pid:
+        _write_stale_claim(session_dir, pid=zombie_pid)
+        # Must not raise: the claim is recovered, not respected.
+        lease = acquire_session_lease(session_dir)
+        try:
+            assert lease.pid == os.getpid()
+            claim = json.loads((session_dir / LEASE_NAME).read_text(encoding="utf-8"))
+            assert claim["pid"] == os.getpid()
+            assert claim["generation"] == lease.generation
+            assert (session_dir / ".session.pid").read_text(encoding="utf-8") == str(os.getpid())
+        finally:
+            lease.release()
+
+
+def test_daemon_reap_removes_a_zombie_owners_claim(tmp_path: Path) -> None:
+    """The reaper's own gate: it removes a claim only for a proven-dead owner.
+
+    A zombie is that proof — the process has exited — so the same discovery
+    pass that reaps the record must be able to reap the claim it was holding.
+    """
+    from tests.unreaped import unreaped_child
+
+    session_dir = tmp_path / "sessions" / "zombie-reap"
+    with unreaped_child() as zombie_pid:
+        _write_stale_claim(session_dir, pid=zombie_pid)
+        assert reap_proven_dead_session_claim(session_dir, zombie_pid)
+        assert not (session_dir / LEASE_NAME).exists()
+        assert not (session_dir / ".session.pid").exists()
+
+
+def test_a_live_owner_still_holds_its_claim_against_a_zombie_probe(
+    tmp_path: Path,
+) -> None:
+    """The other half of the rule: the zombie probe must not free a LIVE claim.
+
+    Asking the process table a new question is exactly the kind of change that
+    can turn a refusal into a takeover, so this pins the refusal that must
+    survive it: a holder that is running is not stealable, by acquisition or by
+    the reaper.
+    """
+    session_dir = tmp_path / "sessions" / "live-owner"
+    session_dir.mkdir(parents=True)
+    live_pid = os.getppid()  # a running process that is not this one
+    _write_stale_claim(session_dir, pid=live_pid)
+    with pytest.raises(SessionLeaseHeldError):
+        acquire_session_lease(session_dir)
+    assert not reap_proven_dead_session_claim(session_dir, live_pid)
+    assert json.loads((session_dir / LEASE_NAME).read_text(encoding="utf-8"))["pid"] == live_pid
 
 
 def test_stale_release_cannot_unlink_successor_claim(tmp_path: Path) -> None:

--- a/tests/unit/tui/test_resume_connect_retry.py
+++ b/tests/unit/tui/test_resume_connect_retry.py
@@ -413,7 +413,7 @@ async def test_the_runtime_record_is_re_read_before_every_attempt(monkeypatch, t
     lookups: list[str] = []
     dialled: list[Any] = []
 
-    def lookup(_root, concrete):
+    def lookup(_root, concrete, **_probe):
         lookups.append(concrete)
         return (first, 90909) if len(lookups) == 1 else (republished, 91555)
 
@@ -506,7 +506,7 @@ async def test_an_empty_record_on_the_first_attempt_is_paced_not_refused(monkeyp
     dials: list[Any] = []
     seen: list[list[str]] = []
 
-    def lookup(_root, concrete):
+    def lookup(_root, concrete, **_probe):
         lookups.append(concrete)
         return (None, None) if len(lookups) == 1 else (record, 90909)
 

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -190,7 +190,7 @@ async def live_owners(
             await server.start_in_process()
             servers[session_id] = server
 
-        def find(_directory: Path, session_id: str) -> tuple[Any, Any]:
+        def find(_directory: Path, session_id: str, **_probe: Any) -> tuple[Any, Any]:
             server = servers.get(session_id)
             return (server._record, server._record.pid) if server else (None, None)
 

--- a/tests/unit/tui/test_sidebar_longrun.py
+++ b/tests/unit/tui/test_sidebar_longrun.py
@@ -169,7 +169,7 @@ async def live_owners(
             await server.start_in_process()
             servers[sid] = server
 
-        def find(_directory: Path, sid: str) -> tuple[Any, Any]:
+        def find(_directory: Path, sid: str, **_probe: Any) -> tuple[Any, Any]:
             server = servers.get(sid)
             return (server._record, server._record.pid) if server else (None, None)
 

--- a/tests/unit/tui/test_sidebar_peer_receipt.py
+++ b/tests/unit/tui/test_sidebar_peer_receipt.py
@@ -112,7 +112,7 @@ async def live_owners(
             await server.start_in_process()
             servers[session_id] = server
 
-        def find(_directory: Path, session_id: str) -> tuple[Any, Any]:
+        def find(_directory: Path, session_id: str, **_probe: Any) -> tuple[Any, Any]:
             server = servers.get(session_id)
             return (server._record, server._record.pid) if server else (None, None)
 

--- a/tests/unreaped.py
+++ b/tests/unreaped.py
@@ -1,0 +1,77 @@
+"""A real exited-but-unreaped process, for tests of liveness probes.
+
+A zombie is the one process state that ``kill(pid, 0)`` cannot tell apart from a
+running process, and it is what a killed runtime leaves behind when its parent —
+usually a long-lived TUI — never reaps it. Testing anything that depends on
+seeing through that state needs a genuine zombie, and producing one has two
+requirements that are easy to lose:
+
+1. **It must be a child of the test process.** Only the parent can reap it. A
+   helper that spawns a child and then exits hands it to the init process, which
+   reaps it immediately, and the window a test needs closes with it.
+
+2. **Its ``Popen`` object must stay referenced for as long as the test needs
+   it.** ``subprocess`` reaps the instances it has finalised, on the next
+   ``Popen`` it creates (``_cleanup``); an instance the test still holds is not
+   in that list, so the zombie survives the probe's own ``ps`` fork. Dropping
+   the last reference and letting ``__del__`` run would let the very next probe
+   reap it — the test would then assert against a pid that is fully dead, which
+   is the state every probe already agreed on, and it would pass without ever
+   exercising the zombie case it was written for.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+#: How long to wait for the kernel to move the killed child to ``Z``. Normally
+#: immediate; generous so a loaded CI runner reports a real failure rather than
+#: a scheduling race.
+_ZOMBIE_TIMEOUT_S = 10.0
+
+
+def process_state(pid: int) -> str:
+    """The process table's state letter for ``pid``, or ``""`` once it is gone.
+
+    Linux answers from ``/proc``; macOS has no ``/proc`` and needs the ``ps``
+    fork, exactly as :func:`local_operator.procstate.is_zombie` documents.
+    """
+    proc_status = Path(f"/proc/{pid}/stat")
+    if proc_status.exists():
+        # `comm` can contain spaces and parentheses; state is the field after
+        # the LAST ')'.
+        return proc_status.read_text().rpartition(")")[2].strip()[:1]
+    result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+        ["/bin/ps", "-o", "state=", "-p", str(pid)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip()[:1]
+
+
+@contextmanager
+def unreaped_child() -> Iterator[int]:
+    """Yield the pid of a real zombie, then reap it on the way out.
+
+    The child is killed and deliberately left unreaped for the whole block, so
+    ``os.kill(pid, 0)`` succeeds against it for as long as the caller holds it —
+    which is precisely the state a liveness probe has to see through.
+    """
+    proc = subprocess.Popen(["sleep", "60"])  # noqa: S603,S607 — fixed argv
+    try:
+        proc.kill()
+        deadline = time.monotonic() + _ZOMBIE_TIMEOUT_S
+        state = process_state(proc.pid)
+        while not state.startswith("Z") and time.monotonic() < deadline:
+            time.sleep(0.02)
+            state = process_state(proc.pid)
+        if not state.startswith("Z"):
+            raise AssertionError(f"child {proc.pid} never became a zombie (state {state!r})")
+        yield proc.pid
+    finally:
+        proc.wait(timeout=10)


### PR DESCRIPTION
# PR Description

## Summary of Changes

A session whose runtime is killed becomes **permanently impossible to open** — from the TUI, from
`lop exec --resume`, and from the phone — while `lop sessions` shows it as merely "stored". The
cause is one process state that `kill(pid, 0)` cannot see: a **zombie**. A SIGKILLed runtime leaves
its transcript claim behind, and when its parent is a long-lived TUI that never reaps it, the pid
stays in the process table answering signal 0. Every probe built on signal 0 alone therefore called
the corpse a working owner, and since both `acquire_session_lease` and
`reap_proven_dead_session_claim` require a holder to be **proven dead**, nothing could ever move
that claim. It was not a race and not a delay: the pid is not reused while it lingers, so the
session was unrecoverable indefinitely.

`registry` had already learned this lesson for discovery records (round 3, U10 — a SIGKILLed
runtime reporting `live` with `0B` RSS); the lease and the attach guard had not, so the three
probes disagreed about one corpse. This change gives them one implementation, in a new stdlib-only
leaf module, and makes it zombie-aware at all three decisions: may this claim be acquired, may this
record be reaped, and should an attach be offered at all.

Release: patch — a session whose runtime was killed no longer reports a corpse as its owner, so it
can be opened again instead of being refused as "already open" forever

## Related Issue(s)

- Related: none — reported by the operator as a session that no interface would attach to
  ("Subagent and todo UX for local UI", `833188c87e7d`); diagnosed on this machine, and two further
  sessions (`70313f4b7836`, `f91fbda61750`) were found in the identical state.

## The mechanism

Three modules ask "is this pid still a process?" and each acts on the answer:

| caller | question it decides |
| --- | --- |
| `session.runtime.registry.pid_alive(pid, check_zombie=...)` | may this discovery record be reaped? |
| `session_lease._pid_state(pid)` | may this transcript claim be acquired or reaped? |
| `resume.live_runtime_pid(cfg, sid)` | should an attach be offered, or refused as "in use"? |

Only the first one probed for zombies. On the bricked session they answered, about the same corpse:

```
registry.pid_alive(94559, check_zombie=True) -> False   # gone: reap the record
session_lease._pid_state(94559)              -> 'live'  # held: claim untouchable
resume.live_runtime_pid(cfg, "833188c87e7d") -> 94559   # busy: refuse the attach
```

So discovery reaped the record (which is why the session appeared as an ordinary stored row) while
the claim it left behind stayed held, and the lease refusal fed the attach refusal. `ps` on that
pid: `94559 91937 Z <defunct>` — parent `91937` (`lop --resume 98b771fe8fe1`, up 7h30m) never waited
on it.

The `engage_runtime` loop has a third symptom from the same wrong answer: a lease whose pid looks
live and has published no record is read as "someone is constructing right now", so the loop waits
for a record that cannot come — the full 30 s deadline, then a failure naming nobody. That is the
phone's first message to such a session never starting a runtime.

## What changed

- `local_operator/procstate.py` (new)
  - One implementation of the zombie probe (`is_zombie`), moved verbatim out of `registry` and
    given the incident rationale. A leaf module with no local imports is the only home that
    satisfies all three callers: `registry` sits on the CLI startup path, and `session_lease` and
    `resume` must stay consultable without the engine or the mobile stack. It fails **closed** on
    any doubt, because calling a live process dead would let a second writer take a transcript a
    working runtime is still appending to.
  - Windows short-circuits to `False`: there is no zombie state there, and liveness is a handle
    question, so returning early is the answer the doomed `/bin/ps` fork would have reached anyway.
- `local_operator/session_lease.py`
  - `_pid_state` returns `"dead"` for a zombie instead of `"live"`. The fork is spent **only after**
    the cheap probe has already said "live", so the common answers — a live owner, and a pid that
    is simply gone — stay fork-free; that was the reason the probe was opt-in in `registry`.
  - `PermissionError` (another account's process) still fails closed, now with the reason stated.
- `local_operator/session/runtime/registry.py`
  - `_is_zombie` is deleted and `pid_alive` calls the shared probe. `pid_alive`'s own contract —
    cheap by default, `check_zombie=True` where the answer changes what a user is told — is
    unchanged, as is the existing assertion that the cheap path still reports a zombie as alive.
- `local_operator/resume.py`
  - `live_runtime_pid` returns `None` for a zombie marker. This is the call that produced the
    operator-visible refusal, so it is the call that has to stop making it. The Windows F2
    early-return is untouched (there is no zombie state to probe, and `os.kill` terminates there).
- Tests: `tests/unreaped.py` (shared helper for a real zombie), `tests/unit/test_procstate.py`,
  new cases in `test_session_lease.py`, `test_launch_arbitration.py`, `test_cli_resume_guard.py`,
  and `tests/e2e/test_zombie_lease_recovery_e2e.py`.
  - `tests/unreaped.py` documents the two requirements that make a zombie usable in a test, both of
    which are silent when wrong: the killed child must be the **test process's own** (a helper that
    exits hands it to init, which reaps it), and its `Popen` must stay **referenced** (subprocess
    reaps the instances it has finalised on the next `Popen` it creates — so the probe's own `ps`
    fork would reap the zombie and the test would then "pass" against a fully dead pid).

## Testing Details

All runs are on this branch's worktree with its own venv (`…/lo-zombie-lease`), product code
verified to resolve from that tree.

### 1. The incident, on the live machine, before any change

`ps -p 94559 -o stat` → `Z`; `os.kill(94559, 0)` succeeds; nothing holds the session directory open
(`lsof +D` empty); the transcript is intact (493/493 JSONL rows parse) and unchanged since 14:29.

```
$ LOCAL_OPERATOR_CONFIG_DIR=<isolated copy> lop exec --resume 833188c87e7d "say hi"
session 833188c87e7d is already open in another process (pid 94559) — watch and steer it there,
or from the phone session list
```

### 2. Before/after on REAL sessions, same directories, same corpses

Two other sessions on this machine were in the identical state, so the fix was measured against
them rather than against a synthetic fixture (unfixed tree = the installed 0.54.x code):

```
########## BEFORE — unfixed ##########
70313f4b7836: lease_pid=95244 ps_state='Z' live_runtime_pid=95244
    acquire_session_lease -> REFUSED (… already open in pid 95244 …)
f91fbda61750: lease_pid=18225 ps_state='Z' live_runtime_pid=18225
    acquire_session_lease -> REFUSED (… already open in pid 18225 …)

########## AFTER — fixed ##########
70313f4b7836: lease_pid=95244 ps_state='Z' live_runtime_pid=None
    acquire_session_lease -> ACQUIRED (pid 59083)
f91fbda61750: lease_pid=18225 ps_state='Z' live_runtime_pid=None
    acquire_session_lease -> ACQUIRED (pid 59083)
```

### 3. The new tests fail on the unfixed code, each for its own reason

Run against a worktree of `origin/main@c938fead6` with only these test files copied in (verified
`session_lease.is_zombie` absent there):

```
1) tests/unit/test_procstate.py                        ERROR: collection (module does not exist)
2) test_a_zombie_owner_does_not_hold_the_claim          FAIL: SessionLeaseHeldError: session
                                                        zombie-owner is already open in pid 68938
   test_daemon_reap_removes_a_zombie_owners_claim       FAIL: assert False = reap_proven_dead_…(…)
3) test_a_claim_held_by_a_zombie_is_recovered_not_…     FAIL: TimeoutError (15.4 s — the engagement
                                                        waited for a record that could not come)
4) test_exec_resume_zombie_owner_proceeds_to_exec       FAIL: assert 1 == 0, stderr:
                                                        "session sess-zombie is already open in
                                                        another process (pid 69711) — watch and steer
                                                        it there, or from the phone session list"
5) tests/e2e/test_zombie_lease_recovery_e2e.py          FAIL: the runtime child exited 0 without
                                                        taking the claim over; its own log:
     INFO:__main__:runtime lost the lease for zombieleas01 to pid 69757; exiting
```

### 4. The same tests on this head

```
39 passed in 6.37s          (the four unit files together)
1 passed, 2 warnings in 2.90s   (tests/e2e -m e2e -n0)
```

The e2e is the full-stack one: the production child (`python -m
local_operator.session.runtime.process`, the argv `launch._spawn_runtime` uses) is started against a
session directory planted with a real zombie's claim, and the assertion is that the recovery turn
lands in the durable transcript — and that the claim left on disk afterwards names the runtime, not
the corpse.

### 5. The real CLI, on the reported session's own claim files

The operator's session was restored first (its claim removed, having proven the owner dead), so the
end-to-end CLI check ran against a copy of that session with the **original** claim
(`generation 751b63cc…, pid 94559`, state `Z`) planted back on it, byte for byte:

```
$ env HOME=<iso>/home LOCAL_OPERATOR_CONFIG_DIR=<iso>/config \
    .venv/bin/local-operator exec --resume 833188c87e7d "hello after the zombie"
lop exec session: session_id=833188c87e7d pid=7718 port=55906 record=<iso>/config/run/mobile/7718.json
(transcript rows: 520 -> 527)

new rows: user: hello after the zombie  (+ the turn's own rows)
```

The previously-bricked session **accepted a prompt**. The same command with the unfixed binary
printed the red refusal and exited 1 without starting a runtime. The provider call in that run then
failed on `No API key configured for provider 'deepseek'` — the isolated config has no credentials
and a resumed session uses its stored model — which is an isolation artifact, not the fix; the
complete turn with the mock provider is the e2e in §4.

### 6. Gates

```
uvx --from black==26.1.0 black --check .     All done! 1269 files would be left unchanged.
uvx isort==5.13.2 --check .                  rc=0
.venv/bin/python -m flake8 .                 rc=0
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
                                             0 errors, 0 warnings, 0 informations
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
                                             19253 passed, 18 skipped in 1099.76s
```

### 7. Rounds after the first remediation — the fork on the discovery path, and the final head

Three more rounds ran because QA round 2 found MAJOR-1 again in the site I had not fixed. The
loop asks the corpse question **twice** per pass — through `find_runtime_record`'s owner lookup
and through `_lease_holder` — and only the second had been deferred. QA measured 171 of 176
probes in a corpse cell coming from the discovery path, and my own test reported zero because it
patched only `session_lease.is_zombie`. The fix threads `check_zombie` into
`find_runtime_record`/`resume.live_runtime_pid` and keys the deferral to the CADENCE
(`dense_regime`, mirroring `_poll_delay`'s dense branch) rather than to elapsed time, which also
made recovery faster: the corpse cell is proven on the first pass instead of after a
window-sized stall.

Measured on the final head `4018663e5`, with an instrument that counts **every** module holding
the probe (discovered by identity from `sys.modules`, asserting both known carriers are
imported, so it cannot report zero while another site forks):

```
live holder, the dense grid's whole 1.0 s life      2 probes    (was ~200: one per pass)
corpse claim, 5 s deadline                         16 probes, all in the coarse tail,
                                                   after spawning on the first pass
corpse cell, fake fleet (recovery)                 0.20-0.43 s (was 3.16-3.30 s)
fresh-record corpse cell                           0.25 s
_pid_state(zombie) default                         'dead'  (21 forks)
_lease_holder(cheap) / (proven)                    0.030-0.042 ms / 3.7-6.1 ms per call
```

Independent verification on this head, from the two agents that ran the rounds: review round 4
falsified the new tests' instruments by forcing `check_zombie=True` back on and made both fail
(one probe per pass), confirms the cadence mirror is exact (`<` in both places), confirms only
the engage loop can run cheap while every attach/liveness caller keeps the default, and measured
the recovery at 0.203 s / 0.252 s. QA round 3 measures a corpse-held session at 2 probes / 1.31 s
against 176 in round 2, a fresh-record corpse at 1.08-1.14 s, and a healthy session at 0.

### 8. Original gates, kept for the record (`05ccf1300`)

The review round's MAJOR-1 changed `launch.py`, `session_lease.py` and `procstate.py`, so the gates
and the neighbourhood suites were re-run on the new head:

```
tests/unit/session/runtime + test_procstate + test_session_lease + test_cli_resume_guard
  + test_retention                                           452 passed in 13.83s
tests/e2e/test_zombie_lease_recovery_e2e.py -m e2e -n0        1 passed in 3.55s
the two engagement tests (durations)                          zombie recovery 3.16s,
                                                              dense window 1.00s
black --check / isort --check / flake8 / pyright              clean (0 errors)
```

Measured probe costs on this host, which is what the corrected docstrings quote:

```
signal-0 (os.kill)                 0.0003 ms median
procstate.is_zombie(live pid)      3.839  ms median
_lease_holder(check_zombie=True)   3.666  ms median
_lease_holder(check_zombie=False)  0.0302 ms median   <- the dense regime's call
```

The unit suite took 18 minutes rather than the usual ~3.5 because the host was at load average
27-31 with sibling suites running; the conftest memory budget had already dropped it to its
2-worker floor.

## Impact

- Any session whose runtime was killed without being reaped can now be opened again, and the claim
  is taken over by the new runtime rather than left to the next victim. Three sessions on this
  machine were already in that state; two are recovered by this code, the third was restored by
  hand before the fix landed.
- **The `ps` fork the probe needs is spent only where the answer changes what a caller does** —
  after signal 0 has already said "live"; in `registry.scan` only for a record whose heartbeat has
  gone quiet; and, as of the review round's MAJOR-1, on the engage loop's lease probe only once its
  fast belief has expired. That last one was wrong in the first head of this PR: `_lease_holder` is
  called on *every* pass, so a live holder — precisely the case where signal 0 succeeds — paid the
  fork on the dense 10 ms cadence, against a published 23-30 µs budget for one iteration (measured
  2.4-3.9 ms here, ~100x). The proof is now deferred until a claim has been held with no record for
  longer than `_CONSTRUCTING_WINDOW_S`, which is 2.5x a measured cold construction and therefore
  the point at which "constructing" stops being the fast belief. The dense regime is fork-free
  again, so the published iteration figure stays true, and a corpse's session recovers ~3 s later
  (measured **3.16 s** end to end) instead of never. The deferral is a latency trade only: that
  probe cannot take a claim — only `session_lease` may, and it always demands the proof.
- No rendered surface changes: no layout, copy or interaction is touched. The only user-visible
  difference is that an error path that fired incorrectly no longer fires. That is also why no
  design or UX round is attached — there is no frame to compare. Say so if you disagree and I will
  run one.
- Nothing about liveness semantics for a *live* owner changes, and that is pinned by a test in both
  directions (acquisition and the reaper still refuse; the cheap probe still calls a zombie alive,
  which is what keeps `scan` fork-free for healthy sessions).

## Checklist

- [x] `flake8`, `black --check`, `isort --check`, `pyright` clean
- [x] Unit suite green (`19253 passed`)
- [x] Real-app evidence (production runtime child, real zombie, real transcript)
- [x] Regression tests fail on the unfixed code
- [x] `pyproject.toml` untouched (no version bump; the release owner owns the bump)
- [x] Agent review round 1 answered with `### Agent review remediation — round 1`; round 2 clean and
      terminal for `057af448f`, with a convergence round on the final head
- [x] QA round 1 PASS, answered with `### QA remediation — round 1`; round 2 on the final head pending
- [ ] Final head green on CI
- [x] Assignee `@damianvtran`

## Not addressed

- **`session/runtime/control.py`'s zombie-blind `pid_alive` (review MINOR-1) — `deferred`.** The
  review round corrected my description of it and it is worse than I first wrote: with a *fresh*
  heartbeat `_identity_by_start_time` refuses to confirm, so `lop stop` paints *"it is heartbeating
  but not answering its socket"* about a corpse — the same wrong answer this PR exists to remove —
  and with a *stale* one the full SIGTERM/SIGKILL ladder runs (~6 s) and reports *killed (sigkill)*,
  with `_recover_record` returning early so the row survives to the next scan. It is bounded and
  self-healing rather than a wedge (the record is reaped by the next reader pass), and the 100 ms
  poll only runs while a signal is in flight, so it is a follow-up rather than part of this PR.
  `deferred — bounded, self-healing, and needs its own measurement of what the probe costs on that
  loop; the review round agreed it is not a blocker.`
- **A corpse's RECORD can still be handed to a non-delivering errand for one dense pass (QA round
  3, Q1 = review round 4, MINOR-1) — recorded, prose corrected.** A cheap discovery probe is
  signal-0 only, and the two errands that deliver nothing (`WarmErrand`, `WakeErrand`) treat
  reaching a record as the completed errand, so on the single pass where an owner published *and*
  died between two dense polls, such an errand can be reported ready against a corpse. The next
  pass proves the owner dead, a wake is retried rather than lost (its schedule stays overdue until
  a runtime loads), and it is strictly narrower than the behaviour before this branch — which read
  that record as live for the ~45 s until its heartbeat quieted. Both docstrings now say this
  instead of the tidier "can only cause a wait", and the closure QA suggests is named here: spend
  the proof once on the record-found path, where the grid is already coarse, so the cheap mode can
  never return a corpse's record at all. `not addressed — bounded to one dense pass, self-healing,
  narrower than the pre-branch baseline; the closure is a one-fork change on the success path.`
- **`session/retention._process_alive` is a FOURTH signal-0-only probe (QA round 1, Q2) — `deferred`.**
  A bare `os.kill(pid, 0)`, shared verbatim with `tools/group_reaper.py` and consumed by the opt-in
  cleanup policy, so a zombie reads as alive there too. Its direction *over*-protects (a live session
  is never exposed), it cannot produce the wedge this PR fixes, and its consumers are the cleanup
  policy and group reaping — so it is not this PR's job, but it does mean this module's "the one
  answer" claim is true of the three attach/acquisition probes rather than repo-wide. Recorded here
  so no later reader assumes otherwise. `deferred — different direction (over-protective), different
  consumers, own PR.`
- **`registry.pid_alive` on Windows (review MINOR-2) — `deferred`, pre-existing.** `os.kill(pid, 0)`
  has no signal-0 on Windows and calls `TerminateProcess`, which `session/retention._process_alive`
  documents and guards and `resume.live_runtime_pid` guards by returning early. `scan()` reaches it
  on every `lop sessions`. Not introduced here and untouched by this PR; it is recorded rather than
  fixed because it needs the Windows CI job to verify and this change cannot test it.
  `deferred — pre-existing, Windows-only, unverifiable on this host.`
- `browser_bridge/state.pid_alive` is a separate probe for a different subject (the extension host)
  and does not share this module's contract.



