### PR TITLE
fix(extension): never leave the popup dead when the worker is stale

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {

--- a/extension/scripts/popup-states-shot.mjs
+++ b/extension/scripts/popup-states-shot.mjs
@@ -20,7 +20,7 @@
  * Usage: node scripts/popup-states-shot.mjs <dist-dir> <out-dir>
  */
 import { spawn } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { existsSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -33,6 +33,70 @@ const CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 const [, , distArg, outArg] = process.argv;
 const DIST = resolve(distArg ?? "dist");
 const OUT = resolve(outArg ?? "/tmp/lo-popup-shots");
+
+/* THE HARNESS MUST NOT DIAL THE OPERATOR'S DAEMON.
+ *
+ * The worker cold-dials `DEFAULT_PORT` (4099) with no token and no pairing
+ * gate, so a load-unpacked build on a throwaway profile reaches the operator's
+ * REAL daemon on loopback. This is not theoretical: review runs of this very
+ * harness put +9 accepted `/extension` connections on the operator's daemon
+ * against an idle baseline of 0, and one run evicted their live link before it
+ * self-healed. The blast radius happened to be bounded only because the daemon
+ * closes an unknown `extension_id` with 4004 before its later-connection-wins
+ * eviction — a harness that ever ran with a PAIRED id would evict for real.
+ *
+ * esbuild INLINES the constant into every bundle, so seeding storage after the
+ * extension loads is too late: the cold-start dial has already gone out. The
+ * port is therefore rewritten in the BUILT artifacts before Chrome ever sees
+ * them, and this script refuses to run against a dist that still carries 4099.
+ * 4499 has no listener, so a dial fails closed instead of finding a stranger.
+ */
+const REAL_DAEMON_PORT = "4099";
+const HARNESS_PORT = "4499";
+const PATCHED_FILES = ["worker.js", "popup/popup.js", "options/options.js"];
+
+/** Rewrite the daemon port inside the built bundles, then verify no executable
+ * artifact still names the real one. Refuses rather than repairs on a surprise:
+ * a harness that "fixes" an unexpected tree is how an unnoticed dial happens. */
+async function isolateFromOperatorDaemon(dist) {
+  for (const relative of PATCHED_FILES) {
+    const file = join(dist, relative);
+    if (!existsSync(file)) throw new Error(`refusing to load ${dist}: ${relative} is missing`);
+    const source = await readFile(file, "utf8");
+    await writeFile(file, source.split(REAL_DAEMON_PORT).join(HARNESS_PORT));
+  }
+  // Verify against the tree that will actually be loaded, not against the
+  // writes above: a bundle that gained a second copy of the constant, or a new
+  // entry point nobody added to PATCHED_FILES, must fail the run rather than
+  // pass it silently. `.js.map` is excluded because it is never executed.
+  const offenders = [];
+  const walk = async (dir) => {
+    for (const item of await readdir(dir, { withFileTypes: true })) {
+      const full = join(dir, item.name);
+      if (item.isDirectory()) await walk(full);
+      else if (item.name.endsWith(".js") && (await readFile(full, "utf8")).includes(REAL_DAEMON_PORT)) {
+        offenders.push(full);
+      }
+    }
+  };
+  await walk(dist);
+  if (offenders.length) {
+    throw new Error(
+      `refusing to load a build that still dials ${REAL_DAEMON_PORT}: ${offenders.join(", ")}`,
+    );
+  }
+  // Belt and braces: if something IS listening on the harness port, this
+  // profile's extension would pair with it. Never proceed into a stranger.
+  try {
+    await fetch(`http://127.0.0.1:${HARNESS_PORT}/health`, {
+      signal: AbortSignal.timeout(500),
+    });
+    throw new Error(`refusing to run: something is listening on ${HARNESS_PORT}`);
+  } catch (error) {
+    if (String(error?.message ?? "").startsWith("refusing")) throw error;
+    // Connection refused is the expected and required outcome.
+  }
+}
 
 /** The states this popup can paint that the change touches, each expressed as
  * the /health payload that produces it. The popup reads /health on every
@@ -52,10 +116,34 @@ const STATES = {
     link_attached: true,
     protocol_version: 1,
   },
+  // The INCIDENT SHAPE, and the reason the inline banner exists: the worker is
+  // wedged while a decision is still queued. renderOnce() paints the consent
+  // card and returns before the unresponsive branch, so this is the state where
+  // #unresponsive — and its Reload button — is unreachable.
+  "origin-wedged": {
+    paired: true,
+    extension_connected: false,
+    extension_unresponsive: true,
+    link_attached: true,
+    pending_origin: "https://contested.example",
+    protocol_version: 1,
+  },
+  // The same pending decision against a HEALTHY worker: the banner must be
+  // absent here, or the remedy is being offered to a worker that does not need
+  // it. The control for the state above.
+  "origin-healthy": {
+    paired: true,
+    extension_connected: true,
+    pending_origin: "https://contested.example",
+    protocol_version: 1,
+  },
 };
 
 async function main() {
   await mkdir(OUT, { recursive: true });
+  // BEFORE Chrome exists, let alone before the extension loads: the cold-start
+  // dial goes out within milliseconds of the worker being instantiated.
+  await isolateFromOperatorDaemon(DIST);
   const profile = `/tmp/lo-popup-shot.${process.pid}.${Date.now()}`;
   const chrome = spawn(
     CHROME,
@@ -112,6 +200,8 @@ async function main() {
       await sleep(600);
       const measured = await page.eval(`(() => {
         const card = document.getElementById("card");
+        const wedge = document.getElementById("origin-wedge");
+        const wedgeReload = document.getElementById("origin-wedge-reload");
         const shown = [...document.querySelectorAll("section.state")].find(
           (s) => !s.classList.contains("hidden"),
         );
@@ -123,6 +213,17 @@ async function main() {
           pinHint: localStorage.getItem("lop:pin-hint"),
           reloadOffered: !!document.getElementById("reload-extension") &&
             !!shown && shown.contains(document.getElementById("reload-extension")),
+          // The inline remedy on the consent card: visible means a real rect,
+          // not merely a node in the document — the D3 finding was precisely a
+          // control that existed while occupying 0px in a hidden section.
+          wedgeBannerVisible: !!wedge && !wedge.classList.contains("hidden") &&
+            wedge.getBoundingClientRect().height > 0,
+          wedgeReloadVisible: !!wedgeReload && wedgeReload.getBoundingClientRect().height > 0,
+          tone: getComputedStyle(document.getElementById("card")).getPropertyValue("--tone").trim(),
+          // Clipping is what design D2 measured: content whose bottom edge sits
+          // past the scroll container's visible height is off-screen.
+          bodyScrollHeight: document.querySelector(".body")?.scrollHeight ?? null,
+          bodyClientHeight: document.querySelector(".body")?.clientHeight ?? null,
         });
       })()`);
       const shot = await page.send("Page.captureScreenshot", { format: "png" });

--- a/extension/scripts/popup-states-shot.mjs
+++ b/extension/scripts/popup-states-shot.mjs
@@ -1,0 +1,202 @@
+/* Capture the popup's cards out of a REAL Chrome, and measure them.
+ *
+ * Why a script in the tree rather than a throwaway: the `#pending` first-paint
+ * pin (popup.css, first-paint.js, PIN_BY_STATE in popup.ts) is a set of MEASURED
+ * pixel values, and a stale pin is a visible reflow on every popup open. The
+ * only way to keep them honest is to re-measure the card at 300px width in the
+ * browser that actually lays it out — an eyeballed number is how the 167.8px
+ * reflow of design round 3 survived review. So the measurement and the frames
+ * come from one run, against `extension/dist`.
+ *
+ * Every Chrome flag here is AGENTS.md §"Capturing a browser surface: headless
+ * Chrome, never a window": headless so it cannot steal the operator's focus, a
+ * unique mktemp profile so it can never touch the operator's own Chrome or its
+ * paired store extension, and a port Chrome picks (read back from
+ * DevToolsActivePort) because a fixed port on this many-session machine drives
+ * ANOTHER agent's browser. The extension is loaded over CDP's
+ * Extensions.loadUnpacked, never --load-extension, which branded Chrome 137+
+ * silently ignores.
+ *
+ * Usage: node scripts/popup-states-shot.mjs <dist-dir> <out-dir>
+ */
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+// Node 22+ ships a global WebSocket, so the CDP client below needs no
+// dependency — deliberately, since this repo keeps the extension devDeps to
+// esbuild + typescript and a capture script is not a reason to grow them.
+
+const CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const [, , distArg, outArg] = process.argv;
+const DIST = resolve(distArg ?? "dist");
+const OUT = resolve(outArg ?? "/tmp/lo-popup-shots");
+
+/** The states this popup can paint that the change touches, each expressed as
+ * the /health payload that produces it. The popup reads /health on every
+ * render, so overriding `fetch` on the page is the whole fixture — no daemon,
+ * and therefore no chance of touching the operator's real one. */
+const STATES = {
+  // The paired, working browser: the card a healthy user sees.
+  connected: { paired: true, extension_connected: true, protocol_version: 1 },
+  // The daemon is unreachable. `fetch` rejects, which is what a dead daemon
+  // looks like from the popup, and renders the Retry card.
+  disconnected: null,
+  // The subject of this change: paired, socket attached, worker mute.
+  unresponsive: {
+    paired: true,
+    extension_connected: false,
+    extension_unresponsive: true,
+    link_attached: true,
+    protocol_version: 1,
+  },
+};
+
+async function main() {
+  await mkdir(OUT, { recursive: true });
+  const profile = `/tmp/lo-popup-shot.${process.pid}.${Date.now()}`;
+  const chrome = spawn(
+    CHROME,
+    [
+      "--headless=new",
+      `--user-data-dir=${profile}`,
+      "--remote-debugging-port=0",
+      "--use-mock-keychain",
+      "--password-store=basic",
+      "--no-first-run",
+      "--no-default-browser-check",
+      "about:blank",
+    ],
+    { stdio: "ignore", detached: true },
+  );
+  // Own the process group so a harness killed mid-run leaves addressable
+  // survivors rather than a browser reparented to PPID 1 holding the profile.
+  const pgid = chrome.pid;
+  const teardown = () => {
+    try {
+      process.kill(-pgid, "SIGTERM");
+    } catch {
+      /* already gone */
+    }
+  };
+  process.on("exit", teardown);
+
+  try {
+    const portFile = join(profile, "DevToolsActivePort");
+    // Chrome writes this file ASYNCHRONOUSLY; an immediate read gets nothing
+    // and the connect fails intermittently, which reads as a flaky harness.
+    for (let i = 0; i < 200 && !(existsSync(portFile) && statSync(portFile).size > 0); i++) {
+      await sleep(100);
+    }
+    const port = (await readFile(portFile, "utf8")).split("\n")[0].trim();
+    const version = await (await fetch(`http://127.0.0.1:${port}/json/version`)).json();
+    const browser = await connect(version.webSocketDebuggerUrl);
+
+    const loaded = await browser.send("Extensions.loadUnpacked", { path: DIST });
+    const id = loaded.id;
+    const report = { chrome: version.Browser, extensionId: id, states: {} };
+
+    for (const [name, health] of Object.entries(STATES)) {
+      const page = await openPage(browser, `chrome-extension://${id}/popup/popup.html`, health);
+      // 300x600 is the popup's real geometry, and it MUST come from the CDP
+      // override: --window-size clamps to a 500px floor on Chrome 152, so a
+      // frame sized by the flag is not evidence of anything.
+      await page.send("Emulation.setDeviceMetricsOverride", {
+        width: 300,
+        height: 600,
+        deviceScaleFactor: 2,
+        mobile: false,
+      });
+      await sleep(600);
+      const measured = await page.eval(`(() => {
+        const card = document.getElementById("card");
+        const shown = [...document.querySelectorAll("section.state")].find(
+          (s) => !s.classList.contains("hidden"),
+        );
+        const pending = document.getElementById("pending");
+        return JSON.stringify({
+          shown: shown ? shown.id : null,
+          cardHeight: card ? card.getBoundingClientRect().height : null,
+          pendingPin: pending ? getComputedStyle(pending).minHeight : null,
+          pinHint: localStorage.getItem("lop:pin-hint"),
+          reloadOffered: !!document.getElementById("reload-extension") &&
+            !!shown && shown.contains(document.getElementById("reload-extension")),
+        });
+      })()`);
+      const shot = await page.send("Page.captureScreenshot", { format: "png" });
+      const file = join(OUT, `${name}.png`);
+      await writeFile(file, Buffer.from(shot.data, "base64"));
+      report.states[name] = { ...JSON.parse(measured), file };
+      await browser.send("Target.closeTarget", { targetId: page.targetId });
+    }
+
+    console.log(JSON.stringify(report, null, 2));
+  } finally {
+    teardown();
+    await sleep(2000);
+    console.error(`profile=${profile}`);
+  }
+}
+
+/** Open the popup as a page with /health stubbed BEFORE any script runs, so the
+ * first render already sees the state under test. */
+async function openPage(browser, url, health) {
+  const { targetId } = await browser.send("Target.createTarget", { url: "about:blank" });
+  const { sessionId } = await browser.send("Target.attachToTarget", { targetId, flatten: true });
+  const page = browser.session(sessionId, targetId);
+  await page.send("Page.enable");
+  await page.send("Runtime.enable");
+  const stub =
+    health === null
+      ? `window.fetch = () => Promise.reject(new TypeError("Failed to fetch"));`
+      : `window.fetch = () => Promise.resolve({ ok: true, json: async () => (${JSON.stringify(health)}) });`;
+  // addScriptToEvaluateOnNewDocument runs before the page's own scripts, which
+  // is what makes this the state of the FIRST paint rather than a later render.
+  await page.send("Page.addScriptToEvaluateOnNewDocument", {
+    source: `${stub}\ntry { localStorage.clear(); } catch {}`,
+  });
+  await page.send("Page.navigate", { url });
+  await sleep(800);
+  return page;
+}
+
+function connect(wsUrl) {
+  return new Promise((resolveConn, rejectConn) => {
+    const ws = new WebSocket(wsUrl);
+    let next = 1;
+    const pending = new Map();
+    ws.addEventListener("message", (event) => {
+      const msg = JSON.parse(String(event.data));
+      const entry = pending.get(msg.id);
+      if (!entry) return;
+      pending.delete(msg.id);
+      if (msg.error) entry.reject(new Error(JSON.stringify(msg.error)));
+      else entry.resolve(msg.result);
+    });
+    ws.addEventListener("error", () => rejectConn(new Error("CDP socket failed")));
+    const rawSend = (method, params, sessionId) =>
+      new Promise((res, rej) => {
+        const id = next++;
+        pending.set(id, { resolve: res, reject: rej });
+        ws.send(JSON.stringify({ id, method, params: params ?? {}, ...(sessionId ? { sessionId } : {}) }));
+      });
+    ws.addEventListener("open", () =>
+      resolveConn({
+        send: (method, params) => rawSend(method, params),
+        session: (sessionId, targetId) => ({
+          targetId,
+          send: (method, params) => rawSend(method, params, sessionId),
+          eval: async (expression) => {
+            const r = await rawSend("Runtime.evaluate", { expression, returnByValue: true }, sessionId);
+            if (r.exceptionDetails) throw new Error(JSON.stringify(r.exceptionDetails));
+            return r.result.value;
+          },
+        }),
+      }),
+    );
+  });
+}
+
+await main();

--- a/extension/src/popup/first-paint.js
+++ b/extension/src/popup/first-paint.js
@@ -27,15 +27,14 @@
  * the duplication of both is the price of running before the module system.
  */
 (function () {
-  // Keep in sync with PIN_HINT_KEY, PIN_CONNECTED/PIN_PAIRING/PIN_UNRESPONSIVE
-  // and show() in popup.ts.
+  // Keep in sync with PIN_HINT_KEY, PIN_CONNECTED/PIN_PAIRING and show() in
+  // popup.ts.
   //
-  // A PIN PER STATE, not a boolean. Two of the three states this can land on
-  // cannot be told apart by a boolean, and the one a boolean has to collapse is
-  // the wedged-but-paired card this popup exists for: pinned to the connected
-  // height it opened 167.8px short of the card it settled on (design D3-1).
-  // popup.ts writes the pin for the card it just rendered, and this script
-  // reproduces that height before the module runs.
+  // A PIN PER STATE, not a boolean: popup.ts writes the pin for the card it
+  // just rendered and this script reproduces that height before the module
+  // runs. Pins are held only for states that are DURABLE properties of the
+  // browser, because a pin is a bet that the next open repeats this state —
+  // see popup.ts's PIN_BY_STATE block for the measurements behind that rule.
   var KEY = "lop:pin-hint";
   // The boolean key the previous revision wrote. Read once as a fallback so the
   // rename does not cost an existing paired browser a resize; "1" meant the
@@ -43,8 +42,9 @@
   var LEGACY_KEY = "lop:paired-hint";
   var PIN_CONNECTED = "86px";
   var PIN_PAIRING = "219px";
-  var PIN_UNRESPONSIVE = "402px";
-  var PINS = [PIN_CONNECTED, PIN_PAIRING, PIN_UNRESPONSIVE];
+  // Only the DURABLE states are pinned — see popup.ts's PIN_BY_STATE for why
+  // the transient wedged card is deliberately absent.
+  var PINS = [PIN_CONNECTED, PIN_PAIRING];
   var pin = null;
   try {
     var stored = localStorage.getItem(KEY);

--- a/extension/src/popup/first-paint.js
+++ b/extension/src/popup/first-paint.js
@@ -43,7 +43,7 @@
   var LEGACY_KEY = "lop:paired-hint";
   var PIN_CONNECTED = "86px";
   var PIN_PAIRING = "219px";
-  var PIN_UNRESPONSIVE = "254px";
+  var PIN_UNRESPONSIVE = "402px";
   var PINS = [PIN_CONNECTED, PIN_PAIRING, PIN_UNRESPONSIVE];
   var pin = null;
   try {

--- a/extension/src/popup/origin-flow.ts
+++ b/extension/src/popup/origin-flow.ts
@@ -42,7 +42,31 @@ export interface DecisionAck {
   check: boolean;
 }
 
-/** The acknowledgement each decision renders. Deny is a COMPLETED choice, not
+/** The acknowledgement shown from the CLICK ALONE, while the worker round-trip
+ * is still outstanding.
+ *
+ * It reports RECEIPT, never outcome. The optimistic ack below is right once a
+ * decision has landed, but until the worker answers the popup does not know
+ * that it has: against a mute worker the success copy, the success tone and
+ * the check sat on screen for 4.9s asserting a grant that was never applied
+ * (UX U2), and a popup is dismissed by clicking anywhere outside it — so the
+ * realistic outcome was a user closing it believing the site was allowed.
+ *
+ * Neutral tone and no check, deliberately: those are the two things a user
+ * reads as "done". The verb is progressive for the same reason. `decision` is
+ * named so the in-flight line already says WHICH way the click went — the user
+ * should not have to wait for the confirmation to see what they chose. */
+export function ackInFlight(decision: OriginDecision): DecisionAck {
+  return {
+    title: decision === "deny" ? "Denying…" : "Allowing…",
+    sub: "Waiting for the extension to apply your choice.",
+    tone: "neutral",
+    check: false,
+  };
+}
+
+/** The acknowledgement each decision renders ONCE THE WORKER HAS CONFIRMED it.
+ * Deny is a COMPLETED choice, not
  * a failure, so it takes the neutral register and no check — danger is
  * reserved for states the user must recover from (error/incompatible), and a
  * check over "denied" would read as the wrong verdict. `broadScope` names

--- a/extension/src/popup/origin-flow.ts
+++ b/extension/src/popup/origin-flow.ts
@@ -308,3 +308,23 @@ export function noticeForRejectedDecision(
     sub: "It timed out or was cancelled, so nothing was granted or denied.",
   };
 }
+
+/** The notice for a decision whose round-trip to the WORKER never completed —
+ * it rejected, or it never answered inside the popup's bound.
+ *
+ * Deliberately NOT `noticeForRejectedDecision`'s "Request changed." copy. That
+ * one means a live worker replaced the generation, which is a statement about
+ * the REQUEST; this one means nothing answered at all, so the popup knows
+ * nothing about the request's fate. Reusing it here would tell the user their
+ * request was superseded when in truth it may have been applied, may not, and
+ * the extension cannot say which.
+ *
+ * The consequence line is what the user needs: reopening re-reads /health, so
+ * the popup will show the real state — including the wedged-worker card, whose
+ * own copy carries the remedy. */
+export function noticeForUnreachableWorker(): OriginNotice {
+  return {
+    title: "No answer from the extension.",
+    sub: "Your click was received, but the extension didn't respond, so this may not have been applied. Reopen this popup to see the current state.",
+  };
+}

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -366,7 +366,8 @@ input:disabled {
  * hanging off the last one rather than as the card's next idea \u2014 16px in, 8px
  * out (design D5). Matching the two restores the rhythm the other cards use. */
 .actions + .sub,
-.actions + .recheck {
+.actions + .recheck,
+.sub + .recheck {
   margin-top: 16px;
 }
 /* The "Check again" verdict. Quiet on purpose: it reports that nothing changed,
@@ -419,15 +420,60 @@ input:disabled {
  * directly under the title — above the prose it qualifies — because it changes
  * what the whole card means, and 12px/13px so a banner cannot outweigh the
  * question it annotates. */
+/* Spacing is deliberately tighter than `.all-sites`' 12px/8px. The banner is
+ * the only element that grows the CONSENT card, which is already the tallest
+ * state, and at the default 300x600 its 74.53px pushed Allow/Deny 4.3px below
+ * the bounded body — the decision itself clipped, on the one card that carries
+ * the incident (design D8 / UX U9). 10px above (it follows a title that brings
+ * its own spacing) and 6px/9px of padding buy back exactly the overflow without
+ * touching any shared rule, so no other card's rhythm moves. */
 .wedge {
-  margin: 12px 0 0;
-  padding: 8px 10px;
+  margin: 10px 0 0;
+  padding: 6px 9px;
   border: 1px solid var(--danger);
   border-radius: 6px;
   background: color-mix(in srgb, var(--danger) 10%, var(--surface));
   color: var(--ink);
   font-size: 13px;
-  line-height: 1.45;
+  line-height: 1.4;
+}
+/* SCOPED to a consent card that is carrying the banner, via :has() — the wedged
+ * prompt is the only card that does not fit (580px against the 600px bound),
+ * and it does not fit because the banner is on it. Reclaiming the difference
+ * from the card's own vertical rhythm keeps every OTHER card's spacing exactly
+ * as designed: the healthy prompt at 513.84px is untouched, which is what makes
+ * this a fix for D8/U9 rather than a global retune nobody asked for. The
+ * elements chosen are the ones whose spacing is least load-bearing — the
+ * queue head/nav and the scope label — never the trough that quarantines the
+ * host or the action row itself. */
+#origin:has(#origin-wedge:not(.hidden)) .queue-head {
+  margin-top: 8px;
+}
+#origin:has(#origin-wedge:not(.hidden)) .queue-nav {
+  margin-top: 6px;
+}
+#origin:has(#origin-wedge:not(.hidden)) .label {
+  margin-top: 10px;
+}
+/* The generic consent prose is DROPPED on the wedged card, not merely tightened.
+ * "The agent wants to open a page on this site with your current login…" is
+ * orientation for a decision that is about to take effect; on this card the
+ * banner immediately above has just said the decision will not be applied, so
+ * the paragraph is both redundant and slightly contradictory — and it is the
+ * 43px that stops Allow/Deny fitting. The load-bearing content (the host in its
+ * trough, the scope picker and what it grants, the queue position) all stays. */
+#origin:has(#origin-wedge:not(.hidden)) #origin-body {
+  display: none;
+}
+
+/* The manual remedy inside the banner. A separate block, one step quieter than
+ * the sentence above it, because it is the SECOND thing to try — it must be
+ * findable without competing with the reload for the first read. */
+.wedge-manual {
+  display: block;
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--ink-muted);
 }
 .linkish {
   appearance: none;

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -425,9 +425,9 @@ input:disabled {
  * The pin is therefore chosen per state, from a synchronous localStorage hint
  * holding the pin show() recorded for the card it last rendered:
  *
- *   86px  -> the connected card (211.2px)
- *   219px -> the pairing form (344.0px)
- *   254px -> the unresponsive card (378.8px)
+ *   86px  -> the connected card (207.2px)
+ *   219px -> the pairing form (340.2px)
+ *   402px -> the unresponsive card (523.3px)
  *
  * Three values rather than a paired/unpaired boolean (design D3-1): a boolean
  * cannot name the third state, and the one it has to collapse — the wedged but

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -59,7 +59,27 @@ body {
 
 /* A card, by the system's Card/panel reading: 10px radius, ONE hairline, and
  * NO shadow. Elevation is the --surface-on---paper step plus the hairline. */
+/* Bounded to the viewport, and a column, so a tall card SCROLLS ITS BODY
+ * instead of running off the bottom of the popup.
+ *
+ * Chrome applies the browser's default zoom to extension popups and caps the
+ * popup at 600 device px, so zoom shrinks the CSS viewport (600 -> 480 at 125%,
+ * 400 at 150%). With the card free-flowing, the tallest state lost its last
+ * element off-screen: the `unresponsive` card's manual chrome://extensions
+ * fallback — by this card's own reasoning the CERTAIN remedy, the one that
+ * worked on 2026-09-11 when a reload did not — was clipped 63px at 125% and
+ * 143px at 150% (design D2). The whole page scrolled, so the header and footer
+ * left too and nothing on screen indicated more content below.
+ *
+ * Scrolling the BODY rather than the page keeps the wordmark and the Settings
+ * link pinned, which is what makes the scroll legible as "there is more card"
+ * instead of "the popup is cut off". `min-height: 0` on the body is load-bearing
+ * — a flex child's default `min-height: auto` refuses to shrink below its
+ * content, so without it the body never scrolls and the overflow is unchanged. */
 .card {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 20px);
   background: var(--surface);
   border: 1px solid var(--hairline-strong);
   border-radius: 10px;
@@ -107,6 +127,14 @@ body {
 
 .body {
   padding: 18px 16px 16px;
+  /* See .card: the scrolling region. `min-height: 0` overrides the flex
+   * default that would otherwise refuse to shrink below the content height. */
+  min-height: 0;
+  overflow-y: auto;
+}
+.head,
+.foot {
+  flex: none;
 }
 
 /* State titles in the old-style serif display, sized for a 300px popup
@@ -332,6 +360,29 @@ input:disabled {
 .actions {
   margin-top: 16px;
 }
+/* Leaving the actions group costs what entering it costs. `.btn.block`'s 8px
+ * margin was doing double duty as both intra-group (button to button) and
+ * post-group spacing, so a paragraph after the buttons read as a caption
+ * hanging off the last one rather than as the card's next idea \u2014 16px in, 8px
+ * out (design D5). Matching the two restores the rhythm the other cards use. */
+.actions + .sub,
+.actions + .recheck {
+  margin-top: 16px;
+}
+/* The "Check again" verdict. Quiet on purpose: it reports that nothing changed,
+ * which is information, not an alarm \u2014 the card's danger rule already carries
+ * the severity. Sized with `.again`'s well so a status line in the body reads
+ * consistently wherever it appears. */
+.recheck {
+  margin: 10px 0 0;
+  padding: 7px 9px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 6px;
+  background: var(--sunken);
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--ink-muted);
+}
 /* The repeat-ask line. Deliberately NOT the danger register: nothing has gone
  * wrong and the previous decision was honoured, so this is information the
  * user needs to read the card correctly, not an alarm. It takes the --sunken
@@ -360,6 +411,23 @@ input:disabled {
   border-radius: 6px;
   background: color-mix(in srgb, var(--danger) 10%, var(--surface));
   color: var(--ink);
+}
+/* The wedged-worker banner on the CONSENT card. It borrows `.all-sites`'s
+ * treatment on purpose: both say "the gate you are looking at is not behaving
+ * the way the rest of this card implies", and inventing a second danger
+ * register beside an established one is how a design system drifts. It sits
+ * directly under the title — above the prose it qualifies — because it changes
+ * what the whole card means, and 12px/13px so a banner cannot outweigh the
+ * question it annotates. */
+.wedge {
+  margin: 12px 0 0;
+  padding: 8px 10px;
+  border: 1px solid var(--danger);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--danger) 10%, var(--surface));
+  color: var(--ink);
+  font-size: 13px;
+  line-height: 1.45;
 }
 .linkish {
   appearance: none;
@@ -427,12 +495,14 @@ input:disabled {
  *
  *   86px  -> the connected card (207.2px)
  *   219px -> the pairing form (340.2px)
- *   402px -> the unresponsive card (523.3px)
  *
- * Three values rather than a paired/unpaired boolean (design D3-1): a boolean
- * cannot name the third state, and the one it has to collapse — the wedged but
- * paired worker this popup exists for — is the one a user reopens from the
- * recovery copy, where a wrong pin cost a measured 167.8px reflow.
+ * A value per state rather than a paired/unpaired boolean (design D3-1), and
+ * ONLY for states that are durable properties of the browser. A pin is a bet
+ * that the next open repeats this state: paired stays paired, unpaired stays
+ * unpaired, but the wedged card is acted on and its own copy asks the user to
+ * reopen — so pinning it optimised a reopen nobody makes and taxed the recovery
+ * open everybody makes, measured at 315.84px of collapse (design D1). The full
+ * reasoning and the measurements live in popup.ts's PIN_BY_STATE block.
  *
  * That choice is applied by first-paint.js, a CLASSIC script in <head>, NOT by
  * popup.ts. popup.js is a deferred module, so an inline style it sets arrives
@@ -443,7 +513,7 @@ input:disabled {
  *
  * All four numbers are measured at 300x600 and move together — the card's
  * height depends on the pairing form, which depends on the reserved error slot
- * below. Re-measure ALL THREE pins if any of them changes; a stale pin is a
+ * below. Re-measure BOTH pins if any of them changes; a stale pin is a
  * resize, which is the defect this whole block exists to prevent. */
 #pending {
   min-height: 219px;

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -170,11 +170,17 @@
              (design D2-2). -->
         <section id="unresponsive" class="state hidden">
           <h1 class="title">Extension stopped answering.</h1>
+          <!-- "this popup closes while it restarts, so open it again to check"
+               is the forewarning the primary action needs (D6): clicking a
+               button and having the window vanish with no confirmation is
+               indistinguishable from the dead-click symptom this card exists to
+               cure, and the likely next move is another toolbar click — the
+               very loop being fixed. -->
           <p class="sub">
-            This browser is paired, but the Local Operator extension has stopped responding, so
-            the agent can't drive it. Reloading the extension usually clears it — pairing is
-            kept, so there is no new code to enter, but open tab handles, snapshot refs and
-            pending site decisions are lost, so re-open and re-snapshot afterwards.
+            This browser is paired, but the extension has stopped responding, so the agent can't
+            drive it. Reloading usually clears it — this popup closes while it restarts, so open
+            it again to check. Pairing is kept; open tab handles, snapshot refs and pending site
+            decisions are lost.
           </p>
           <!-- Primary = the one-click remedy, because the manual instruction
                below is four steps through a page this popup cannot even link to
@@ -187,6 +193,12 @@
             <button id="reload-extension" class="btn primary block">Reload the extension</button>
             <button id="retry-unresponsive" class="btn block">Check again</button>
           </div>
+          <!-- The verdict of a "Check again" that changed nothing. Without it
+               an unchanged answer is invisible: the card is byte-identical, so
+               a probe that genuinely ran looks exactly like a dead click (U4).
+               role="status" so AT hears the result rather than only seeing it;
+               popup.ts writes it only when the card did not change. -->
+          <p class="recheck hidden" id="unresponsive-outcome" role="status"></p>
           <!-- The FALLBACK, and it is not a softer restatement of the button: a
                reload demonstrably did NOT clear the stale worker on 2026-09-11
                20:23 (the bridge log took no /extension dial for a whole session
@@ -199,9 +211,8 @@
                fallback and cost the card 164px of height it has no room for at
                600px (measured). -->
           <p class="sub">
-            Still not answering? Toggle the extension OFF then ON in
-            <code>chrome://extensions</code> — that clears a stale registration a reload can't,
-            at the same cost.
+            Still stuck? Toggle it OFF then ON in <code>chrome://extensions</code> — that clears
+            a stale registration a reload can't, at the same cost.
           </p>
         </section>
 
@@ -247,6 +258,31 @@
                URL/host value, so a long host reads as an intact string and a
                mid-token break reads as "this is a URL", not a typo (D11). -->
           <h1 class="title" id="origin-title">Let the agent use this site?</h1>
+          <!-- THE REMEDY, INLINE, when the worker is wedged while a decision is
+               queued — the exact shape of the reported incident (the operator's
+               dead clicks happened while the agent was driving), and the one
+               state where #unresponsive is unreachable: renderOnce() paints
+               this card and returns before that branch (reviewer/UX U1, QA Q5,
+               design D3, three independent streams).
+
+               Inline rather than reordering the branches. The pending decision
+               is what the user opened the popup for, and hiding it behind the
+               wedge card would answer "the remedy is unreachable" by making the
+               request unreachable instead. So the prompt stays answerable and
+               the card stops pretending the answer will land: popup.ts sets the
+               danger tone and unhides this banner from the SAME
+               `extension_unresponsive` signal #unresponsive uses, so there is
+               one source of truth for "the worker is not answering" and no
+               chance of offering a reload to a healthy worker.
+
+               The manual chrome://extensions fallback is deliberately NOT
+               repeated here: this is a banner on a consent card, not the
+               recovery card, and #unresponsive carries the full remedy once the
+               queue drains. -->
+          <p class="wedge hidden" id="origin-wedge" role="status">
+            The extension has stopped answering, so this can't be applied right now.
+            <button type="button" class="linkish" id="origin-wedge-reload">Reload the extension</button>
+          </p>
           <p class="sub" id="origin-body">
             The agent wants to open a page on this site with your current login. It can only use
             sites you allow, and you can take this back any time in Settings.

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -172,14 +172,37 @@
           <h1 class="title">Extension stopped answering.</h1>
           <p class="sub">
             This browser is paired, but the Local Operator extension has stopped responding, so
-            the agent can't drive it. Toggle the extension OFF then ON in
-            <code>chrome://extensions</code> to reload it — pairing is kept, so there is no new
-            code to enter, but open tab handles, snapshot refs and pending site decisions are
-            lost, so re-open and re-snapshot afterwards.
+            the agent can't drive it. Reloading the extension usually clears it — pairing is
+            kept, so there is no new code to enter, but open tab handles, snapshot refs and
+            pending site decisions are lost, so re-open and re-snapshot afterwards.
           </p>
+          <!-- Primary = the one-click remedy, because the manual instruction
+               below is four steps through a page this popup cannot even link to
+               (an extension page may not open a chrome:// URL). chrome.runtime
+               .reload() restarts the worker from here, and the popup CLOSES as
+               a side effect of its own extension being torn down — expected,
+               and why the copy below tells the user what to do next rather than
+               promising them a result on this card. -->
           <div class="actions">
+            <button id="reload-extension" class="btn primary block">Reload the extension</button>
             <button id="retry-unresponsive" class="btn block">Check again</button>
           </div>
+          <!-- The FALLBACK, and it is not a softer restatement of the button: a
+               reload demonstrably did NOT clear the stale worker on 2026-09-11
+               20:23 (the bridge log took no /extension dial for a whole session
+               and a reload did not wake it) — only disable→enable did. So the
+               certain remedy stays on the card, named by URL rather than linked
+               because an extension page may not open a chrome:// URL.
+               It does NOT repeat the loss list above: both remedies discard the
+               same worker, so the paragraph above states that cost once for
+               both. Restating it here read as a second, larger price for the
+               fallback and cost the card 164px of height it has no room for at
+               600px (measured). -->
+          <p class="sub">
+            Still not answering? Toggle the extension OFF then ON in
+            <code>chrome://extensions</code> — that clears a stale registration a reload can't,
+            at the same cost.
+          </p>
         </section>
 
         <!-- Origin-decision acknowledgement, shown from the click alone

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -193,12 +193,6 @@
             <button id="reload-extension" class="btn primary block">Reload the extension</button>
             <button id="retry-unresponsive" class="btn block">Check again</button>
           </div>
-          <!-- The verdict of a "Check again" that changed nothing. Without it
-               an unchanged answer is invisible: the card is byte-identical, so
-               a probe that genuinely ran looks exactly like a dead click (U4).
-               role="status" so AT hears the result rather than only seeing it;
-               popup.ts writes it only when the card did not change. -->
-          <p class="recheck hidden" id="unresponsive-outcome" role="status"></p>
           <!-- The FALLBACK, and it is not a softer restatement of the button: a
                reload demonstrably did NOT clear the stale worker on 2026-09-11
                20:23 (the bridge log took no /extension dial for a whole session
@@ -214,6 +208,19 @@
             Still stuck? Toggle it OFF then ON in <code>chrome://extensions</code> — that clears
             a stale registration a reload can't, at the same cost.
           </p>
+          <!-- The verdict of a "Check again" that changed nothing. Without it
+               an unchanged answer is invisible: the card is byte-identical, so
+               a probe that genuinely ran looks exactly like a dead click (U4).
+               role="status" so AT hears the result rather than only seeing it;
+               popup.ts writes it only when the card did not change.
+
+               BELOW the manual fallback, deliberately. Above it, this 65.6px
+               line pushed the certain remedy off the bottom at 125% zoom — so
+               asking "did it recover?" cost the user the sentence telling them
+               what to do about the answer (UX U10). Ordered by what the user
+               needs next: the remedies first, then the status of the last
+               probe. -->
+          <p class="recheck hidden" id="unresponsive-outcome" role="status"></p>
         </section>
 
         <!-- Origin-decision acknowledgement, shown from the click alone
@@ -279,9 +286,25 @@
                repeated here: this is a banner on a consent card, not the
                recovery card, and #unresponsive carries the full remedy once the
                queue drains. -->
-          <p class="wedge hidden" id="origin-wedge" role="status">
-            The extension has stopped answering, so this can't be applied right now.
+          <!-- role="alert", not "status": this is the danger register, and an
+               already-open popup that transitions INTO the wedged state should
+               announce the banner ahead of the surrounding prose rather than
+               after it (design N1). "won't be applied" rather than "can't be
+               applied right now" states the certainty the danger tone is
+               already claiming (N3). -->
+          <p class="wedge hidden" id="origin-wedge" role="alert">
+            The extension has stopped answering, so this won't be applied.
             <button type="button" class="linkish" id="origin-wedge-reload">Reload the extension</button>
+            <!-- The manual remedy, named here too. The banner deliberately does
+                 not repeat the reload's LOSS LIST (that is the recovery card's
+                 job), but it must not leave the user without the certain cure:
+                 while a request is queued this card is the ONLY card they can
+                 see, and `ACCESS_REQUEST_TTL_MS` is 10 minutes — so a user whose
+                 reload failed had ten minutes of a card offering only the remedy
+                 that just failed (UX U11, QA Q6). One sentence, no second
+                 button: the reload stays the single primary action. -->
+            <span class="wedge-manual">Still stuck after that? Toggle it OFF then ON in
+            <code>chrome://extensions</code>.</span>
           </p>
           <p class="sub" id="origin-body">
             The agent wants to open a page on this site with your current login. It can only use

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -225,15 +225,15 @@ const LEGACY_PAIRED_HINT_KEY = "lop:paired-hint";
 // (padding, the driven-URL trough, the actions row) is the constant between
 // them, so a pin is the state's total card height minus that chrome:
 //
-//   connected card      207.2px  ->  86px
-//   pairing form        340.2px  -> 219px
+//   connected card      207.16px  ->  86px
+//   pairing form        339.52px  -> 219px
 //
+// The chrome constant is 121.0px (measured 121.16 / 120.52 against the two
+// cards, i.e. sub-pixel rounding on one shared value), so `card = pin + 121`.
 // Measured by sweeping the pin in a real headless Chrome at 300x600 dpr=2 and
-// reading the card back; the `card = pin + 121` invariant is what makes the
-// sweep a solve rather than a guess. Re-measure the same way if either card's
-// copy or controls change: an eyeballed pin IS the reflow this block exists to
-// prevent (on this build, reverting the unresponsive pin alone measured a
-// 148.27px jump before that state stopped being pinned at all).
+// reading the card back; that invariant is what makes the sweep a solve rather
+// than a guess. Re-measure the same way if either card's copy or controls
+// change: an eyeballed pin IS the reflow this block exists to prevent.
 //
 // ONLY DURABLE STATES ARE PINNED, and that is the whole design (design D1).
 // A pin is a BET that the next open repeats this state. `connected` and
@@ -241,32 +241,50 @@ const LEGACY_PAIRED_HINT_KEY = "lop:paired-hint";
 // paired next time, an unpaired one still unpaired — so the bet pays.
 // `unresponsive` is transient BY CONSTRUCTION: the card exists to be acted on,
 // and its copy tells the user to reload and open it again, so the next open is
-// precisely the one most likely to be a DIFFERENT card. Pinning it optimised
-// the reopen nobody makes (0.27px) and taxed the recovery open everybody makes
-// — measured 315.84px of collapse against base's 167.84px, i.e. it nearly
-// doubled the worst visible reflow on the path this feature creates.
+// precisely the one most likely to be a DIFFERENT card.
 //
-// Leaving it unpinned means the wedged open keeps whatever the browser's
-// durable pin is and grows into the tall card once, while the recovery open —
-// the one the card's own copy asks for — lands on a pin that is already right.
-// An unmeasured state keeping the last hint is the same rule the two pinned
-// states rely on, not a special case for this one.
+// THIS IS A TRADE, AND THESE ARE ITS NUMBERS. Measured from the seed a real
+// browser carries (`86px` — paired for weeks), two consecutive opens per
+// sequence, /health delayed so #pending is genuinely the first frame:
+//
+//   recovery open (wedged -> connected)   167.84px -> 0.16px   <- instructed
+//   arrival (working browser wedges)      168.77px -> 257.77px
+//   failed reload (2026-09-11, 2nd wedge)   0.77px -> 257.77px
+//
+// The win is on the transition the card's copy INSTRUCTS ("open it again to
+// check"): a ~168px lurch becomes nothing. The cost is on the arrival and
+// reopen paths, which are ~89px and ~257px worse than base. The worst single
+// motion is 257.77px, not 132.84px — an earlier revision of this comment and
+// of the PR claimed the worst case was back to base, and it is not.
+//
+// THE TRANSITION OUT is the one the pin cannot help and does not need to: the
+// wedge card writes no hint, so the recovery open reads the `connected` pin
+// this browser has carried all along and lands on it exactly (0.16px). That is
+// why the durable pin must survive the wedge rather than be overwritten by it.
+//
+// A CONDITIONAL WEDGE PIN WAS PROPOSED AND MEASURED, AND IT IS WORSE. Pinning
+// the wedge only when the stored durable pin is `connected` was expected to
+// retire the arrival cost. Driven on a real build with a 343.77px wedge pin:
+// arrival stayed 257.77px (show() writes the pin AFTER the card renders, so
+// the open that first meets the wedge can never be helped by it), and the
+// instructed recovery open REGRESSED 0.16px -> 257.61px, because the wedge pin
+// it left behind then mis-sized the connected card. It buys nothing and sells
+// the one win. Do not re-derive it from the idea alone.
 //
 // THE `connected` FIGURE IS THE CARD WITH AN EMPTY DRIVEN-URL TROUGH (PR #996,
-// finding D3-1, kept across this branch's rebase because it still holds). The
-// same state is taller once a URL is in it — a settled 257.3px, and 292.1px for
-// the long-URL variant, against an empty-trough card. That residual is a KNOWN,
-// RECORDED DEFERRAL, not an oversight, and #996 measured it identical across
-// the pre-PR base and both of its remediation heads: the hint records the
-// height the browser last SETTLED on, so a card whose text changes between
-// opens pays one resize either way, and a per-state constant cannot express a
-// height that depends on the URL. Do not add one here; the provenance is #996's
-// D3-1 note. Re-measuring `connected` with a URL present will therefore read
-// ~257px and is not a contradiction of this table.
-//
-// #996 quoted its own empty-trough figure as 211.2px; this table carries the
-// re-measured 207.2px for the same card, so the ~4px is a measurement
-// correction on this branch, not a second card.
+// finding D3-1, kept across this branch's rebase because it describes a
+// different quantity from the trade above and still holds). The same state is
+// taller once a URL is in it — a settled 257.3px, and 292.1px for the long-URL
+// variant. That residual is a KNOWN, RECORDED DEFERRAL, not an oversight, and
+// #996 measured it identical across the pre-PR base and both of its
+// remediation heads: the hint records the height the browser last SETTLED on,
+// so a card whose text changes between opens pays one resize either way, and a
+// per-state constant cannot express a height that depends on the URL. Do not
+// add one here; the provenance is #996's D3-1 note. Re-measuring `connected`
+// with a URL present will therefore read ~257px and is not a contradiction of
+// this table. (#996 quoted its own empty-trough figure as 211.2px; this table
+// carries the re-measured 207.2px for the same card, so the ~4px is a
+// measurement correction on this branch, not a second card.)
 const PIN_CONNECTED = "86px";
 const PIN_PAIRING = "219px";
 const PINS: readonly string[] = [PIN_CONNECTED, PIN_PAIRING];
@@ -533,7 +551,24 @@ async function renderOnce(): Promise<void> {
     // loop: optimistic ack, honest notice, identical prompt, indefinitely
     // (U1/Q5/D3). Read from /health rather than from `connState`, because a
     // dead worker's last `connState` write reads "connected" forever.
-    const wedged = health?.extension_unresponsive === true;
+    // BOTH halves, because they answer different questions. `#unresponsive`
+    // describes the daemon↔extension LINK and correctly renders on
+    // `extension_unresponsive` alone. This banner makes a narrower claim — that
+    // THIS DECISION cannot be delivered — and a decision travels over
+    // `chrome.runtime.sendMessage`, a channel that does not touch that socket.
+    //
+    // `extension_unresponsive` is true for two distinct reasons (daemon.py):
+    // the socket is attached but mute, OR `dropped_unproven()` — a 60s latch
+    // after the daemon severed the link. In that second window the worker is
+    // usually alive and re-dialling, so the banner claimed the decision could
+    // not be applied while Allow applied it and painted the confirmed success
+    // card (review M1). That is the same class of lie as U2's false success,
+    // pointed the other way, and it steers the user at a reload that destroys
+    // the very pending decision they opened the popup to answer.
+    //
+    // `link_attached` is what separates them: attached-and-mute is the case
+    // where `sendMessage` genuinely is unlikely to land.
+    const wedged = health?.extension_unresponsive === true && health?.link_attached === true;
     const wedge = document.getElementById("origin-wedge");
     // Guarded like `origin-again` above: a role="status" region rewritten on
     // every render re-announces the same sentence to a screen reader (D10).
@@ -547,7 +582,27 @@ async function renderOnce(): Promise<void> {
     // a focused primary on a consent dialog invites an accidental Space/Enter
     // approval (U5). Only on a newly-shown prompt, so a re-render cannot steal
     // focus back from a user who has tabbed onward.
-    if (freshPrompt) document.getElementById("origin-scope")?.focus();
+    //
+    // `preventScroll` is load-bearing, not a nicety. `.body` became a scroll
+    // container when the card was bounded to the viewport, and focusing an
+    // element inside one scrolls it into view — so on the tallest card this
+    // scrolled to the bottom on open, putting the title AND the whole danger
+    // banner above the fold at ≥125% zoom (design D7 / UX U8, measured
+    // scrollTop 139 at 125%, 219 at 150%). Overlay scrollbars are 0px wide and
+    // the header stays pinned, so a zoomed user saw an ordinary consent prompt
+    // with live Allow/Deny and no sign their answer could not land — round-1
+    // U1, reintroduced by the round-1 D2 fix through a control neither
+    // mentions. The keyboard landing point is unchanged.
+    if (freshPrompt) {
+      document.getElementById("origin-scope")?.focus({ preventScroll: true });
+      // Belt and braces: a fresh prompt always opens at the TOP of its card.
+      // preventScroll stops focus() from scrolling, but any other future call
+      // that reveals an element would reintroduce the same defect, and the
+      // first thing the user must read is the question (and the banner that
+      // qualifies it), never the middle of the card.
+      const body = document.querySelector(".body");
+      if (body) body.scrollTop = 0;
+    }
     return;
   }
 
@@ -841,7 +896,11 @@ async function recheckUnresponsive(): Promise<void> {
     // the screen. Only an unchanged verdict needs words.
     const stillWedged = !document.getElementById("unresponsive")?.classList.contains("hidden");
     if (outcome && stillWedged) {
-      outcome.textContent = `Still not answering (checked ${new Date().toLocaleTimeString()}).`;
+      // Hours and minutes only. The default `toLocaleTimeString()` prints
+      // seconds and an AM/PM in a 12-hour locale, which is a lot of digits for
+      // a 12px well whose whole job is to prove the probe ran (design N2).
+      const checkedAt = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+      outcome.textContent = `Still not answering (checked ${checkedAt}).`;
       outcome.classList.remove("hidden");
     }
   }

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -9,6 +9,7 @@ import { DEFAULT_PORT, getLocal, getSession, getSurfaces } from "../state";
 import { pairVerdict, viewForHealth } from "./pair-flow";
 import {
   ackForDecision,
+  ackInFlight,
   noticeForRejectedDecision,
   noticeForUnreachableWorker,
   originPromptView,
@@ -200,13 +201,11 @@ const NOTICE_HOLD_MS = 1500;
 // as a LAYOUT HINT.
 //
 // It records the PIN rather than a boolean derived from /health (design D3-1).
-// A boolean could only ever name two of the three measured states, so a browser
-// in the third — the wedged-but-paired worker this PR exists for — opened at
-// whichever of the two the boolean happened to collapse to and then grew the
-// difference: measured 86px → 378.8px, a 167.8px reflow in the state whose copy
-// sends the user to "Check again". The pin is written by show(), i.e. for the
-// card that was actually rendered, so a repeated open reproduces the height
-// already on screen.
+// A boolean could only name two states, so a browser in any third one opened at
+// whichever of the two the boolean collapsed to and then grew the difference.
+// The pin is written by show(), i.e. for the card that was actually rendered,
+// so a repeated open reproduces the height already on screen — for the states
+// it is worth betting on (see PIN_BY_STATE).
 //
 // It is a hint and nothing else: it never gates behaviour, and render() paints
 // whatever /health actually reports. A stale or absent pin costs one resize,
@@ -228,42 +227,52 @@ const LEGACY_PAIRED_HINT_KEY = "lop:paired-hint";
 //
 //   connected card      207.2px  ->  86px
 //   pairing form        340.2px  -> 219px
-//   unresponsive card   523.3px  -> 402px
 //
-// The unresponsive pin moved 254 -> 402 when that card gained its one-click
-// "Reload the extension" action and the manual fallback became its own
-// paragraph. SOLVED, not derived: the card's own chrome is a constant 121px
-// over the pin, measured by sweeping the pin across 86/219/254/300/350/380/
-// 398/400/402/410 in a real headless Chrome at 300x600 dpr=2 and reading the
-// card back (86->207, 219->340, 254->375, 402->523). Re-measure the same way
-// if this card's copy or controls change; an eyeballed pin IS the 167.8px
-// reflow this block exists to prevent.
+// Measured by sweeping the pin in a real headless Chrome at 300x600 dpr=2 and
+// reading the card back; the `card = pin + 121` invariant is what makes the
+// sweep a solve rather than a guess. Re-measure the same way if either card's
+// copy or controls change: an eyeballed pin IS the reflow this block exists to
+// prevent (on this build, reverting the unresponsive pin alone measured a
+// 148.27px jump before that state stopped being pinned at all).
 //
-// A state with no entry keeps the last hint. That is deliberate: only these
-// three were measured in a real render, and a pin for the rest would be a pixel
-// guess no frame backs — while an unmeasured state costs exactly the one
-// resize a browser with no hint at all gets. Re-measure all three together when
-// any of them moves: a stale pin IS the resize this whole block exists to
-// prevent (popup.css carries the same numbers).
+// ONLY DURABLE STATES ARE PINNED, and that is the whole design (design D1).
+// A pin is a BET that the next open repeats this state. `connected` and
+// `pairing` are durable properties of the browser — a paired browser is still
+// paired next time, an unpaired one still unpaired — so the bet pays.
+// `unresponsive` is transient BY CONSTRUCTION: the card exists to be acted on,
+// and its copy tells the user to reload and open it again, so the next open is
+// precisely the one most likely to be a DIFFERENT card. Pinning it optimised
+// the reopen nobody makes (0.27px) and taxed the recovery open everybody makes
+// — measured 315.84px of collapse against base's 167.84px, i.e. it nearly
+// doubled the worst visible reflow on the path this feature creates.
 //
-// The `connected` figure is the card with an EMPTY driven-URL trough. The same
-// state is taller once a URL is in it — a settled 257.3px (and 292.1px for the
-// long-URL variant) against this table's 211.2px, +47.3px / +82.1px of reopen
-// growth. That residual is a KNOWN, RECORDED DEFERRAL, not an oversight, and it
-// was measured identical across the pre-PR base and both remediation heads: the
-// hint records the height the browser last SETTLED on, so a card whose text
-// changes between opens pays one resize either way, and a per-state constant
-// cannot express a height that depends on the URL. Do not add one here; the
-// provenance lives in PR #996's D3-1 note. Re-measuring `connected` with a URL
-// present will therefore read ~257px and is not a contradiction of this table.
+// Leaving it unpinned means the wedged open keeps whatever the browser's
+// durable pin is and grows into the tall card once, while the recovery open —
+// the one the card's own copy asks for — lands on a pin that is already right.
+// An unmeasured state keeping the last hint is the same rule the two pinned
+// states rely on, not a special case for this one.
+//
+// THE `connected` FIGURE IS THE CARD WITH AN EMPTY DRIVEN-URL TROUGH (PR #996,
+// finding D3-1, kept across this branch's rebase because it still holds). The
+// same state is taller once a URL is in it — a settled 257.3px, and 292.1px for
+// the long-URL variant, against an empty-trough card. That residual is a KNOWN,
+// RECORDED DEFERRAL, not an oversight, and #996 measured it identical across
+// the pre-PR base and both of its remediation heads: the hint records the
+// height the browser last SETTLED on, so a card whose text changes between
+// opens pays one resize either way, and a per-state constant cannot express a
+// height that depends on the URL. Do not add one here; the provenance is #996's
+// D3-1 note. Re-measuring `connected` with a URL present will therefore read
+// ~257px and is not a contradiction of this table.
+//
+// #996 quoted its own empty-trough figure as 211.2px; this table carries the
+// re-measured 207.2px for the same card, so the ~4px is a measurement
+// correction on this branch, not a second card.
 const PIN_CONNECTED = "86px";
 const PIN_PAIRING = "219px";
-const PIN_UNRESPONSIVE = "402px";
-const PINS: readonly string[] = [PIN_CONNECTED, PIN_PAIRING, PIN_UNRESPONSIVE];
+const PINS: readonly string[] = [PIN_CONNECTED, PIN_PAIRING];
 const PIN_BY_STATE: Partial<Record<State, string>> = {
   connected: PIN_CONNECTED,
   pairing: PIN_PAIRING,
-  unresponsive: PIN_UNRESPONSIVE,
 };
 
 /** The pinned height this browser last settled on, or null for "no hint". */
@@ -517,6 +526,22 @@ async function renderOnce(): Promise<void> {
     setOriginBusy(false);
     renderQueueControls(queue, selected);
     show("origin");
+    // The wedged-worker banner, from the SAME signal #unresponsive renders
+    // from. This card returns before that branch is ever reached, so without it
+    // the popup shows a live Allow/Deny against a worker that cannot apply
+    // either, with the neutral tone and no route to the remedy — measured as a
+    // loop: optimistic ack, honest notice, identical prompt, indefinitely
+    // (U1/Q5/D3). Read from /health rather than from `connState`, because a
+    // dead worker's last `connState` write reads "connected" forever.
+    const wedged = health?.extension_unresponsive === true;
+    const wedge = document.getElementById("origin-wedge");
+    // Guarded like `origin-again` above: a role="status" region rewritten on
+    // every render re-announces the same sentence to a screen reader (D10).
+    if (wedge) wedge.classList.toggle("hidden", !wedged);
+    // Tell the truth with the status rule too. show() has just set the origin
+    // card's neutral hairline; a card whose decision cannot land is a state the
+    // user must recover from, which is what danger is reserved for here.
+    if (wedged) document.getElementById("card")?.style.setProperty("--tone", "var(--danger)");
     // The prompt is an alertdialog demanding a decision, so give the keyboard
     // a landing point on the first meaningful control. Deliberately NOT Allow:
     // a focused primary on a consent dialog invites an accidental Space/Enter
@@ -542,11 +567,11 @@ async function renderOnce(): Promise<void> {
   // /health is the authority on whether this browser is paired, and the two
   // cards below are what decide which pin show() records for the next open.
   // Nothing is mirrored from /health here: the previous revision derived a
-  // BOOLEAN from `paired || extension_unresponsive` and the wedge state — which
-  // renders the honest card below, not the pairing form — is precisely the one
-  // the boolean could not express, so every reopen of it started at the
-  // connected card's height and grew 167.8px into this card (design D3-1,
-  // measured 86px → 378.8px). show() records the pin per card instead.
+  // BOOLEAN from `paired || extension_unresponsive`, which could not express
+  // the wedge state — it renders the honest card below, not the pairing form —
+  // so every reopen of it started at the wrong height and grew into this card
+  // (design D3-1). show() records the pin per card instead, for the durable
+  // states only.
   // The worker is wedgeable in a way the socket does not show: attached, paired,
   // and answering nothing. Say so instead of painting the green "Connected."
   // card over a browser the agent cannot drive — that card is exactly what the
@@ -777,19 +802,64 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
 
 document.getElementById("retry")?.addEventListener("click", () => void render());
 document.getElementById("retry-incompatible")?.addEventListener("click", () => void render());
-document.getElementById("retry-unresponsive")?.addEventListener("click", () => void render());
-// The one-click remedy for a wedged worker, and it lives ONLY on the
-// `unresponsive` card — which renderOnce() paints from the daemon's
-// `extension_unresponsive`, never from the worker's own `connState` (a dead
-// worker's last write reads "connected" forever). So a healthy worker is never
-// offered a reload: the button is in a section that is `hidden` unless the
-// daemon itself reports the extension is not answering.
+
+// "Check again" has to LOOK like it checked. Re-entering render() re-probes
+// /health, but when the answer is unchanged the DOM is byte-identical — a
+// MutationObserver over the whole body recorded ZERO mutations for 2.5s after
+// the click, and HEALTH_TIMEOUT_MS is 3000, so a user could click, wait three
+// seconds and see nothing at all. That is the dead-click perception this PR
+// exists to remove, reappearing on the recovery card itself (UX U4).
+//
+// So the click owns the button for the length of the probe (disabled +
+// "Checking…", with aria-busy for AT), and the outcome is stated even when the
+// outcome is "no change" — the one case the DOM cannot express on its own.
+const RECHECK_SETTLE_MS = 400;
+async function recheckUnresponsive(): Promise<void> {
+  const button = document.getElementById("retry-unresponsive") as HTMLButtonElement | null;
+  const outcome = document.getElementById("unresponsive-outcome");
+  if (!button) {
+    await render();
+    return;
+  }
+  const label = button.textContent;
+  button.disabled = true;
+  button.textContent = "Checking…";
+  button.setAttribute("aria-busy", "true");
+  outcome?.classList.add("hidden");
+  try {
+    await render();
+    // A minimum visible duration, because the honest failure here is a probe
+    // that answers in 8ms: without it the in-flight state exists for less than
+    // a frame and the user sees the same nothing they reported.
+    await new Promise((resolve) => setTimeout(resolve, RECHECK_SETTLE_MS));
+  } finally {
+    button.disabled = false;
+    button.textContent = label ?? "Check again";
+    button.removeAttribute("aria-busy");
+    // If render() moved us off this card the check succeeded and the new card
+    // IS the outcome; saying "still not answering" under it would contradict
+    // the screen. Only an unchanged verdict needs words.
+    const stillWedged = !document.getElementById("unresponsive")?.classList.contains("hidden");
+    if (outcome && stillWedged) {
+      outcome.textContent = `Still not answering (checked ${new Date().toLocaleTimeString()}).`;
+      outcome.classList.remove("hidden");
+    }
+  }
+}
+document.getElementById("retry-unresponsive")?.addEventListener("click", () => void recheckUnresponsive());
+
+// The one-click remedy for a wedged worker. Both of its surfaces are painted
+// from the daemon's `extension_unresponsive` and never from the worker's own
+// `connState` (a dead worker's last write reads "connected" forever), so a
+// healthy worker is never offered a reload: on the `unresponsive` card the
+// button sits in a section that stays `hidden`, and on the origin card the
+// banner carrying it is unhidden only by the same signal.
 //
 // chrome.runtime.reload() is allowed from an extension page and needs no
 // permission. It tears down this very extension, so THE POPUP CLOSES as a side
 // effect — there is no post-reload state to render here, which is why the card
-// tells the user what to check next instead of promising a result.
-document.getElementById("reload-extension")?.addEventListener("click", () => {
+// warns the user up front that it will vanish and tells them to reopen (D6).
+function reloadExtension(): void {
   try {
     chrome.runtime.reload();
   } catch (error) {
@@ -798,7 +868,11 @@ document.getElementById("reload-extension")?.addEventListener("click", () => {
     // is about to be gone if the call did work.
     console.warn("extension reload failed", error);
   }
-});
+}
+document.getElementById("reload-extension")?.addEventListener("click", reloadExtension);
+// Same remedy, reached from the consent card's inline banner (U1/Q5/D3). One
+// handler for both so the two surfaces cannot drift apart.
+document.getElementById("origin-wedge-reload")?.addEventListener("click", reloadExtension);
 // Allow sends whatever scope the select holds; the select's value set is
 // exactly scopeOptions' values, so no other decision can be minted here.
 document.getElementById("origin-allow")?.addEventListener("click", () => {
@@ -817,11 +891,31 @@ document.getElementById("connected-all-sites-off")?.addEventListener("click", ()
 document.getElementById("origin-previous")?.addEventListener("click", () => void moveQueue(-1));
 document.getElementById("origin-next")?.addEventListener("click", () => void moveQueue(1));
 
-// Lock the three consent buttons the moment one is clicked: the session-storage
+// The controls a DECISION owns, and the only ones a decision may re-enable.
+//
+// Previous/Next are deliberately NOT here. Their enabled state is DERIVED from
+// queue length by renderQueueControls (`disabled = queue.length < 2`), and a
+// decision that empties the queue down to one entry runs its cleanup AFTER the
+// trailing render() — so re-enabling them here overwrote the renderer's answer
+// and put two inert stops back on a single-request prompt, which is the U4
+// defect the base branch fixed (review F2, reproduced A/B: base `true true`,
+// this head `false false` with one entry left). Ownership of queue navigation
+// stays with the renderer; a decision only ever owns its own three controls.
+const DECISION_CONTROLS = ["origin-scope", "origin-allow", "origin-deny"] as const;
+
+// Lock the consent controls the moment one is clicked: the session-storage
 // read below is async, and a second click in that window would double-send the
 // decision. render()'s prompt path unlocks for the next genuine prompt.
+//
+// `busy` disables queue navigation too — while a decision is in flight, moving
+// to another entry would rewrite the module state the in-flight click is
+// judged against. Re-enabling is the asymmetric half: it is scoped to the
+// decision's own controls, per DECISION_CONTROLS above.
 function setOriginBusy(busy: boolean): void {
-  for (const id of ["origin-scope", "origin-allow", "origin-deny", "origin-previous", "origin-next"]) {
+  const ids = busy
+    ? [...DECISION_CONTROLS, "origin-previous", "origin-next"]
+    : [...DECISION_CONTROLS];
+  for (const id of ids) {
     const control = document.getElementById(id) as HTMLButtonElement | HTMLSelectElement | null;
     if (control) control.disabled = busy;
   }
@@ -927,8 +1021,12 @@ async function moveQueue(delta: -1 | 1): Promise<void> {
   await render();
 }
 
-function showOriginAck(decision: OriginDecision): void {
-  const ack = ackForDecision(decision, shownBroadScope);
+/** @param confirmed whether the WORKER has answered. Until it has, the ack
+ * reports receipt only (UX U2): the success tone, the check and the granted
+ * trough are the three things a user reads as "this landed", and none of them
+ * may appear over a decision whose fate the popup does not yet know. */
+function showOriginAck(decision: OriginDecision, confirmed: boolean): void {
+  const ack = confirmed ? ackForDecision(decision, shownBroadScope) : ackInFlight(decision);
   const title = document.getElementById("origin-ack-title");
   const sub = document.getElementById("origin-ack-sub");
   if (title) title.textContent = ack.title;
@@ -936,9 +1034,14 @@ function showOriginAck(decision: OriginDecision): void {
   // Print the value that was granted, in the prompt's own monospace trough.
   // The prompt pane is gone by now, so "this domain" would have no referent on
   // screen — and the broader the grant, the vaguer that reading gets (D2).
+  // Only once CONFIRMED: this trough is the element that means "this is what
+  // you granted", so printing it while the round-trip is outstanding claims
+  // the grant the title is careful not to claim.
   const granted = document.getElementById("origin-ack-granted");
   if (granted) {
-    const value = grantedValueFor(decision, shownBroadScope, shownBroadKey, shownPromptOrigin);
+    const value = confirmed
+      ? grantedValueFor(decision, shownBroadScope, shownBroadKey, shownPromptOrigin)
+      : undefined;
     granted.textContent = value ?? "";
     granted.classList.toggle("hidden", !value);
   }
@@ -992,7 +1095,12 @@ async function decideOnce(decision: OriginDecision): Promise<void> {
     // holds the ack through stale echoes; render() takes over to Connected
     // once the echo clears.
     decidedOrigin = { origin, decision, entryId: promptId, decidedAt: Date.now() };
-    showOriginAck(decision);
+    // RECEIPT, not outcome. The latch above suppresses the prompt's echo, so
+    // every render during the round-trip keeps whatever is painted here — which
+    // is why this may not be the success card: against a mute worker it sat
+    // there for 4.9s claiming a grant that was never applied (UX U2). The
+    // confirmed ack is painted below, once the worker has actually answered.
+    showOriginAck(decision, false);
     // The worker round-trip is BOUNDED and its failure is contained, because a
     // wedged worker turns this click into the user's "I clicked and nothing
     // happened": `setOriginBusy(true)` above disabled Allow/Deny, and before
@@ -1006,6 +1114,14 @@ async function decideOnce(decision: OriginDecision): Promise<void> {
     // race. The loser is not cancellable, which is harmless: an answer arriving
     // late resolves a promise nobody reads, and render() below re-reads the
     // real state from storage and /health either way.
+    //
+    // A SECOND click after the bound fires is also safe, and that is a property
+    // of the worker rather than of this popup: `decideAccess` (approval-store)
+    // resolves by `entryId`, so the re-send finds no live entry and returns
+    // `applied: false` \u2014 the user sees a notice, never a double grant, and the
+    // `once` grant is keyed requester+origin so it cannot be spent twice
+    // either (review F3). Not guarded here on purpose: blocking the retry would
+    // cost a user whose FIRST send was genuinely lost their only way to retry.
     let response: { applied?: boolean } | undefined;
     let reachedWorker = true;
     try {
@@ -1063,6 +1179,14 @@ async function decideOnce(decision: OriginDecision): Promise<void> {
         // CURRENT prompt with live buttons.
         await new Promise((resolve) => setTimeout(resolve, NOTICE_HOLD_MS));
       }
+    } else {
+      // CONFIRMED: the worker applied it. Only now may the success tone, the
+      // check and the granted trough appear — the in-flight ack above is
+      // deliberately none of those, so this is the single transition from
+      // "received" to "done" (UX U2). The latch is left in place: the queue
+      // write and /health both still echo this generation, and render()'s ack
+      // branch keeps this card up until the echo clears.
+      showOriginAck(decision, true);
     }
   }
   // A successful decision removes this generation; FIFO becomes current. A
@@ -1080,6 +1204,16 @@ function showOriginNotice(title: string, sub: string): void {
   if (titleEl) titleEl.textContent = title;
   if (subEl) subEl.textContent = sub;
   document.getElementById("origin-ack-check")?.classList.add("hidden");
+  // The granted trough must go with the check. It is filled by a CONFIRMED
+  // ack, and this card is shown when a decision could not be applied — so
+  // leaving it up printed the origin directly under "may not have been
+  // applied", i.e. the one element that reads as "this is what you granted"
+  // surviving onto the card that says nothing may have been granted (UX U3).
+  const granted = document.getElementById("origin-ack-granted");
+  if (granted) {
+    granted.textContent = "";
+    granted.classList.add("hidden");
+  }
   show("origin-ack");
   document.getElementById("card")?.style.setProperty("--tone", "var(--hairline-strong)");
 }

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -10,6 +10,7 @@ import { pairVerdict, viewForHealth } from "./pair-flow";
 import {
   ackForDecision,
   noticeForRejectedDecision,
+  noticeForUnreachableWorker,
   originPromptView,
   repeatAskNotice,
   preselectedScope,
@@ -172,6 +173,20 @@ let pairingShown = false;
 // because renders are serialised — see daemonHealth().
 const HEALTH_TIMEOUT_MS = 3000;
 
+// How long a decision may wait on the WORKER before the popup concludes it is
+// not answering. Generous next to a healthy round-trip (single-digit ms over
+// chrome.runtime), because overshooting costs only a slower honest message
+// while undershooting would accuse a merely-busy worker of being wedged. The
+// bound exists at all because a stale MV3 worker answers a sendMessage with
+// silence rather than a rejection, and an unbounded await there is what left
+// Allow/Deny permanently disabled — see decide().
+const DECISION_TIMEOUT_MS = 5000;
+
+// How long a notice is held before render() paints over it. Same value the
+// pairing success hold uses: long enough to read a two-line card, short enough
+// that the popup is not lying about the current state for long.
+const NOTICE_HOLD_MS = 1500;
+
 // The pinned #pending height this browser last settled on, mirrored into
 // localStorage so the FIRST PAINT can size itself.
 //
@@ -211,9 +226,18 @@ const LEGACY_PAIRED_HINT_KEY = "lop:paired-hint";
 // (padding, the driven-URL trough, the actions row) is the constant between
 // them, so a pin is the state's total card height minus that chrome:
 //
-//   connected card      211.2px  ->  86px
-//   pairing form        344.0px  -> 219px
-//   unresponsive card   378.8px  -> 254px
+//   connected card      207.2px  ->  86px
+//   pairing form        340.2px  -> 219px
+//   unresponsive card   523.3px  -> 402px
+//
+// The unresponsive pin moved 254 -> 402 when that card gained its one-click
+// "Reload the extension" action and the manual fallback became its own
+// paragraph. SOLVED, not derived: the card's own chrome is a constant 121px
+// over the pin, measured by sweeping the pin across 86/219/254/300/350/380/
+// 398/400/402/410 in a real headless Chrome at 300x600 dpr=2 and reading the
+// card back (86->207, 219->340, 254->375, 402->523). Re-measure the same way
+// if this card's copy or controls change; an eyeballed pin IS the 167.8px
+// reflow this block exists to prevent.
 //
 // A state with no entry keeps the last hint. That is deliberate: only these
 // three were measured in a real render, and a pin for the rest would be a pixel
@@ -234,7 +258,7 @@ const LEGACY_PAIRED_HINT_KEY = "lop:paired-hint";
 // present will therefore read ~257px and is not a contradiction of this table.
 const PIN_CONNECTED = "86px";
 const PIN_PAIRING = "219px";
-const PIN_UNRESPONSIVE = "254px";
+const PIN_UNRESPONSIVE = "402px";
 const PINS: readonly string[] = [PIN_CONNECTED, PIN_PAIRING, PIN_UNRESPONSIVE];
 const PIN_BY_STATE: Partial<Record<State, string>> = {
   connected: PIN_CONNECTED,
@@ -754,6 +778,27 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
 document.getElementById("retry")?.addEventListener("click", () => void render());
 document.getElementById("retry-incompatible")?.addEventListener("click", () => void render());
 document.getElementById("retry-unresponsive")?.addEventListener("click", () => void render());
+// The one-click remedy for a wedged worker, and it lives ONLY on the
+// `unresponsive` card — which renderOnce() paints from the daemon's
+// `extension_unresponsive`, never from the worker's own `connState` (a dead
+// worker's last write reads "connected" forever). So a healthy worker is never
+// offered a reload: the button is in a section that is `hidden` unless the
+// daemon itself reports the extension is not answering.
+//
+// chrome.runtime.reload() is allowed from an extension page and needs no
+// permission. It tears down this very extension, so THE POPUP CLOSES as a side
+// effect — there is no post-reload state to render here, which is why the card
+// tells the user what to check next instead of promising a result.
+document.getElementById("reload-extension")?.addEventListener("click", () => {
+  try {
+    chrome.runtime.reload();
+  } catch (error) {
+    // Nothing to fall back TO in the UI: the manual chrome://extensions
+    // instruction is already on the card as the certain remedy, and this popup
+    // is about to be gone if the call did work.
+    console.warn("extension reload failed", error);
+  }
+});
 // Allow sends whatever scope the select holds; the select's value set is
 // exactly scopeOptions' values, so no other decision can be minted here.
 document.getElementById("origin-allow")?.addEventListener("click", () => {
@@ -912,6 +957,22 @@ function showOriginAck(decision: OriginDecision): void {
 
 async function decide(decision: OriginDecision): Promise<void> {
   setOriginBusy(true);
+  try {
+    await decideOnce(decision);
+  } finally {
+    // The controls are re-enabled on EVERY exit, including one nobody
+    // predicted. The branches inside clear it at the point they know what to
+    // say, but `setOriginBusy(true)` fires before any of them and the failure
+    // this PR is about is precisely a path that never reaches its re-enable:
+    // an unhandled throw here (a render() failure, a DOM shape this popup did
+    // not expect) would otherwise leave Allow and Deny dead for the life of
+    // the popup, which reads as "I clicked and nothing happened". Clearing a
+    // flag twice is free; leaving it set is the bug.
+    setOriginBusy(false);
+  }
+}
+
+async function decideOnce(decision: OriginDecision): Promise<void> {
   // The click answers what the user SAW — shownPromptOrigin/shownPromptId
   // captured at render — never a re-read of current state: re-reading was
   // round-2 B1's consent hole, where a prompt replaced after render made the
@@ -932,13 +993,55 @@ async function decide(decision: OriginDecision): Promise<void> {
     // once the echo clears.
     decidedOrigin = { origin, decision, entryId: promptId, decidedAt: Date.now() };
     showOriginAck(decision);
-    const response = (await chrome.runtime.sendMessage({
-      event: "origin_decision",
-      origin,
-      decision,
-      entryId: promptId,
-    })) as { applied?: boolean } | undefined;
-    if (!response?.applied) {
+    // The worker round-trip is BOUNDED and its failure is contained, because a
+    // wedged worker turns this click into the user's "I clicked and nothing
+    // happened": `setOriginBusy(true)` above disabled Allow/Deny, and before
+    // this every path out of a rejected or never-answered sendMessage skipped
+    // the re-enable, leaving the controls dead for the life of the popup. A
+    // stale MV3 worker produces both halves — it rejects immediately ("Could
+    // not establish connection") when it is gone, and answers nothing at all
+    // when it is loaded but mute, which is the state the operator hit.
+    //
+    // `chrome.runtime.sendMessage` has no timeout option, so the bound is a
+    // race. The loser is not cancellable, which is harmless: an answer arriving
+    // late resolves a promise nobody reads, and render() below re-reads the
+    // real state from storage and /health either way.
+    let response: { applied?: boolean } | undefined;
+    let reachedWorker = true;
+    try {
+      response = (await Promise.race([
+        chrome.runtime.sendMessage({
+          event: "origin_decision",
+          origin,
+          decision,
+          entryId: promptId,
+        }),
+        new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), DECISION_TIMEOUT_MS)).then(
+          () => {
+            reachedWorker = false;
+            return undefined;
+          },
+        ),
+      ])) as { applied?: boolean } | undefined;
+    } catch {
+      // The send itself rejected: no receiver, or the worker died mid-flight.
+      // Not rethrown — the click handler is `() => void decide(...)`, so a
+      // rejection here would be an uncaught rejection on the popup page for a
+      // failure the user is about to be told about honestly.
+      reachedWorker = false;
+    }
+    if (!reachedWorker) {
+      // Nothing answered, so the decision's fate is unknown to this popup: do
+      // NOT leave the optimistic ack latched claiming it was applied.
+      decidedOrigin = null;
+      setOriginBusy(false);
+      const notice = noticeForUnreachableWorker();
+      showOriginNotice(notice.title, notice.sub);
+      // The same read-hold the other notices take, then fall through to
+      // render(), which re-probes /health — and paints the unresponsive card
+      // when the daemon confirms the worker is the thing that is wedged.
+      await new Promise((resolve) => setTimeout(resolve, NOTICE_HOLD_MS));
+    } else if (!response?.applied) {
       decidedOrigin = null;
       // A rejection with an EMPTY prompt id came from a /health-fallback
       // render (no generation to aim at) — the request was not replaced, and
@@ -958,7 +1061,7 @@ async function decide(decision: OriginDecision): Promise<void> {
         // Hold the notice long enough to read (same shape as the pairing
         // success hold), then fall through to render(), which draws the
         // CURRENT prompt with live buttons.
-        await new Promise((resolve) => setTimeout(resolve, 1500));
+        await new Promise((resolve) => setTimeout(resolve, NOTICE_HOLD_MS));
       }
     }
   }

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -439,7 +439,21 @@ async function connect(): Promise<void> {
     // dial deadline reaps it, and the console says which one it was.
     let frame: DaemonMessage;
     try {
-      frame = JSON.parse(String(message.data)) as DaemonMessage;
+      const parsed: unknown = JSON.parse(String(message.data));
+      // PARSING IS ONLY HALF THE GUARD. `null`, `2`, `"x"`, `true` and `[]` are
+      // all VALID JSON, so they clear `JSON.parse` and then reach the `"method"
+      // in frame` test below — and `in` throws `TypeError` on any non-object.
+      // That is the same uncaught-throw-in-an-event-handler this whole block
+      // exists to remove, reached by the same class of input (a truncated or
+      // garbled daemon write) that motivated the parse guard, so the shape
+      // check has to live inside the same guard rather than trusting the cast.
+      // Arrays are rejected too: `"method" in []` is legal but an array is not
+      // a frame, and letting one through would hand `dispatch` a bad request.
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        console.warn("dropped an unparseable frame from the daemon", parsed);
+        return;
+      }
+      frame = parsed as DaemonMessage;
     } catch (error) {
       console.warn("dropped an unparseable frame from the daemon", error);
       return;

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -121,6 +121,31 @@ function fireAndForget(op: Promise<unknown> | undefined | void, what: string): v
   void Promise.resolve(op).catch((error) => console.warn(`${what} failed`, error));
 }
 
+/**
+ * Fire-and-forget an async function whose SYNCHRONOUS throw is as fatal as its
+ * rejection.
+ *
+ * `fireAndForget` above takes a promise, so the call that produces it has
+ * already run by the time containment is applied: an `async function` that
+ * throws before its first `await` still rejects (safe), but a plain function
+ * that throws synchronously escapes into the caller. That caller here is always
+ * a Chrome event handler — an alarm tick, a runtime lifecycle event, the socket
+ * `onmessage` — and an exception thrown out of one of those is an uncaught
+ * error in the worker, which is the state this PR exists to eliminate: Chrome's
+ * MV3 worker is poisoned by exactly that, and the operator's dead toolbar
+ * clicks (2026-09-11 20:23) coincided with a worker that never dialled again.
+ *
+ * Taking a THUNK rather than a promise is what closes that window — the call
+ * itself happens inside the try.
+ */
+function guarded(op: () => Promise<unknown> | unknown, what: string): void {
+  try {
+    fireAndForget(Promise.resolve(op()), what);
+  } catch (error) {
+    console.warn(`${what} failed`, error);
+  }
+}
+
 // Raise a system notification when a site decision is pending (finding U2).
 // BEST-EFFORT ONLY: on macOS this banner frequently never reaches the user —
 // Chrome needs its own Notification Center authorization (System Settings →
@@ -338,7 +363,21 @@ async function connect(): Promise<void> {
     return;
   }
 
-  const wire = new WebSocket(`ws://127.0.0.1:${port}/extension`);
+  // `new WebSocket()` THROWS synchronously on a malformed or blocked URL — and
+  // `port` comes from chrome.storage, so a corrupted value reaches this line as
+  // a constructor argument. Every caller of connect() is `void connect()` from
+  // an event handler, so an escape here is an uncaught worker error rather than
+  // a failed dial. Contain it and let the ordinary backoff retry: a bad stored
+  // port is fixed by re-pairing, not by crashing the worker in between.
+  let wire: WebSocket;
+  try {
+    wire = new WebSocket(`ws://127.0.0.1:${port}/extension`);
+  } catch (error) {
+    console.warn("extension dial failed to open a socket", error);
+    connecting = false;
+    scheduleReconnect();
+    return;
+  }
   socket = wire;
   // This dial's identity. Everything asynchronous that belongs to it — the
   // handshake writes, the frames it carries, and every response a handler it
@@ -392,9 +431,27 @@ async function connect(): Promise<void> {
   };
   wire.onmessage = (message) => {
     if (socket !== wire) return; // a superseded socket's frames are not ours
-    const frame = JSON.parse(String(message.data)) as DaemonMessage;
-    if ("method" in frame) void dispatch(frame, generation);
-    else if (frame.event === "ping") wire.send(JSON.stringify({ event: "pong" }));
+    // A frame that does not parse is a DAEMON-side defect (a truncated write, a
+    // future protocol version, a proxy injecting something), and it used to
+    // throw straight out of this handler — an uncaught error in the worker for
+    // one bad byte on the wire, with every later frame on a healthy socket
+    // still pending. Drop the frame, keep the socket: the daemon retries or the
+    // dial deadline reaps it, and the console says which one it was.
+    let frame: DaemonMessage;
+    try {
+      frame = JSON.parse(String(message.data)) as DaemonMessage;
+    } catch (error) {
+      console.warn("dropped an unparseable frame from the daemon", error);
+      return;
+    }
+    // `dispatch` already answers its own failures through `respond`, but the
+    // guard covers the path where dispatch itself cannot start (a throw before
+    // its first await), which would otherwise land as an uncaught rejection.
+    if ("method" in frame) guarded(() => dispatch(frame as { id: string; method: string; params: Record<string, unknown> }, generation), `dispatch ${String((frame as { method: string }).method)}`);
+    // `send` on a socket that raced into CLOSING throws InvalidStateError. The
+    // pong is the daemon's liveness probe, so losing one costs a link teardown
+    // — but throwing here costs the whole worker.
+    else if (frame.event === "ping") guarded(() => wire.send(JSON.stringify({ event: "pong" })), "pong");
     else if (frame.event === "hello_ack") {
       paired = frame.paired;
       fireAndForget(
@@ -462,7 +519,7 @@ function scheduleReconnect(): void {
   attempt += 1;
   fastPathTimer = setTimeout(() => {
     fastPathTimer = undefined;
-    void connect();
+    guarded(connect, "fast-path dial");
   }, delay);
 }
 
@@ -477,22 +534,28 @@ function ensureReconnectAlarm(): void {
   chrome.alarms.create(RECONNECT_ALARM_NAME, { periodInMinutes: RECONNECT_ALARM_PERIOD_MINUTES });
 }
 ensureReconnectAlarm();
+// Every dial below is `guarded` rather than `void`d. These are the RECOVERY
+// paths — the alarm floor is the only thing that rewakes a suspended worker —
+// so a rejection escaping one of them is both an uncaught worker error and the
+// loss of the tick that was meant to heal the connection.
 chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === RECONNECT_ALARM_NAME && shouldDialOnAlarm({ connected, connecting })) void connect();
+  if (alarm.name === RECONNECT_ALARM_NAME && shouldDialOnAlarm({ connected, connecting })) {
+    guarded(connect, "alarm dial");
+  }
   // The sweep persists receipts, resolves in-command waiters through the queue
   // observer, and centrally re-arms the earliest remaining queue/result/grant
   // deadline. No caller owns this alarm independently.
-  if (alarm.name === ACCESS_EXPIRY_ALARM) void expireAccessRequest();
+  if (alarm.name === ACCESS_EXPIRY_ALARM) guarded(expireAccessRequest, "access expiry sweep");
 });
 chrome.runtime.onStartup.addListener(() => {
   alive = true;
   ensureReconnectAlarm();
-  void connect();
+  guarded(connect, "startup dial");
 });
 chrome.runtime.onInstalled.addListener(() => {
   alive = true;
   ensureReconnectAlarm();
-  void connect();
+  guarded(connect, "install dial");
 });
 // Cold-start convergence: on every worker start (including a rewake from
 // suspension, when the globals have reset to their false initializers) the
@@ -506,7 +569,7 @@ alive = true;
 // contain failure so MV3 never reports an unhandled top-level rejection.
 void restoreAccessQueue()
   .catch((error) => console.warn("approval queue restore failed", error))
-  .finally(() => void connect());
+  .finally(() => guarded(connect, "cold-start dial"));
 
 // TOP-LEVEL REGISTRATION IS LOAD-BEARING (MV3): a service worker is torn down
 // when idle and re-instantiated by an event, and only listeners registered

--- a/extension/tests/bridge-wedge.integration.test.mjs
+++ b/extension/tests/bridge-wedge.integration.test.mjs
@@ -171,7 +171,7 @@ function installChrome({ overrides = {}, hangFirstSessionGet = false } = {}) {
     ),
     runtime: {
       getURL: (path) => `chrome-extension://test/${path}`,
-      getManifest: () => ({ version: "0.1.10" }),
+      getManifest: () => ({ version: "0.1.12" }),
       onStartup: { addListener: () => {} },
       onInstalled: { addListener: () => {} },
       onMessage: { addListener: () => {} },
@@ -447,7 +447,7 @@ async function loadWorker({ sendMessage, aliasTabGroups = null } = {}) {
     overrides: {
       runtime: {
         getURL: (path) => `chrome-extension://test/${path}`,
-        getManifest: () => ({ version: "0.1.10" }),
+        getManifest: () => ({ version: "0.1.12" }),
         onStartup: { addListener: () => {} },
         onInstalled: { addListener: () => {} },
         onMessage: { addListener: () => {} },
@@ -762,18 +762,27 @@ test("X3 an unparseable daemon frame does not throw out of the socket handler", 
   const realWarn = console.warn;
   console.warn = (...args) => warnings.push(args.map(String).join(" "));
   try {
-    // A truncated write, a proxy injecting a body, a future protocol version:
-    // whatever the cause, it reaches onmessage as a string JSON.parse rejects.
-    // The old handler let that throw, taking the whole event handler with it.
-    worker.socket.onmessage?.({ data: "{not json" });
+    // Two distinct classes, and the second is the one that survived round 1.
+    // "{not json" fails INSIDE JSON.parse. But `null`, `2`, `"x"`, `true` and
+    // `[]` are all VALID JSON: they parse cleanly and then reach `"method" in
+    // frame`, where `in` throws TypeError on any non-object — an uncaught throw
+    // out of the socket handler reached by exactly the input class that
+    // motivated the parse guard (review F1). Every one is driven here, because
+    // a test that only covers the parse failure is green over the hole.
+    const payloads = ["{not json", "null", "2", '"x"', "true", "[]", "[1,2]"];
+    for (const data of payloads) {
+      worker.socket.onmessage?.({ data });
+      await tick(10);
+    }
     await tick(40);
 
     // The observation is the harness's, not a string grep: nothing escaped.
     assert.deepEqual(rejections, [], "a bad frame escaped as an unhandled rejection");
     assert.deepEqual(uncaught, [], "a bad frame escaped as an uncaught exception");
-    assert.ok(
-      warnings.some((line) => line.includes("unparseable frame")),
-      `expected the drop to be recorded, got ${JSON.stringify(warnings)}`,
+    assert.equal(
+      warnings.filter((line) => line.includes("unparseable frame")).length,
+      payloads.length,
+      `every malformed frame must be recorded as dropped, got ${JSON.stringify(warnings)}`,
     );
 
     // And the SOCKET survives it: the next good frame is still answered, which

--- a/extension/tests/bridge-wedge.integration.test.mjs
+++ b/extension/tests/bridge-wedge.integration.test.mjs
@@ -741,3 +741,131 @@ test("A3 a snapshot stalled on one tab does not hold another tab's lane (D1)", a
     delete globalThis.chrome;
   }
 });
+
+// --- X3/X4: the worker's remaining uncaught paths (popup-stale-worker lane) --
+//
+// X2 above covers the fire-and-forget `sendMessage` broadcast. These two cover
+// the paths that were still able to throw OUT of a Chrome event handler on that
+// fix's head — which is the same defect with a different origin: an uncaught
+// error in an MV3 worker is the state Chrome's worker is poisoned into, and a
+// poisoned worker is what made the operator's toolbar clicks do nothing.
+
+test("X3 an unparseable daemon frame does not throw out of the socket handler", async () => {
+  const rejections = [];
+  const uncaught = [];
+  const onRejection = (error) => rejections.push(error);
+  const onUncaught = (error) => uncaught.push(error);
+  process.on("unhandledRejection", onRejection);
+  process.on("uncaughtException", onUncaught);
+  const worker = await loadWorker();
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    // A truncated write, a proxy injecting a body, a future protocol version:
+    // whatever the cause, it reaches onmessage as a string JSON.parse rejects.
+    // The old handler let that throw, taking the whole event handler with it.
+    worker.socket.onmessage?.({ data: "{not json" });
+    await tick(40);
+
+    // The observation is the harness's, not a string grep: nothing escaped.
+    assert.deepEqual(rejections, [], "a bad frame escaped as an unhandled rejection");
+    assert.deepEqual(uncaught, [], "a bad frame escaped as an uncaught exception");
+    assert.ok(
+      warnings.some((line) => line.includes("unparseable frame")),
+      `expected the drop to be recorded, got ${JSON.stringify(warnings)}`,
+    );
+
+    // And the SOCKET survives it: the next good frame is still answered, which
+    // is the whole point of dropping the frame rather than the connection.
+    worker.deliver({ event: "ping" });
+    await tick(40);
+    assert.deepEqual(
+      worker.sent.filter((frame) => frame.event === "pong"),
+      [{ event: "pong" }],
+      "one bad byte on the wire must not cost the live socket",
+    );
+  } finally {
+    process.off("unhandledRejection", onRejection);
+    process.off("uncaughtException", onUncaught);
+    console.warn = realWarn;
+    await worker.close();
+    delete globalThis.chrome;
+  }
+});
+
+test("X4 a socket constructor that throws leaves the worker able to dial again", async () => {
+  // `new WebSocket()` throws synchronously on a malformed URL, and the port it
+  // is built from comes out of chrome.storage — so a corrupted stored value
+  // reaches that constructor. Every caller is a fire-and-forget from an event
+  // handler, so the throw surfaced as an uncaught worker error instead of a
+  // failed dial.
+  const rejections = [];
+  const uncaught = [];
+  const onRejection = (error) => rejections.push(error);
+  const onUncaught = (error) => uncaught.push(error);
+  process.on("unhandledRejection", onRejection);
+  process.on("uncaughtException", onUncaught);
+  installChrome({
+    overrides: {
+      runtime: {
+        getURL: (path) => `chrome-extension://test/${path}`,
+        getManifest: () => ({ version: "0.1.12" }),
+        onStartup: { addListener: () => {} },
+        onInstalled: { addListener: () => {} },
+        onMessage: { addListener: () => {} },
+        sendMessage: async () => {},
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: "node-test" },
+    configurable: true,
+    writable: true,
+  });
+  let constructed = 0;
+  globalThis.WebSocket = class {
+    static OPEN = 1;
+    readyState = 1;
+    constructor() {
+      constructed += 1;
+      // Only the FIRST dial throws. A worker that could never dial again would
+      // pass a "no uncaught error" assertion while being exactly as dead as the
+      // one this fix is about, so recovery is what is actually asserted below.
+      if (constructed === 1) throw new SyntaxError("'ws://127.0.0.1:NaN/extension' is invalid.");
+      queueMicrotask(() => this.onopen?.());
+    }
+    send() {}
+    close() {}
+  };
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  let worker;
+  try {
+    worker = await load(`export * from ${JSON.stringify(join(SRC, "worker.ts"))};`);
+    await tick(40);
+    assert.deepEqual(rejections, [], "the constructor throw escaped as an unhandled rejection");
+    assert.deepEqual(uncaught, [], "the constructor throw escaped as an uncaught exception");
+    assert.ok(
+      warnings.some((line) => line.includes("dial failed to open a socket")),
+      `expected the failed dial to be recorded, got ${JSON.stringify(warnings)}`,
+    );
+    assert.equal(constructed, 1, "precondition: exactly the first dial threw");
+
+    // RECOVERY is the assertion that matters. A worker that swallowed the throw
+    // and then never dialled again would satisfy every check above while being
+    // exactly as dead as the wedge this PR is about. The fast-path backoff for
+    // attempt 0 is 1s (reconnect.ts), so wait past it and require a SECOND
+    // socket — which also drains the armed timer, leaving no live handle behind
+    // for the next test in this file.
+    for (let i = 0; i < 40 && constructed < 2; i++) await tick(50);
+    assert.equal(constructed, 2, "a failed dial must be retried, not abandoned");
+  } finally {
+    process.off("unhandledRejection", onRejection);
+    process.off("uncaughtException", onUncaught);
+    console.warn = realWarn;
+    if (worker) await worker.close();
+    delete globalThis.chrome;
+  }
+});

--- a/extension/tests/popup-pairing-jitter.integration.test.mjs
+++ b/extension/tests/popup-pairing-jitter.integration.test.mjs
@@ -567,10 +567,16 @@ test("the pin is applied BEFORE the first paint, not by the deferred module (Q4)
   const owned = Object.fromEntries(
     [...popup.matchAll(/const PIN_(\w+) = "(\d+)px"/g)].map((m) => [m[1], m[2]]),
   );
+  // Only the DURABLE states carry a pin. A pin is a bet that the next open
+  // repeats this state, and the wedged card is transient by construction — its
+  // own copy asks the user to act and reopen — so pinning it optimised a reopen
+  // nobody makes and cost the recovery open everybody makes a measured 315.84px
+  // collapse (design D1). Asserting the exact SET, not a subset: adding a pin
+  // for a transient state is the regression this encodes.
   assert.deepEqual(
     Object.keys(owned).sort(),
-    ["CONNECTED", "PAIRING", "UNRESPONSIVE"],
-    "popup.ts must own the three measured pins (design D3-1) — a state with no pin of its own reopens at the wrong height",
+    ["CONNECTED", "PAIRING"],
+    "popup.ts must pin the durable states and only those (design D1) — pinning a transient card taxes the next open",
   );
   const early = Object.fromEntries(
     [...source.matchAll(/var PIN_(\w+) = "(\d+)px"/g)].map((m) => [m[1], m[2]]),
@@ -659,17 +665,16 @@ test("the pin follows the card that was rendered, in both directions (D1/D3-1)",
       false,
       "precondition: the wedge state really does render the unresponsive card",
     );
-    // 402px, re-measured after this card gained its one-click "Reload the
-    // extension" action: pin = card height - 121px of constant card chrome,
-    // solved by sweeping the pin in a real headless Chrome at 300x600 dpr=2
-    // (86->207, 219->340, 254->375, 402->523) and verified at 0.27px of first-
-    // paint reflow. The number is asserted here rather than imported from
-    // popup.ts on purpose — a test that reads the constant it is checking
-    // cannot fail when the constant drifts from the measured card.
+    // The wedge card must NOT overwrite the hint. It is transient by
+    // construction, so recording it would pin the next open — which its own
+    // copy asks the user to make — to a height that open will not have: with
+    // this card pinned, the recovery open collapsed a measured 315.84px against
+    // base's 167.84px (design D1). Leaving the durable pin in place means the
+    // wedged open grows into the tall card once and the recovery open is exact.
     assert.equal(
       globalThis.localStorage.getItem("lop:pin-hint"),
-      "402px",
-      "the wedge card must record ITS OWN pin, or every reopen grows into it (D3-1)",
+      "219px",
+      "the transient wedge card must leave the durable pin alone (design D1)",
     );
   } finally {
     await bundle.close();

--- a/extension/tests/popup-pairing-jitter.integration.test.mjs
+++ b/extension/tests/popup-pairing-jitter.integration.test.mjs
@@ -659,9 +659,16 @@ test("the pin follows the card that was rendered, in both directions (D1/D3-1)",
       false,
       "precondition: the wedge state really does render the unresponsive card",
     );
+    // 402px, re-measured after this card gained its one-click "Reload the
+    // extension" action: pin = card height - 121px of constant card chrome,
+    // solved by sweeping the pin in a real headless Chrome at 300x600 dpr=2
+    // (86->207, 219->340, 254->375, 402->523) and verified at 0.27px of first-
+    // paint reflow. The number is asserted here rather than imported from
+    // popup.ts on purpose — a test that reads the constant it is checking
+    // cannot fail when the constant drifts from the measured card.
     assert.equal(
       globalThis.localStorage.getItem("lop:pin-hint"),
-      "254px",
+      "402px",
       "the wedge card must record ITS OWN pin, or every reopen grows into it (D3-1)",
     );
   } finally {

--- a/extension/tests/popup-render.integration.test.mjs
+++ b/extension/tests/popup-render.integration.test.mjs
@@ -71,7 +71,19 @@ function installDomStub() {
       addEventListener: (event, handler) => {
         (node._handlers[event] ||= []).push(handler);
       },
-      focus: () => {},
+      // Records HOW focus was called. `preventScroll` is the whole D7/U8 fix:
+      // focusing inside a scroll container scrolls it, which put the title and
+      // the danger banner above the fold at zoom. A stub that ignores the
+      // options object cannot tell the fix from its absence.
+      focus: (options) => {
+        node._focusCalls.push(options ?? null);
+        globalThis.document.activeElement = node;
+        // The real container scrolls to reveal the focused element unless the
+        // caller opts out — modelled so the assertion is on the OUTCOME
+        // (where the card sits) rather than on the argument alone.
+        const body = nodes.get("__body");
+        if (body && !(options && options.preventScroll)) body.scrollTop = body._maxScroll ?? 0;
+      },
       replaceChildren: (...kids) => {
         node.children = kids;
         // A real <select> adopts the first option's value on replaceChildren;
@@ -82,6 +94,8 @@ function installDomStub() {
       },
       querySelectorAll: () => [],
       _handlers: {},
+      _focusCalls: [],
+      scrollTop: 0,
       click: () => (node._handlers.click || []).forEach((h) => h()),
     };
     // The scope select reports its options the way popup.ts reads them.
@@ -92,6 +106,12 @@ function installDomStub() {
     return node;
   };
   for (const id of IDS) nodes.set(id, make(id));
+  // The scroll container the bounded card introduced. `_maxScroll` stands in
+  // for a card taller than the viewport, which is the only condition under
+  // which focus-scrolling is observable at all.
+  const bodyNode = make("__body");
+  bodyNode._maxScroll = 139;
+  nodes.set("__body", bodyNode);
   // Button labels the real markup ships with. popup.ts restores a label it
   // swapped out (the "Checking…" in-flight state), so a stub whose buttons
   // start blank would make a correct restore look like a cleared button.
@@ -99,6 +119,7 @@ function installDomStub() {
 
   globalThis.document = {
     getElementById: (id) => nodes.get(id) ?? null,
+    querySelector: (selector) => (selector === ".body" ? nodes.get("__body") : null),
     createElement: () => make("option"),
     querySelectorAll: () => [],
     addEventListener: () => {},
@@ -949,6 +970,109 @@ test("Check again shows that it checked, and says so when nothing changed", asyn
       "an unchanged answer must still be stated",
     );
     assert.match(nodes.get("unresponsive-outcome").textContent, /still not answering/i);
+  } finally {
+    await bundle.close();
+  }
+});
+
+/* --- Round 2: the banner must not over-claim, and the card must open at its top */
+
+test("the banner stays hidden while the decision is still deliverable (M1)", async () => {
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  // The post-drop latch: the daemon severed the socket, so `link_attached` is
+  // false, but `extension_unresponsive` stays true for LINK_DROP_TTL_S = 60s
+  // while the worker is usually alive and re-dialling. A decision travels over
+  // chrome.runtime.sendMessage, which never touched that socket — so it is
+  // deliverable, and the banner claiming otherwise steers the user at a reload
+  // that would destroy the very decision they came to answer (review M1).
+  let health = {
+    paired: true,
+    extension_connected: false,
+    extension_unresponsive: true,
+    link_attached: false,
+    protocol_version: 1,
+  };
+  installHealth(() => health);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("token", "t");
+    areas.session.set("accessQueue", [pendingEntry()]);
+    areas.session.set("accessQueueVersion", 1);
+    await bundle.import();
+    await tick(20);
+    assert.equal(nodes.get("origin").classList.contains("hidden"), false, "precondition: the prompt is up");
+    assert.equal(
+      nodes.get("origin-wedge").classList.contains("hidden"),
+      true,
+      "a severed-but-re-dialling link must not be reported as an undeliverable decision",
+    );
+
+    // And the decision really is deliverable in that state — which is what
+    // makes the banner a false claim rather than a cautious one.
+    nodes.get("origin-allow").click();
+    await tick(80);
+    assert.match(
+      nodes.get("origin-ack-title").textContent,
+      /allowed\./i,
+      "the decision must apply normally while the link is merely dropped",
+    );
+
+    // ATTACHED and mute is the case the banner is actually for: sendMessage
+    // genuinely has nowhere to land.
+    health = { ...health, link_attached: true };
+    areas.session.set("accessQueue", [pendingEntry("gen-2")]);
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(30);
+    assert.equal(
+      nodes.get("origin-wedge").classList.contains("hidden"),
+      false,
+      "an attached-but-mute worker must still raise the banner",
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("a fresh prompt opens at the top of its card, not scrolled past its banner (D7/U8)", async () => {
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  installHealth(() => ({
+    paired: true,
+    extension_connected: false,
+    extension_unresponsive: true,
+    link_attached: true,
+    protocol_version: 1,
+  }));
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("token", "t");
+    areas.session.set("accessQueue", [pendingEntry()]);
+    areas.session.set("accessQueueVersion", 1);
+    await bundle.import();
+    await tick(30);
+
+    const scope = nodes.get("origin-scope");
+    const body = globalThis.document.querySelector(".body");
+    assert.equal(nodes.get("origin-wedge").classList.contains("hidden"), false, "precondition: the banner is up");
+
+    // The keyboard landing point is unchanged — the fix must not cost it.
+    assert.ok(scope._focusCalls.length > 0, "the scope select is still focused for the keyboard");
+    assert.equal(globalThis.document.activeElement, scope, "and it really holds focus");
+
+    // THE DEFECT: focusing inside the scroll container scrolled the card to its
+    // maximum, putting the title and the whole danger banner above the fold at
+    // >=125% zoom — a zoomed user saw an ordinary consent prompt with live
+    // Allow/Deny and no sign their answer could not land.
+    assert.equal(
+      body.scrollTop,
+      0,
+      "the card must open at its top: the question and the banner qualifying it are the first things to read",
+    );
+    assert.ok(
+      scope._focusCalls.some((options) => options && options.preventScroll === true),
+      "focus must opt out of scrolling rather than rely on the card being short enough",
+    );
   } finally {
     await bundle.close();
   }

--- a/extension/tests/popup-render.integration.test.mjs
+++ b/extension/tests/popup-render.integration.test.mjs
@@ -18,10 +18,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { build } from "esbuild";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 /** The popup's markup, reduced to the ids and classes popup.ts touches.
  * Kept as a literal id list rather than parsing popup.html: a test that
@@ -33,7 +35,8 @@ const IDS = [
   "origin-host", "origin-again", "origin-scope", "origin-scope-detail", "origin-position",
   "origin-waiting", "origin-allow", "origin-deny", "origin-previous", "origin-next",
   "origin-ack-title", "origin-ack-sub", "origin-ack-check", "card", "retry",
-  "retry-incompatible", "retry-unresponsive", "connected-all-sites", "connected-all-sites-off",
+  "retry-incompatible", "retry-unresponsive", "reload-extension",
+  "connected-all-sites", "connected-all-sites-off",
   "pair-form",
   "pair-code", "pair-error", "port", "port-row",
 ];
@@ -102,10 +105,14 @@ function installDomStub() {
   return nodes;
 }
 
-function installChromeStub() {
+function installChromeStub({ sendMessage } = {}) {
   const areas = { session: new Map(), local: new Map() };
   const listeners = [];
   const sent = [];
+  // Every chrome.runtime.reload() the popup made. Counted rather than flagged:
+  // "the popup reloaded the extension twice" is a real defect (the second call
+  // races the teardown of the first) and a boolean cannot see it.
+  const reloads = [];
   const makeArea = (name) => ({
     get: async (keys) => {
       const out = {};
@@ -140,8 +147,13 @@ function installChromeStub() {
     // The worker resolves the decided entry and writes the queue back. Modelled
     // faithfully, because the ordering under test IS the storage ordering.
     runtime: {
+      reload: () => reloads.push(Date.now()),
       sendMessage: async (message) => {
         sent.push(message);
+        // A test-supplied worker replaces the faithful one below: an
+        // unresponsive worker is the whole subject of the decide() tests, and
+        // it is expressed as what sendMessage DOES, not as a flag.
+        if (sendMessage) return sendMessage(message);
         if (message?.event !== "origin_decision") return { applied: true };
         const queue = areas.session.get("accessQueue") ?? [];
         const rest = queue.filter((e) => e.entryId !== message.entryId);
@@ -153,7 +165,7 @@ function installChromeStub() {
     },
     tabs: { query: async () => [] },
   };
-  return { areas, sent };
+  return { areas, sent, reloads };
 }
 
 const entry = (entryId, origin = "https://app.example.com", broad = { scope: "domain", key: "example.com" }) => ({
@@ -491,6 +503,179 @@ test("a wedged worker is not painted as connected (D4)", async () => {
     );
     assert.equal(nodes.get("pairing").classList.contains("hidden"), true, "a paired browser must not be asked for a code");
     assert.equal(nodes.get("connected").classList.contains("hidden"), true);
+  } finally {
+    await bundle.close();
+  }
+});
+
+/* --- The stale/unresponsive worker, from the popup's seat -------------------
+ *
+ * The operator's complaint was "I click the toolbar icon and nothing happens,
+ * it takes 2-3 tries". Chrome owns opening the popup, so a click that shows
+ * NOTHING means the MV3 worker never started; but a click that shows a popup
+ * whose buttons then do nothing is this module's fault, and that is what these
+ * cover: decide() awaited the worker with no bound and no catch, so a stale
+ * worker left Allow/Deny disabled for the life of the popup with no message.
+ *
+ * Assertions are on what the user can SEE and DO — the buttons' disabled state
+ * and the text in the ack slot — never on the presence of a call.
+ */
+
+/** A live daemon whose /health payload the test controls per render. */
+function installHealth(get) {
+  globalThis.fetch = async () => ({ ok: true, json: async () => get() });
+}
+
+const pendingEntry = (entryId = "gen-1") => ({
+  entryId,
+  origin: "https://app.example.com",
+  displayAuthority: "app.example.com",
+  requester: "req-1",
+  kind: "async",
+  requestedAt: Date.now(),
+  expiresAt: Date.now() + 600_000,
+  sequence: 1,
+  broad: { scope: "domain", key: "example.com" },
+});
+
+test("a decision whose worker REJECTS leaves the controls usable and says so", async () => {
+  const nodes = installDomStub();
+  const { areas } = installChromeStub({
+    // Exactly what MV3 throws when the worker is gone and nothing receives the
+    // message — captured from the operator's own console.
+    sendMessage: async () => {
+      throw new Error("Could not establish connection. Receiving end does not exist.");
+    },
+  });
+  installHealth(() => ({ paired: true, extension_connected: true, protocol_version: 1 }));
+  const rejections = [];
+  const onRejection = (error) => rejections.push(error);
+  process.on("unhandledRejection", onRejection);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("token", "t");
+    areas.session.set("accessQueue", [pendingEntry()]);
+    areas.session.set("accessQueueVersion", 1);
+    await bundle.import();
+    await tick(20);
+    assert.equal(nodes.get("origin").classList.contains("hidden"), false, "precondition: the prompt is up");
+    assert.equal(nodes.get("origin-allow").disabled, false, "precondition: Allow is clickable");
+
+    nodes.get("origin-allow").click();
+    // Past the notice hold (1500ms), so the settled state is what is asserted.
+    await tick(1800);
+
+    // THE DEFECT: setOriginBusy(true) ran, the await rejected, and nothing ever
+    // re-enabled these. From the user's seat the popup stopped responding.
+    assert.equal(nodes.get("origin-allow").disabled, false, "Allow must not be left disabled by an unreachable worker");
+    assert.equal(nodes.get("origin-deny").disabled, false, "Deny must not be left disabled by an unreachable worker");
+
+    // And the click must be ACKNOWLEDGED honestly rather than silently dropped.
+    const title = nodes.get("origin-ack-title").textContent;
+    const sub = nodes.get("origin-ack-sub").textContent;
+    assert.match(title, /didn't|did not|no answer/i, `the user must be told the extension did not answer, got ${JSON.stringify(title)}`);
+    assert.doesNotMatch(
+      title + " " + sub,
+      /request changed/i,
+      "'Request changed.' means a REPLACED generation — a live worker's answer — and must not be reused for an unreachable one",
+    );
+    assert.deepEqual(rejections, [], "the failed round-trip escaped as an unhandled rejection");
+  } finally {
+    process.off("unhandledRejection", onRejection);
+    await bundle.close();
+  }
+});
+
+test("a decision whose worker NEVER ANSWERS is bounded and ends the same way", async () => {
+  const nodes = installDomStub();
+  const { areas } = installChromeStub({
+    // The nastier half, and the one the operator actually hit: the worker is
+    // loaded but mute, so the send neither resolves nor rejects — ever. Without
+    // a bound this await is permanent and the popup is dead until it closes.
+    sendMessage: () => new Promise(() => {}),
+  });
+  installHealth(() => ({ paired: true, extension_connected: true, protocol_version: 1 }));
+  const rejections = [];
+  const onRejection = (error) => rejections.push(error);
+  process.on("unhandledRejection", onRejection);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("token", "t");
+    areas.session.set("accessQueue", [pendingEntry()]);
+    areas.session.set("accessQueueVersion", 1);
+    await bundle.import();
+    await tick(20);
+    assert.equal(nodes.get("origin-allow").disabled, false, "precondition: Allow is clickable");
+
+    nodes.get("origin-allow").click();
+    // Still inside the 5s bound: the popup is legitimately waiting, and saying
+    // "no answer" here would libel a merely-slow worker.
+    await tick(300);
+    assert.equal(nodes.get("origin-allow").disabled, true, "while the round-trip is in flight the controls stay busy");
+
+    // Past the bound plus the notice hold.
+    await tick(7000);
+    assert.equal(nodes.get("origin-allow").disabled, false, "the timeout path must re-enable Allow");
+    assert.equal(nodes.get("origin-deny").disabled, false, "the timeout path must re-enable Deny");
+    assert.match(
+      nodes.get("origin-ack-title").textContent,
+      /didn't|did not|no answer/i,
+      "a click that timed out must still be acknowledged",
+    );
+    assert.deepEqual(rejections, [], "the timed-out round-trip escaped as an unhandled rejection");
+  } finally {
+    process.off("unhandledRejection", onRejection);
+    await bundle.close();
+  }
+});
+
+test("the wedged-worker card offers a one-click reload, and a healthy one never does", async () => {
+  const nodes = installDomStub();
+  const { reloads } = installChromeStub();
+  // The daemon is the authority here, deliberately: the worker's own
+  // `connState` reads "connected" long after the worker is dead (it is that
+  // worker's last write), so a reload offered from it would appear on a healthy
+  // popup and disappear on a wedged one — backwards.
+  let health = { paired: true, extension_connected: true, protocol_version: 1 };
+  installHealth(() => health);
+  const bundle = await loadPopup();
+  try {
+    await bundle.import();
+    await tick(20);
+
+    // HEALTHY: the remedy is not on offer. A reload discards open tab handles,
+    // snapshot refs and pending site decisions, so offering it to a working
+    // browser invites a user to pay that for nothing.
+    assert.equal(nodes.get("connected").classList.contains("hidden"), false, "precondition: the healthy card is up");
+    assert.equal(
+      nodes.get("unresponsive").classList.contains("hidden"),
+      true,
+      "a healthy worker must not be offered a reload",
+    );
+    // "Hidden section" is only the same thing as "no reload on offer" because
+    // the control lives INSIDE that section. This harness's DOM is flat (every
+    // id is a sibling), so it cannot express containment and a click on it here
+    // would fire in a state a real user cannot reach. Assert the containment
+    // against the real markup instead, which is what makes the line above a
+    // statement about what the user can do rather than about a CSS class.
+    const markup = await readFile(join(HERE, "..", "src", "popup", "popup.html"), "utf8");
+    const section = markup.slice(markup.indexOf('<section id="unresponsive"'));
+    const body = section.slice(0, section.indexOf("</section>"));
+    assert.ok(
+      body.includes('id="reload-extension"'),
+      "the reload control must live inside #unresponsive, or hiding that card does not withdraw the offer",
+    );
+    assert.deepEqual(reloads, [], "nothing on the healthy path may reload the extension");
+
+    // WEDGED: the daemon says the extension is not answering.
+    health = { ...health, extension_connected: false, extension_unresponsive: true, link_attached: true };
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(20);
+    assert.equal(nodes.get("unresponsive").classList.contains("hidden"), false, "precondition: the wedge card is up");
+
+    nodes.get("reload-extension").click();
+    await tick(20);
+    assert.equal(reloads.length, 1, "the wedge card's primary action must reload the extension exactly once");
   } finally {
     await bundle.close();
   }

--- a/extension/tests/popup-render.integration.test.mjs
+++ b/extension/tests/popup-render.integration.test.mjs
@@ -34,8 +34,9 @@ const IDS = [
   "origin", "origin-ack",
   "origin-host", "origin-again", "origin-scope", "origin-scope-detail", "origin-position",
   "origin-waiting", "origin-allow", "origin-deny", "origin-previous", "origin-next",
-  "origin-ack-title", "origin-ack-sub", "origin-ack-check", "card", "retry",
+  "origin-ack-title", "origin-ack-sub", "origin-ack-check", "origin-ack-granted", "card", "retry",
   "retry-incompatible", "retry-unresponsive", "reload-extension",
+  "origin-wedge", "origin-wedge-reload", "unresponsive-outcome",
   "connected-all-sites", "connected-all-sites-off",
   "pair-form",
   "pair-code", "pair-error", "port", "port-row",
@@ -91,6 +92,10 @@ function installDomStub() {
     return node;
   };
   for (const id of IDS) nodes.set(id, make(id));
+  // Button labels the real markup ships with. popup.ts restores a label it
+  // swapped out (the "Checking…" in-flight state), so a stub whose buttons
+  // start blank would make a correct restore look like a cleared button.
+  nodes.get("retry-unresponsive").textContent = "Check again";
 
   globalThis.document = {
     getElementById: (id) => nodes.get(id) ?? null,
@@ -676,6 +681,274 @@ test("the wedged-worker card offers a one-click reload, and a healthy one never 
     nodes.get("reload-extension").click();
     await tick(20);
     assert.equal(reloads.length, 1, "the wedge card's primary action must reload the extension exactly once");
+  } finally {
+    await bundle.close();
+  }
+});
+
+/* --- Round 1 remediation: the wedged worker WITH a decision pending ---------
+ *
+ * The state three review streams found independently (reviewer/UX U1, QA Q5,
+ * design D3) and the shape of the reported incident: the operator's dead clicks
+ * happened while the agent was driving, i.e. with a request queued. renderOnce()
+ * paints the consent card and returns before the `unresponsive` branch, so the
+ * PR's own remedy was in a hidden section exactly when it was needed.
+ */
+
+test("a decision pending against a WEDGED worker surfaces the remedy inline", async () => {
+  const nodes = installDomStub();
+  const { areas, reloads } = installChromeStub();
+  let health = { paired: true, extension_connected: true, protocol_version: 1 };
+  installHealth(() => health);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("token", "t");
+    areas.session.set("accessQueue", [pendingEntry()]);
+    areas.session.set("accessQueueVersion", 1);
+    await bundle.import();
+    await tick(20);
+
+    // HEALTHY worker, same pending decision: the prompt is a normal prompt. No
+    // banner, and no remedy on offer — a working worker must never be told to
+    // reload, and this is the control that keeps the banner honest.
+    assert.equal(nodes.get("origin").classList.contains("hidden"), false, "precondition: the prompt is up");
+    assert.equal(
+      nodes.get("origin-wedge").classList.contains("hidden"),
+      true,
+      "a healthy worker must not be told its extension stopped answering",
+    );
+
+    // The worker goes mute while the request is still queued. The prompt STAYS
+    // — it is what the user opened the popup for, and hiding it would answer
+    // "the remedy is unreachable" by making the request unreachable instead.
+    health = { ...health, extension_connected: false, extension_unresponsive: true, link_attached: true };
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(20);
+    assert.equal(nodes.get("origin").classList.contains("hidden"), false, "the pending decision stays visible");
+    assert.equal(
+      nodes.get("origin-wedge").classList.contains("hidden"),
+      false,
+      "the card must say the decision cannot be applied right now",
+    );
+
+    // And the remedy is reachable from here, in one click, without finding
+    // another card first.
+    nodes.get("origin-wedge-reload").click();
+    await tick(20);
+    assert.equal(reloads.length, 1, "the inline remedy must reload the extension");
+
+    // RENDER N+1 — every defect in this class is right on N and wrong on N+1.
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(20);
+    assert.equal(nodes.get("origin-wedge").classList.contains("hidden"), false, "the banner must survive a re-render");
+
+    // Recovery: the worker answers again, so the banner must go. A sticky
+    // warning would be its own lie.
+    health = { ...health, extension_connected: true, extension_unresponsive: false };
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(20);
+    assert.equal(
+      nodes.get("origin-wedge").classList.contains("hidden"),
+      true,
+      "the banner must clear when the worker answers again",
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("a decision in flight does not claim success until the worker confirms", async () => {
+  const nodes = installDomStub();
+  let release;
+  const { areas } = installChromeStub({
+    // A worker that answers only when the test says so: the window between the
+    // click and the answer IS the subject, and it was 4.9s of green "Site
+    // allowed." over a decision that was never applied (UX U2).
+    sendMessage: () => new Promise((resolve) => { release = () => resolve({ applied: true }); }),
+  });
+  installHealth(() => ({ paired: true, extension_connected: true, protocol_version: 1 }));
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("token", "t");
+    areas.session.set("accessQueue", [pendingEntry()]);
+    areas.session.set("accessQueueVersion", 1);
+    await bundle.import();
+    await tick(20);
+    nodes.get("origin-allow").click();
+    await tick(50);
+
+    // IN FLIGHT. The click is acknowledged — the user must see it landed — but
+    // none of the three things that read as "done" may be on screen.
+    assert.match(
+      nodes.get("origin-ack-title").textContent,
+      /allowing/i,
+      "an in-flight decision must acknowledge the click and name which way it went",
+    );
+    assert.equal(nodes.get("origin-ack-check").classList.contains("hidden"), true, "no check before the worker confirms");
+    assert.equal(
+      nodes.get("origin-ack-granted").classList.contains("hidden"),
+      true,
+      "the granted trough means 'this is what you granted' and must not precede the grant",
+    );
+
+    // CONFIRMED: now, and only now, the success card.
+    release();
+    await tick(60);
+    // The entry's default scope is `domain`, so the confirmed ack names the
+    // domain grant — asserting the CONFIRMED vocabulary, not a fixed string:
+    // what matters is that it switched out of the progressive in-flight voice.
+    assert.match(
+      nodes.get("origin-ack-title").textContent,
+      /allowed\./i,
+      "a confirmed decision reads as done, not as in progress",
+    );
+    assert.doesNotMatch(nodes.get("origin-ack-title").textContent, /allowing/i);
+    assert.equal(nodes.get("origin-ack-check").classList.contains("hidden"), false, "a confirmed decision shows the check");
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("the unreachable-worker notice carries no granted value", async () => {
+  const nodes = installDomStub();
+  // The trough is filled by a CONFIRMED ack, so the only way to reach the bug
+  // is the real sequence: one decision lands (printing the granted host), the
+  // next one cannot be delivered. Asserting it from a first, never-confirmed
+  // click would pass with the fix reverted, because the in-flight ack no longer
+  // fills the trough at all — the guard has to be proven where it bites.
+  let worker = "alive";
+  const { areas } = installChromeStub({
+    sendMessage: async (message) => {
+      if (worker === "dead") {
+        throw new Error("Could not establish connection. Receiving end does not exist.");
+      }
+      const queue = areas.session.get("accessQueue") ?? [];
+      await chrome.storage.session.set({
+        accessQueue: queue.filter((e) => e.entryId !== message.entryId),
+      });
+      return { applied: true };
+    },
+  });
+  installHealth(() => ({ paired: true, extension_connected: true, protocol_version: 1 }));
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("token", "t");
+    areas.session.set("accessQueue", [pendingEntry("gen-1"), pendingEntry("gen-2")]);
+    areas.session.set("accessQueueVersion", 1);
+    await bundle.import();
+    await tick(20);
+
+    // Decision one lands, so the granted host is printed in the trough.
+    nodes.get("origin-allow").click();
+    await tick(80);
+    assert.equal(
+      nodes.get("origin-ack-granted").classList.contains("hidden"),
+      false,
+      "precondition: a confirmed decision prints what it granted",
+    );
+    const granted = nodes.get("origin-ack-granted").textContent;
+    assert.ok(granted, "precondition: the trough actually carries a value");
+
+    // The worker dies before the next decision can be delivered.
+    worker = "dead";
+    await tick(40);
+    nodes.get("origin-allow").click();
+    await tick(1800);
+
+    // The trough is the element a user reads as the granted value. Leaving the
+    // previous decision's host under "may not have been applied" prints an
+    // answer to a question the popup just said it cannot answer (UX U3).
+    assert.match(nodes.get("origin-ack-title").textContent, /didn't|did not|no answer/i);
+    assert.equal(
+      nodes.get("origin-ack-granted").classList.contains("hidden"),
+      true,
+      "a decision that may not have been applied must not print a granted value",
+    );
+    assert.equal(
+      nodes.get("origin-ack-granted").textContent,
+      "",
+      "the granted trough must be cleared, not merely hidden — a later ack would reveal the stale host",
+    );
+    assert.equal(nodes.get("origin-ack-check").classList.contains("hidden"), true, "no check on an unapplied decision");
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("a decision does not resurrect queue controls the renderer disabled", async () => {
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  installHealth(() => ({ paired: true, extension_connected: true, protocol_version: 1 }));
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("token", "t");
+    // Two entries, so Previous/Next start live; deciding one leaves a single
+    // request, and a single-request prompt must not offer two inert stops (U4).
+    areas.session.set("accessQueue", [pendingEntry("gen-1"), pendingEntry("gen-2")]);
+    areas.session.set("accessQueueVersion", 1);
+    await bundle.import();
+    await tick(20);
+    assert.equal(nodes.get("origin-previous").disabled, false, "precondition: two entries, navigation is live");
+
+    nodes.get("origin-allow").click();
+    await tick(60);
+
+    // The decision owns its own three controls. Previous/Next are DERIVED from
+    // queue length by renderQueueControls, and the decision's cleanup runs
+    // after that render — so re-enabling them here overwrote the renderer.
+    assert.equal(nodes.get("origin-allow").disabled, false, "the decision's own controls come back");
+    assert.equal(
+      nodes.get("origin-previous").disabled,
+      true,
+      "one entry left: queue navigation stays the renderer's call, not the decision's",
+    );
+    assert.equal(nodes.get("origin-next").disabled, true, "same for Next");
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("Check again shows that it checked, and says so when nothing changed", async () => {
+  const nodes = installDomStub();
+  installChromeStub();
+  const health = {
+    paired: true,
+    extension_connected: false,
+    extension_unresponsive: true,
+    link_attached: true,
+    protocol_version: 1,
+  };
+  let probes = 0;
+  globalThis.fetch = async () => {
+    probes += 1;
+    return { ok: true, json: async () => health };
+  };
+  const bundle = await loadPopup();
+  try {
+    await bundle.import();
+    await tick(20);
+    assert.equal(nodes.get("unresponsive").classList.contains("hidden"), false, "precondition: the wedge card is up");
+    const before = probes;
+
+    nodes.get("retry-unresponsive").click();
+    // Mid-probe: the click must own the button, or a re-check that changes
+    // nothing is indistinguishable from a dead click — the exact complaint this
+    // PR was filed about, reappearing on the recovery card (UX U4).
+    await tick(30);
+    assert.equal(nodes.get("retry-unresponsive").disabled, true, "the button acknowledges the click while probing");
+    assert.match(nodes.get("retry-unresponsive").textContent, /checking/i, "and says what it is doing");
+
+    await tick(700);
+    assert.ok(probes > before, "the re-check must actually re-probe /health");
+    assert.equal(nodes.get("retry-unresponsive").disabled, false, "the button comes back");
+    assert.equal(nodes.get("retry-unresponsive").textContent, "Check again", "with its label restored");
+    // An unchanged verdict is the one outcome the DOM cannot express by itself.
+    assert.equal(
+      nodes.get("unresponsive-outcome").classList.contains("hidden"),
+      false,
+      "an unchanged answer must still be stated",
+    );
+    assert.match(nodes.get("unresponsive-outcome").textContent, /still not answering/i);
   } finally {
     await bundle.close();
   }

--- a/extension/tests/worker-wire-generation.integration.test.mjs
+++ b/extension/tests/worker-wire-generation.integration.test.mjs
@@ -120,7 +120,7 @@ async function loadWorker() {
     windows: { get: async () => ({ id: 1 }), getCurrent: async () => ({ id: 1 }) },
     runtime: {
       getURL: (p) => `chrome-extension://test/${p}`,
-      getManifest: () => ({ version: "0.1.11" }),
+      getManifest: () => ({ version: "0.1.12" }),
       onStartup: { addListener: () => {} },
       onInstalled: { addListener: () => {} },
       onMessage: { addListener: () => {} },


### PR DESCRIPTION
## Symptom

Clicking the extension's toolbar icon sometimes does nothing and takes 2-3 tries.

## Root cause

Two distinct defects, both downstream of a stale MV3 service worker, and neither covered by #996's containment (this PR is stacked on #996 and targets its branch).

**1. The worker could still emit uncaught errors.** #996 added `fireAndForget`, which contains a *promise*. Three remaining paths **throw synchronously**, so the call has already escaped by the time that helper sees it:

| path | what throws |
|---|---|
| `new WebSocket(...)` in `connect()` | a corrupted port read back from `chrome.storage` is a malformed URL |
| `JSON.parse` in `wire.onmessage` | a truncated/garbage frame took the whole handler with it |
| `wire.send(pong)` | `InvalidStateError` on a socket that raced into CLOSING |

An exception out of a Chrome event handler *is* an uncaught worker error, which is the state Chrome poisons an MV3 worker into — so the new `guarded()` helper takes a **thunk**, not a promise. The `void connect()` / `void expireAccessRequest()` sites move onto it too: those are the **recovery** paths, so a rejection there also loses the tick meant to heal the connection.

**2. `decide()` was unbounded and had no catch.** A stale worker produces *both* halves — an immediate rejection when it is gone, silence when it is loaded but mute. On either, `setOriginBusy(false)` was never reached, so **Allow/Deny stayed disabled for the life of the popup** with nothing on screen. That is the user's "I clicked and nothing happened".

## What changed

- **`worker.ts`** — `guarded()` thunk helper; socket constructor, frame parse, and pong send contained; dial/sweep fire-and-forgets moved onto it. #996's wire-generation binding on `respond`/`send` is untouched.
- **`popup/popup.ts`** — `decide()` split so a `finally` clears the busy flag on **every** exit; the round-trip races a 5s bound (`chrome.runtime.sendMessage` has no timeout option); an unanswered decision gets its own notice.
- **`popup/origin-flow.ts`** — `noticeForUnreachableWorker()`. Deliberately **not** "Request changed.", which means a *live* worker replaced the generation — a claim this path cannot make.
- **`popup/popup.html`** — #996's `#unresponsive` card gains a primary **"Reload the extension"** (`chrome.runtime.reload()`, no new permission; the popup closes as a side effect). #996's manual `chrome://extensions` fallback **stays and is not softened**: a reload demonstrably did *not* clear the stale worker on 2026-09-11 20:23 — only disable→enable did. The loss list is stated once for both remedies, since both discard the same worker.
- **Pin re-measured** (below).

The reload control lives **inside** `#unresponsive`, so the offer is withdrawn automatically whenever the daemon stops reporting `extension_unresponsive`. A healthy worker is never invited to pay a reload's cost.

## Re-measured first-paint pin (required by #996's design round 3)

The card grew, so the pin was **solved, not eyeballed** — swept in real headless Chrome at 300x600 dpr=2, reading the card back each time:

| pin | card height |
|---|---|
| 86px | 207px |
| 219px | 340px |
| 254px | 375px (#996's card, this Chrome) |
| **402px** | **523px (this card)** |

`card = pin + 121px` of constant card chrome. `PIN_UNRESPONSIVE` moves **254px → 402px** in all three sites that carry it (`popup.ts`, `first-paint.js`, `popup.css`) plus #996's assertion in `popup-pairing-jitter`.

**Verified, not assumed** — reopening the wedged card with the hint already written:

```json
{"first":{"shown":"pending","card":523},"settled":{"shown":"unresponsive","card":523.265625},"reflowPx":0.27}
```

0.27px against the 168.8px reflow the pin exists to prevent.

## Gates

```
pnpm typecheck                                    clean
pnpm test                                         181 tests, 181 pass, 0 fail
pnpm build:zip && validate-store-zip.sh … 0.1.12  validated Chrome Web Store package v0.1.12 (13 files, no source maps)
```

## Real-execution evidence

Throwaway headless Chrome (`Chrome/153.0.8010.37`), unique `mktemp` profile, `--remote-debugging-port=0` read back from `DevToolsActivePort`, extension loaded via CDP `Extensions.loadUnpacked` — per AGENTS.md §"Capturing a browser surface". The operator's own Chrome, profile and installed store extension were never touched; own-profile process sweep asserted **0** survivors on every run.

**Worker uncaught errors on base, and gone on head.** *Correction from QA round 1:* the `accessQueue` storage-broadcast example originally quoted here was **already contained by #996** and is a `console.warning` on both branches — the premise held but the example was misattributed. The uncaught errors actually reproduced on base, against a real loopback WS server, are:

| trigger | base `90615d76c` | head |
|---|---|---|
| unparseable frame from the daemon | **UNCAUGHT** `SyntaxError … at wire.onmessage` | 0 uncaught → `console.warning: dropped an unparseable frame from the daemon` |
| corrupted stored port → `new WebSocket()` | **UNCAUGHT** `SyntaxError: Failed to construct 'WebSocket' … at connect` | 0 uncaught → `console.warning: extension dial failed to open a socket` |
| **valid JSON, non-object frame** (`null`, `2`, `"x"`, `true`, `[]`) | **UNCAUGHT** `TypeError: Cannot use 'in' operator …` — found in review round 1, present on the first head of this PR too | 0 uncaught → recorded drop, one per payload |

**Popup states, before (#996 head `90615d76c`) and after,** captured at a true 300x600 dpr=2 via `Emulation.setDeviceMetricsOverride` (`--window-size` clamps to a 500px floor on this Chrome and would not be evidence of anything). Both sides captured in the **same mode** from the same script, `extension/scripts/popup-states-shot.mjs` (committed — it is the reusable part; the frames stay off the tree per AGENTS.md §7):

```sh
node scripts/popup-states-shot.mjs dist /tmp/lo-shots-after
```

| state | before | after |
|---|---|---|
| connected | 207.16px, no reload offered | 207.16px, no reload offered (unchanged) |
| disconnected (daemon unreachable) | 258.77px | 258.77px (unchanged) |
| unresponsive | 375.77px, **no** reload offered | 523.27px, **reload offered** |

Screenshots of all three states, both sides, are attached in the review thread.

## Mutation runs (each fix proven to be load-bearing)

Every new test was reverted against the pre-fix source and confirmed **red**:

| reverted | test | result |
|---|---|---|
| `decide()` back to the unbounded await | REJECTS + NEVER ANSWERS | ✖ ✖ |
| unguarded `JSON.parse` | X3 | ✖ |
| unguarded `new WebSocket()` | X4 | ✖ |
| reload button moved out of `#unresponsive` | reload test | ✖ |

X4 asserts **recovery** (a second dial actually happens), not merely the absence of an error — a worker that swallowed the throw and never dialled again would be exactly as dead as the wedge this PR is about.

## Version

`0.1.10 → 0.1.12` in `manifest.json` and `package.json`. **0.1.11 belongs to #996**, so the two trees stay individually pinned.

## Not addressed (deliberate — bridge-wedge lane / next PR)

- **`local_operator/browser_bridge/daemon.py:653`** — the handshake's `except` does not cover `WebSocketDisconnect`, so a client vanishing mid-handshake logs a traceback. Untouched: another session holds uncommitted work in `daemon.py`.
- **`local_operator/browser_bridge/resources.py:219-237`** — reports an unresponsive extension as "update the extension", which is a misdiagnosis pointing the user at the wrong remedy.
- **The optional popup-open latency diagnostic** — not built.

No Python file is touched by this PR.


---

## Round 1 remediation (head `4bca0620c`)

All four review streams reported; all findings answered in one commit. Per-finding dispositions are in the four remediation comments on this PR.

**Blockers/majors fixed:** the remedy is now reachable from the consent card when a decision is pending (an inline danger banner with a one-click reload — the branches are deliberately *not* reordered, so the pending decision stays answerable); the worker's frame guard now shape-checks as well as parses; `decide()`'s outer `finally` no longer resurrects queue controls the renderer disabled; the click-alone ack reports receipt rather than success until the worker confirms; the failure notice no longer inherits the granted-host trough; "Check again" acknowledges the click and states an unchanged verdict; the first-paint pin is held only for durable states (a deliberate trade, spelled out below); the card is bounded to the viewport so the manual fallback is no longer clipped at zoom.

**Re-measured on head** (headless Chrome 153, 300px, dpr=2):

| surface | before (`e2afc3943`) | after (`4bca0620c`) |
|---|---|---|
| wedged + decision pending | remedy in a hidden section, neutral tone | banner + reload visible, danger tone |
| `unresponsive` card height | 523.27px | **472.77px** on `85b7de442` (464.77px as measured on `4bca0620c`; +8px from the U10 reorder) |
| fallback clipped @125% / @150% | 63px / 143px | **0px** / **76.23px** on `85b7de442` but scrollable, footer pinned (68.28px on `4bca0620c`) |
| worst first-paint motion | 315.84px | **265.77px** on `85b7de442` (arrival/failed-reload; the *instructed* path is 0.16px — see the trade below) |
| suite | 181 pass | **186 pass** |

### The first-paint pin: the rule, and the trade

**The rule.** The hint is a **pin value keyed to state**, not a boolean. `PIN_BY_STATE` covers only the **durable** states — `connected` (86px) and `pairing` (219px) — where "durable" means a property of the browser the next open is likely to repeat. A **transient** state writes nothing and leaves the stored durable pin in place. The read side is **allowlisted** against those same values, so a stale or unrecognised value is treated as no hint, and the legacy-boolean key is still read as a fallback so an already-paired browser does not pay a resize for the rename.

**The trade — this does not restore base behaviour across all sequences.** Measured from the seed a real browser carries (`86px` — paired for weeks), two consecutive opens per sequence, `/health` delayed so `#pending` is genuinely the first frame. Reproduced independently by the design stream and by my own cross-check:

| sequence | base `90615d76c` | this branch |
|---|---|---|
| **recovery open (wedged → connected)** — *the transition the card's copy instructs* | 167.84px | **0.16px** ✅ |
| arrival (a working browser wedges) | 168.77px | **265.77px** ❌ |
| failed reload (the 2026-09-11 case, a 2nd wedged open) | 0.77px | **265.77px** ❌ |
| restart → connected | 0.16px | 0.16px |

**The worst single motion is 265.77px on `85b7de442`, not "132.84px = base".** An earlier revision of this description and of the commit message said the worst case was back to base; that was wrong, and design caught it. The figure was **257.77px** when design measured it on `4bca0620c`; QA re-measured **265.77px** on this head in round 3 (Q9/U14), because the U10 recheck reorder made `.actions + .sub`'s 16px reach the fallback paragraph where the then-hidden `.recheck` had kept it at 8px — the `#unresponsive` card grew 464.77 → 472.77px. The 8px is a measurement drift this delta caused, not a behaviour change: the instructed recovery open is still 0.16px. The win is on the one path the card explicitly instructs ("open it again to check"), where a ~168px lurch becomes nothing; the cost lands on the arrival and reopen paths.

**A conditional wedge pin was proposed, implemented and rejected on measurement.** Pinning the wedge only when the stored durable pin is `connected` was expected to retire the arrival cost. Driven with a 343.77px wedge pin on `4bca0620c`: arrival stayed **257.77px** (the pre-reorder figure) — `show()` writes the pin *after* the card renders, so the open that first meets the wedge can never be helped by it — and the instructed recovery open **regressed 0.16 → 257.61px**, because the wedge pin then mis-sized the connected card. It buys nothing and sells the one win. The failed measurement is recorded in the `PIN_BY_STATE` comment so it is not re-derived from the idea alone.

The regression on the wedged reopen is **paid deliberately**: base spent its pin on the reopen nobody is told to make, and this build spends it on the recovery open the card explicitly asks for. **`315.84 → 265.77` is a statement about the worst transition, not about every transition** — the arrival and failed-reload paths are worse than base (168.77px and 0.77px → 265.77px), and that is the trade rather than an oversight.

**Seeds, because the two "worst" numbers above are not the same measurement** (review round 3, nit 5): `315.84px` was measured on a **fresh profile** with no stored pin; the `265.77 / 0.16 / 168.77 / 0.77` figures come from the **seeded `86px` sequences** (a browser paired for weeks), which is the realistic carry-in. And `265.77px` is the worst of the *three seeded sequences*, which are all the `#unresponsive` card — not a bound on what a user meets: UX U16 measured the consent-card shape of the same incident (agent driving, so a decision is queued) at **341.39px** on this head, down from 373.0px on `4bca0620c`.

**Harness safety.** The committed capture script now refuses to run against any build that still dials `4099`, patching the port in the built artifacts before load (esbuild inlines the constant) and refusing if a bundle is missing or anything answers on the harness port. `lop browser status` before and after this round's captures: `extension connected: yes`, `paired: yes`, unchanged.

## Not addressed (updated)

- **Post-reload recovery is unprovable under CDP `loadUnpacked`** — a 4-line control extension vanishes identically, so this is a harness lifetime artifact, not a defect. The teardown half is proven; the recovery half is **BLOCKED pending a packed/store install**, not passing.
- `daemon.py:653` handshake traceback and `resources.py:219-237`'s "update the extension" misdiagnosis — bridge-wedge lane, no Python touched here.
- UX U5 (a reload-attempt counter across popup teardowns) — deferred, needs persisted state; U6/U7 marked non-blocking by the UX stream.
- Test fixtures still reporting `0.1.7`–`0.1.9` belong to base/#996 and are outside this delta.



---

## Round 2 (head `2aa1d484d`)

QA returned a **PASS**; code review, design and UX each carried one major, with design and UX finding the same new defect from two directions. All answered in one commit — per-finding dispositions in the four round-2 remediation comments.

- **Banner no longer over-claims (review M1).** It read `extension_unresponsive`, the daemon's view of its *WebSocket link*, while a decision travels over `chrome.runtime.sendMessage`. During the 60s post-drop latch the worker is usually alive and re-dialling, so the card said the decision could not be applied *while Allow applied it* — and steered the user at a reload that destroys pending decisions. Now gated on `link_attached` too, which isolates attached-and-mute. `#unresponsive` reading the same flag is correct and untouched.
- **The card opens at its top (design D7 = UX U8).** Bounding the card made `.body` a scroll container, and focusing the scope select scrolled it — so at ≥125% zoom the wedged card opened past its own title *and its entire danger banner*: round-1 U1 reintroduced by the round-1 D2 fix. `focus({ preventScroll: true })` + explicit scroll reset. `scrollTop` **0 at 100 / 125 / 150%** (was 0 / 139 / 219).
- **The wedged card fits (design D8 = UX U9).** Dropping the generic consent prose when the banner is present — redundant beside a banner that has just said the decision will not land — gives **531px, overflow 0**, Allow/Deny **16px inside** the fold (was 4.3px below). (Fixture: a `/health`-only prompt with a single-line scope trough; a domain-capable queue entry measures 548.39px with the same `overflow 0` and the same 16px of slack — UX U15.)
- **The certain remedy is reachable while a decision is pending (UX U11, QA Q6).** The banner now carries the manual `chrome://extensions` sentence; the "Check again" verdict moved below that remedy so answering the recovery question no longer pushes it off-screen (U10).
- Nits: `role="alert"`, "won't be applied", hh:mm recheck timestamp.

Both majors are mutation-red. Suite **188 pass / 0 fail**.

**Deferred this round:** review m1 (`pairVerdict`'s null-narrowing — pairing path, outside the delta), UX U5 (reload-attempt counter — needs state surviving a popup teardown), UX U12 (reload/toggle copy divergence — the other half lives in `local_operator/`, untouched here), and a "more below" scroll affordance for the 125/150% case (a new visual element; left for the design stream to specify rather than guessed at mid-round).


