### PR TITLE
chore(release): bump version to 0.54.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.28"
+version = "0.54.29"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version-only bump for the post-v0.54.28 window. **Owner session pid 50809.** Branch `release-next-05429`.

`git diff --stat origin/main` is exactly one file and one line:

```
 pyproject.toml | 2 +-
-v: "0.54.28"   +v: "0.54.29"
```

## Why PATCH

Four bug fixes restoring behaviour that was broken. Nothing here adds a capability or changes an interface, so nothing clears the step-function bar for a minor: `0.54.29 = <last tag v0.54.28> + patch`.

## Window (`git log v0.54.28..origin/main`, four merge commits)

| PR | merge SHA | class | Release line |
|----|-----------|-------|--------------|
| [#1025](https://github.com/damianvtran/local-operator/pull/1025) `fix(session)` — a zombie owner no longer holds a transcript claim | `2ec6ad64332b133a5c4d8f364144283a1e7088c1` | patch | a session whose runtime was killed can be opened again — from the TUI, from `lop exec --resume` and from the phone — instead of being refused as "already open in another process" forever |
| [#998](https://github.com/damianvtran/local-operator/pull/998) `fix(session)` — bounded recovery, the steer seam, the phone arrival fill, the daemon-kill cause token | `343a2ba89518eb38696aaa257f58756618d533b6` | patch | a session whose runtime was lost mid-turn now recovers on every surface: the returned message comes back to the composer exactly once, the phone gets the arrival fill, and a cut-off turn is never presented as a deliberate stop |
| [#1018](https://github.com/damianvtran/local-operator/pull/1018) `fix(mobile)` — open a conversation with its subagents collapsed, keep every ask option reachable | `1179c27663731a512a161d7ced23d7a96432e76e` | patch | the phone opens on the conversation instead of the subagent roster, and a long ask keeps every option tappable |
| [#996](https://github.com/damianvtran/local-operator/pull/996) `fix(browser)` — stop an unresponsive extension wedging every session | `99e81a1c53502effaf350309f1f964d30b09019a` | patch | an unresponsive browser extension no longer wedges every session: the daemon detects a mute peer, stops advertising it as connected, fails commands fast with an actionable message, and the extension's shared command chains self-drain so one stuck Chrome call can no longer park every later command |

No other PR merged in the window and no second `chore(release)` PR was opened: two sessions announced this window by message (both retracted once the observable-lock rule was applied) and one opened the window's only lock — this one.

## Merge method, so the notes do not imply otherwise

Every PR in this window merged on the code-owner (tier 1) admin path with **no human approval click**, each carrying its own recorded independent agent review / QA rounds (plus design/UX where the change was user-visible) as its approval, and each disclosing that on its own thread. That is the documented path this repo uses, not a bypass of a broken control. This bump is the same: a one-file scope-check round runs before it merges.
