### PR TITLE
feat(usage): surface DeepSeek credit state instead of drawing it as unknown

### DIFF
--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -15,7 +15,12 @@ What local-operator DOES fetch, grouped by the credential it needs:
   - ``kimi`` — Moonshot `GET /v1/users/me/balance`, on whichever host the
     provider is CONFIGURED for, so the key that reaches the chat API is the
     key that reaches the balance. The region also fixes the currency.
-  - ``deepseek`` — `GET /user/balance` → one balance per currency.
+  - ``deepseek`` — `GET /user/balance` → one balance per currency, each with
+    the vendor's granted/topped-up split and its ``is_available`` serving flag.
+    DeepSeek publishes **no** usage or spend endpoint — `/user/balance` is the
+    only account route in their API docs — so there is no window to report and
+    none is invented here. What these sessions cost locally is
+    `/analytics`' question, answered from recorded token counts.
 
 - With an OAuth access token, when the user logged in via OAuth:
   ``anthropic`` (`/api/oauth/usage`), ``openai``/``openai-device`` (ChatGPT
@@ -276,6 +281,14 @@ class UsageLimit:
     #: must not look alike in a list where the user is deciding whether to switch
     #: models or stop working.
     shared: bool = False
+    #: One line of vendor-supplied composition for this allowance, rendered
+    #: under its row (DeepSeek's ``100.00 USD paid · 20.00 USD granted``). It
+    #: exists because a single total hides the part that EXPIRES: granted
+    #: credit is promotional and dated, so an account reading ``120.00 USD
+    #: left`` may have far less durable balance than the number suggests.
+    #: Free-form display text, never parsed back — a fetcher that has no split
+    #: to report leaves it empty and the renderer emits no line.
+    detail: str = ""
 
     def effective_status(self) -> str:
         return self.status or self.amount.status()
@@ -745,6 +758,15 @@ async def fetch_deepseek_balance(client: httpx.AsyncClient, api_key: str) -> Usa
     a factor of seven. ``is_available`` is the provider's own "can this account
     still serve requests" flag and is worth surfacing, because a zero balance and a
     suspended account look identical in the numbers alone.
+
+    Every row carries an EXPLICIT status. A balance-only amount has no
+    denominator, so ``UsageAmount.status()`` can only ever answer ``unknown``
+    for it — which rendered a number the endpoint had just reported as a
+    number we do not have (hollow mark) and tallied it in the footer as "not
+    reported". The account flag and the sign of the total are the two facts
+    that decide whether this wallet can pay for the next request, and they are
+    what the status is derived from here. Same shape
+    :func:`fetch_radient_balance` already uses.
     """
     payload = await _get_json(client, DEEPSEEK_BALANCE_URL, _bearer(api_key))
     if payload is None:
@@ -752,6 +774,11 @@ async def fetch_deepseek_balance(client: httpx.AsyncClient, api_key: str) -> Usa
     infos = payload.get("balance_infos")
     if not isinstance(infos, list):
         return None
+    # Strictly a JSON ``false``. A missing key or a value of another type is
+    # NOT evidence the account is suspended, and coercing one (``""``, ``0``)
+    # into "unavailable" would paint every row of a healthy account red on a
+    # schema change. Absent stays fail-open, as it was before.
+    available = payload.get("is_available") is not False
     limits: list[UsageLimit] = []
     for item in infos:
         if not isinstance(item, dict):
@@ -769,12 +796,39 @@ async def fetch_deepseek_balance(client: httpx.AsyncClient, api_key: str) -> Usa
                 # currency in the label rather than mislabelled as dollars.
                 amount=UsageAmount(remaining=total, unit="usd" if currency == "USD" else "unknown"),
                 window="lifetime",
+                status="ok" if available and total > 0 else "exhausted",
+                detail=_deepseek_split(item, currency),
             )
         )
     if not limits:
         return None
-    notes = None if payload.get("is_available", True) else "account not available for requests"
+    notes = None if available else "account not available for requests"
     return UsageReport(provider="deepseek", limits=limits, notes=notes)
+
+
+def _deepseek_split(item: dict[str, Any], currency: str) -> str:
+    """``100.00 USD paid · 20.00 USD granted`` for one balance entry.
+
+    The vendor reports the total as the sum of a topped-up part the user bought
+    and a granted part that was given and EXPIRES, which is why the split is
+    worth a line: the same ``120.00 USD left`` means something different
+    depending on how much of it is dated promotional credit.
+
+    The currency is repeated on each number rather than factored out, because
+    the row above states it only in its label — a CNY amount is deliberately
+    unitless in ``amount.unit`` (see the fetcher), so this line is the only
+    place a number and its currency appear together.
+
+    Built from whichever parts parsed: a body carrying neither field produces
+    no line at all rather than an empty scaffold.
+    """
+    parts = [
+        (_num(item.get("topped_up_balance")), "paid"),
+        (_num(item.get("granted_balance")), "granted"),
+    ]
+    return " · ".join(
+        f"{value:.2f} {currency} {name}" for value, name in parts if value is not None
+    )
 
 
 #: Z.AI's coding-plan quota endpoint. Lives on the API host but OUTSIDE the

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -774,10 +774,11 @@ async def fetch_deepseek_balance(client: httpx.AsyncClient, api_key: str) -> Usa
     infos = payload.get("balance_infos")
     if not isinstance(infos, list):
         return None
-    # Strictly a JSON ``false``. A missing key or a value of another type is
-    # NOT evidence the account is suspended, and coercing one (``""``, ``0``)
-    # into "unavailable" would paint every row of a healthy account red on a
-    # schema change. Absent stays fail-open, as it was before.
+    # Strictly a JSON ``false``, and that IS a behaviour change for the other
+    # falsy values: the old truthiness test read ``null``, ``0`` and ``""`` as
+    # unavailable, so a schema change that started sending any of them reddened
+    # every row of a healthy account. Only the documented boolean decides now;
+    # a missing key or a non-boolean stays fail-open.
     available = payload.get("is_available") is not False
     limits: list[UsageLimit] = []
     for item in infos:
@@ -796,6 +797,12 @@ async def fetch_deepseek_balance(client: httpx.AsyncClient, api_key: str) -> Usa
                 # currency in the label rather than mislabelled as dollars.
                 amount=UsageAmount(remaining=total, unit="usd" if currency == "USD" else "unknown"),
                 window="lifetime",
+                # `exhausted` is what the PANEL reads; it is not failover's
+                # signal. `usage_health` (the router, reached from `failover.py`
+                # and `auth_store.py`) reads `amount`, `shared` and `tier` and
+                # never `status`, so a funded-but-suspended account is drawn dead
+                # here and still routes normally. The display can afford to be
+                # blunt about a wallet that cannot pay; the router cannot.
                 status="ok" if available and total > 0 else "exhausted",
                 detail=_deepseek_split(item, currency),
             )

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -186,14 +186,21 @@ def report_from_dict(data: Any) -> UsageReport | None:
                 status=limit.get("status"),
                 resets_at=limit.get("resets_at"),
                 resets_at_ms=limit.get("resets_at_ms"),
-                tier=str(limit.get("tier", "")),
+                # ``or ""`` rather than a bare default, because a JSON ``null``
+                # is PRESENT: ``str(None)`` would decode to the four character
+                # string ``None`` and paint it as a tier — and, for ``detail``,
+                # as a bogus annotation under a meter. Our own writer cannot emit
+                # null (``asdict`` over a ``str`` field), so this only fires on a
+                # hand-edited or foreign-written cache, which is exactly the row
+                # a decoder must not trust.
+                tier=str(limit.get("tier") or ""),
                 shared=bool(limit.get("shared", False)),
                 # Decoded explicitly like every other field: this rebuild is
                 # field-by-field rather than ``UsageLimit(**limit)``, so a new
                 # field omitted here is silently dropped on the CACHED path
                 # while the live fetch still carries it — the annotation would
                 # appear on a cold `/usage` and vanish on every warm one.
-                detail=str(limit.get("detail", "")),
+                detail=str(limit.get("detail") or ""),
             )
             for limit in data.get("limits", [])
         ]

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -188,6 +188,12 @@ def report_from_dict(data: Any) -> UsageReport | None:
                 resets_at_ms=limit.get("resets_at_ms"),
                 tier=str(limit.get("tier", "")),
                 shared=bool(limit.get("shared", False)),
+                # Decoded explicitly like every other field: this rebuild is
+                # field-by-field rather than ``UsageLimit(**limit)``, so a new
+                # field omitted here is silently dropped on the CACHED path
+                # while the live fetch still carries it — the annotation would
+                # appear on a cold `/usage` and vanish on every warm one.
+                detail=str(limit.get("detail", "")),
             )
             for limit in data.get("limits", [])
         ]

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -31,6 +31,7 @@ offset and the focus.
 
 from __future__ import annotations
 
+import bisect
 from dataclasses import dataclass
 from typing import Any
 
@@ -680,10 +681,12 @@ class UsageBody:
     happens to contain the copy.
 
     ``details`` holds the LINE INDICES of limit-detail rows, identified the same
-    way and for the same reason: a detail is the second row of a two-row cut
-    unit whose first row is the meter it annotates, and compaction keeps or
-    drops the pair together. ``100.00 USD paid · 20.00 USD granted`` stranded
-    under some other provider's meter is worse than not showing the split.
+    way and for the same reason. A detail is DECORATION attached to the meter
+    row directly above it — strictly lower priority than any meter — so it lives
+    in this body but not in the tree the window is chosen against
+    (:meth:`skeleton`). ``100.00 USD paid · 20.00 USD granted`` stranded under
+    some other provider's meter is worse than not showing the split, and a
+    window that could have shown a number instead of the split is worse still.
     """
 
     lines: list[Text]
@@ -691,6 +694,54 @@ class UsageBody:
     blocks: tuple[tuple[int, int], ...] = ()
     notes: frozenset[int] = frozenset()
     details: frozenset[int] = frozenset()
+
+    def content_rows(self) -> tuple[int, ...]:
+        """Composed rows that are not annotations, in order.
+
+        The row map between this body and :meth:`skeleton`: ``content_rows()[i]``
+        is the row showing the ``i``-th detail-free row. Derived rather than
+        stored — a second copy of the row order is how a window ends up one row
+        off from the data it is scrolling.
+        """
+        return tuple(row for row in range(len(self.lines)) if row not in self.details)
+
+    def content_at(self, row: int) -> int:
+        """Which detail-free position a composed row (or the body's end) sits at."""
+        return bisect.bisect_left(self.content_rows(), row)
+
+    def row_at(self, content_index: int) -> int:
+        """The composed row showing the ``content_index``-th detail-free row.
+
+        One past the last content row answers the body's end, so a window's tail
+        position can be read back through the same map.
+        """
+        rows = self.content_rows()
+        return rows[content_index] if content_index < len(rows) else len(self.lines)
+
+    def skeleton(self) -> UsageBody:
+        """This body with its annotations taken out — the tree the window is
+        chosen against.
+
+        Windowing in content space is what makes the detail droppable without
+        ever stranding it: the rows a window shows are picked over the meters
+        alone, and the annotations are painted afterwards out of the budget the
+        meters did not need (see :meth:`UsagePanel._window_rows`). Cut points,
+        blocks and notes come across so a block-aware window stops in the same
+        place it always did.
+        """
+        if not self.details:
+            # The identity is the common case: one provider can carry a split.
+            return self
+        rows = self.content_rows()
+        return UsageBody(
+            lines=[self.lines[row] for row in rows],
+            cuts=frozenset(bisect.bisect_left(rows, cut) for cut in self.cuts),
+            blocks=tuple(
+                (bisect.bisect_left(rows, start), bisect.bisect_left(rows, end))
+                for start, end in self.blocks
+            ),
+            notes=frozenset(bisect.bisect_left(rows, note) for note in self.notes),
+        )
 
 
 def build_usage_body(  # noqa: ANN001
@@ -763,20 +814,25 @@ def build_usage_body(  # noqa: ANN001
             continue
         lines.append(Text())
         for limit in report.limits:
-            lines.append(_limit_row(limit, columns, now_ms, degraded=bool(account_note)))
+            meter = _limit_row(limit, columns, now_ms, degraded=bool(account_note))
+            lines.append(meter)
             detail = getattr(limit, "detail", "")
             if detail:
-                # Indented under its meter and truncated to the same body width
-                # as every other composed row, so a long split loses its tail
-                # rather than widening the card.
+                # Indented under its meter and truncated to the row it
+                # ANNOTATES — the meter's own ink, not the card's width. A
+                # balance row's right edge is wherever its number ends, which at
+                # 60 columns is 35 cells (the bar has collapsed to a single dot)
+                # while a split is a fixed 37-cell string; measuring the split
+                # against the card let it out-paint the row it annotates and take
+                # the block's right edge with it.
                 row = Text(f"{TIER_INDENT}{detail}", style=dim)
-                row.truncate(max(1, width), overflow="ellipsis")
+                row.truncate(max(1, cell_len(meter.plain.rstrip())), overflow="ellipsis")
                 lines.append(row)
                 details.add(len(lines) - 1)
-            # The cut point goes AFTER the detail, never between it and its
-            # meter: `cuts` is where a short viewport may stop, so cutting
-            # between them is what would leave an annotation with nothing to
-            # annotate. One cut unit, no new glue mechanism.
+            # The cut closes the meter's GROUP — it is where a block-aligned
+            # window may stop. It does not make the pair indivisible: windows are
+            # chosen over the meters, so a budget that cannot hold the split
+            # keeps the meter and drops the annotation.
             cuts.add(len(lines))
         blocks.append((block_start, len(lines)))
     return UsageBody(lines, frozenset(cuts), tuple(blocks), frozenset(notes), frozenset(details))
@@ -1020,9 +1076,12 @@ class UsagePanel(Static):
     def action_scroll_page(self, delta: int) -> None:
         # A page is what the card is SHOWING, not what it budgeted for: the
         # window stops at a block boundary, so paging by the budget would step
-        # over the heading that the boundary held back.
+        # over the heading that the boundary held back. Measured over the meters
+        # (see :meth:`UsageBody.skeleton`), because a detail row the window never
+        # painted must not count as a row the reader is looking at.
         body = self._body()
-        shown = self._window_end(body, self._body_budget()) - self._offset
+        start = body.content_at(self._offset)
+        shown = self._window_end(body.skeleton(), start, self._body_budget()) - start
         self._scroll_by(delta * max(1, shown))
 
     def action_scroll_home(self) -> None:
@@ -1270,16 +1329,24 @@ class UsagePanel(Static):
         return self._fit()[2]
 
     def _max_offset(self) -> int:
+        """The furthest composed row the viewport may start at.
+
+        Measured in content space (see :meth:`UsageBody.skeleton`): annotations
+        are not rows the reader scrolled to, and clamping against the composed
+        body would let a scroll position rest on a detail whose meter is behind
+        it — a split floating under the title with nothing it could belong to.
+        """
         body = self._body()
         budget = self._body_budget()
-        raw = max(0, len(body.lines) - budget)
+        content = body.skeleton()
+        raw = max(0, len(content.lines) - budget)
         # If the raw tail begins inside a provider block, start at its heading.
         # `_window_rows` then removes notes/blank air and keeps the meters that
         # fit, so End never shows anonymous numbers.
-        for start, end in body.blocks:
+        for start, end in content.blocks:
             if start <= raw < end and end - start > budget:
-                return start
-        return raw
+                return body.row_at(start)
+        return body.row_at(raw)
 
     # -- scrollbar -----------------------------------------------------------
     # ONE source of truth for "which composed rows are the scrolling viewport",
@@ -1625,51 +1692,87 @@ class UsagePanel(Static):
         decorative blank yields before identity or quota values.
 
         A staleness note is kept AHEAD of the meters rather than yielding with
-        the other air. Being a cut point only made it *eligible*: the tail slice
-        below keeps ``data[-(budget - 1):]`` and the note is ``data[0]``, so it
-        was still the first row discarded — which rendered a 169-minute-old
-        meter with nothing on the card saying so, the exact frame this panel was
-        reported for. The note qualifies the meters, so a budget that can show a
-        meter can show the sentence that says the meter is old; dropping a
-        *meter* to keep it is the honest trade, because an unlabelled stale
-        number is worse than one fewer number.
+        the other air. A cut point alone only made it *eligible*: the tail a
+        window keeps is the end of the block and the note is its first row, so it
+        was the first row discarded — which rendered a 169-minute-old meter with
+        nothing on the card saying so, the exact frame this panel was reported
+        for. The note qualifies the meters, so a budget that can show a meter can
+        show the sentence that says the meter is old; dropping a *meter* to keep
+        it is the honest trade, because an unlabelled stale number is worse than
+        one fewer number. ``_select_rows`` therefore reserves the note's rows
+        before it spends any on meters.
 
-        Compaction works in CUT UNITS, not rows: a meter carrying a detail line
-        is two rows the cut set marks as one unit, and a budget that cannot
-        hold both drops the pair rather than keeping either half. Splitting
-        them would show a credit split with no meter, or a meter whose
-        annotation silently belongs to the row above it.
+        Compaction works on the METERS: the window is chosen over the tree
+        without the annotations (:meth:`UsageBody.skeleton`) and the details are
+        painted afterwards, out of rows the meters did not need. Two rules
+        follow, and the second one is what the first draft of this change got
+        wrong — it made a meter and its detail one indivisible unit, so a budget
+        that could not hold both kept neither, and the card announced a provider
+        with no numbers under it:
+
+        * a detail is never painted without its meter in the same window — not
+          as the window's first row, not at any scroll offset, not compacted;
+        * the meter always wins a tie. At every budget and every offset this
+          window shows at least as many meters as the tree without annotations
+          showed, and in fact exactly as many: the annotation is decoration and
+          the number is the reason `/usage` was opened.
         """
-        for start, end in body.blocks:
-            if self._offset == start and end - start > budget:
-                if budget <= 1:
-                    return [body.lines[start]], end
-                tails = [index for index in range(start + 1, end) if index + 1 in body.cuts]
-                # A detail row is the tail of its cut unit but says nothing
-                # without the meter directly above it, so the pair travels as
-                # one. Every other row is its own unit, exactly as before.
-                units = [[i - 1, i] if i in body.details else [i] for i in tails]
-                notes = [unit for unit in units if unit[0] in body.notes]
-                meters = [unit for unit in units if unit[0] not in body.notes]
-                notes = notes[: budget - 1]
-                # Notes first, then as many WHOLE trailing meter units as the
-                # rows left over hold — from the end, because the meters nearest
-                # the tail are the ones the scroll position is asking for. A
-                # pair that does not fit is dropped entire rather than halved.
-                room = budget - 1 - sum(len(unit) for unit in notes)
-                kept: list[list[int]] = []
-                for unit in reversed(meters):
-                    if len(unit) > room:
-                        break
-                    kept.insert(0, unit)
-                    room -= len(unit)
-                rows = [index for unit in (*notes, *kept) for index in unit]
-                return [body.lines[start], *(body.lines[i] for i in rows)], end
-        end = self._window_end(body, budget)
-        return body.lines[self._offset : end], end
+        content = body.skeleton()
+        kept = body.content_rows()
+        start = bisect.bisect_left(kept, self._offset)
+        selected, content_end = self._select_rows(content, start, budget)
+        rows = [kept[index] for index in selected]
+        room = budget - len(rows)
+        if room > 0:
+            # Only rows the meters did not need may go to an annotation, and
+            # they go to the ones nearest the tail first: a compacted window is
+            # anchored on its last rows and a scrolled one is read from the
+            # bottom up, so the split next to the tail is the one being looked
+            # for.
+            for index in reversed(selected):
+                if room <= 0:
+                    break
+                detail = kept[index] + 1
+                if detail in body.details:
+                    rows.append(detail)
+                    room -= 1
+            rows.sort()
+        end = kept[content_end] if content_end < len(kept) else len(body.lines)
+        return [body.lines[row] for row in rows], end
 
-    def _window_end(self, body: UsageBody, budget: int) -> int:
-        """Where the window stops: the last row that COMPLETES a block.
+    def _select_rows(self, body: UsageBody, start: int, budget: int) -> tuple[list[int], int]:
+        """Which rows the window shows, as indices into a detail-free body.
+
+        Split out from :meth:`_window_rows` because the choice is made over the
+        meters alone: an annotation must never be able to cost a window a
+        number, so the selection cannot see the details at all.
+
+        A block taller than the short viewport is compacted from its tail: its
+        heading, then the staleness notes it has room for, then as many of the
+        LAST meters as the budget still holds. Every row it takes is one row, so
+        a budget that can hold a meter always shows it — the earlier version
+        walked trailing units and broke on the first one too large for the room
+        left, which kept nothing at all (a heading with no numbers, one row of
+        the allowance unused) the moment a meter carried an annotation.
+        """
+        for block_start, block_end in body.blocks:
+            if start == block_start and block_end - block_start > budget:
+                if budget <= 1:
+                    return [block_start], block_end
+                tails = [
+                    index for index in range(block_start + 1, block_end) if index + 1 in body.cuts
+                ]
+                notes = [index for index in tails if index in body.notes][: budget - 1]
+                meters = [index for index in tails if index not in body.notes]
+                room = budget - 1 - len(notes)
+                kept = meters[max(0, len(meters) - room) :] if room > 0 else []
+                return sorted([block_start, *notes, *kept]), block_end
+        end = self._window_end(body, start, budget)
+        return list(range(start, end)), end
+
+    def _window_end(self, body: UsageBody, start: int, budget: int) -> int:
+        """Where a window opened at ``start`` stops: the last row that
+        COMPLETES a block.
 
         A budget that ran out mid-block left a provider heading — or a heading
         and the blank under it — as the last thing on the card, announcing a
@@ -1680,11 +1783,11 @@ class UsagePanel(Static):
         it keeps the raw cut: the head of a block reads better than a card with
         an empty body.
         """
-        end = min(self._offset + budget, len(body.lines))
+        end = min(start + budget, len(body.lines))
         pulled = end
-        while pulled > self._offset and pulled not in body.cuts:
+        while pulled > start and pulled not in body.cuts:
             pulled -= 1
-        return pulled if pulled > self._offset else end
+        return pulled if pulled > start else end
 
     def _recentre(self, width: int, height: int) -> None:
         return overlay.recentre(self, width, height)

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -445,7 +445,13 @@ def _limit_row(  # noqa: ANN001
 
     fraction = limit.amount.fraction()
     row = Text()
-    row.append(f"{MARK_KNOWN if fraction is not None else MARK_UNKNOWN} ", style=mark_style)
+    # The mark keys on whether the WINDOW's state is known, not on whether a
+    # proportion could be computed. A balance-only row has no denominator by
+    # construction, so keying the mark on `fraction` drew every reported
+    # balance as a figure we do not have. The BAR still keys on the fraction:
+    # the proportion genuinely is unknown there, and dots say so honestly.
+    known = limit.effective_status() != "unknown"
+    row.append(f"{MARK_KNOWN if known else MARK_UNKNOWN} ", style=mark_style)
 
     label = limit.label
     if limit.tier:
@@ -672,12 +678,19 @@ class UsageBody:
     keeps that decision with the code that knows which row is which — a
     substring test would silently start matching an account whose identity
     happens to contain the copy.
+
+    ``details`` holds the LINE INDICES of limit-detail rows, identified the same
+    way and for the same reason: a detail is the second row of a two-row cut
+    unit whose first row is the meter it annotates, and compaction keeps or
+    drops the pair together. ``100.00 USD paid · 20.00 USD granted`` stranded
+    under some other provider's meter is worse than not showing the split.
     """
 
     lines: list[Text]
     cuts: frozenset[int]
     blocks: tuple[tuple[int, int], ...] = ()
     notes: frozenset[int] = frozenset()
+    details: frozenset[int] = frozenset()
 
 
 def build_usage_body(  # noqa: ANN001
@@ -702,6 +715,7 @@ def build_usage_body(  # noqa: ANN001
     cuts: set[int] = set()
     blocks: list[tuple[int, int]] = []
     notes: set[int] = set()
+    details: set[int] = set()
     if not reports:
         return UsageBody(lines, frozenset({0}))
 
@@ -750,9 +764,22 @@ def build_usage_body(  # noqa: ANN001
         lines.append(Text())
         for limit in report.limits:
             lines.append(_limit_row(limit, columns, now_ms, degraded=bool(account_note)))
+            detail = getattr(limit, "detail", "")
+            if detail:
+                # Indented under its meter and truncated to the same body width
+                # as every other composed row, so a long split loses its tail
+                # rather than widening the card.
+                row = Text(f"{TIER_INDENT}{detail}", style=dim)
+                row.truncate(max(1, width), overflow="ellipsis")
+                lines.append(row)
+                details.add(len(lines) - 1)
+            # The cut point goes AFTER the detail, never between it and its
+            # meter: `cuts` is where a short viewport may stop, so cutting
+            # between them is what would leave an annotation with nothing to
+            # annotate. One cut unit, no new glue mechanism.
             cuts.add(len(lines))
         blocks.append((block_start, len(lines)))
-    return UsageBody(lines, frozenset(cuts), tuple(blocks), frozenset(notes))
+    return UsageBody(lines, frozenset(cuts), tuple(blocks), frozenset(notes), frozenset(details))
 
 
 class UsagePanel(Static):
@@ -1606,18 +1633,38 @@ class UsagePanel(Static):
         meter can show the sentence that says the meter is old; dropping a
         *meter* to keep it is the honest trade, because an unlabelled stale
         number is worse than one fewer number.
+
+        Compaction works in CUT UNITS, not rows: a meter carrying a detail line
+        is two rows the cut set marks as one unit, and a budget that cannot
+        hold both drops the pair rather than keeping either half. Splitting
+        them would show a credit split with no meter, or a meter whose
+        annotation silently belongs to the row above it.
         """
         for start, end in body.blocks:
             if self._offset == start and end - start > budget:
                 if budget <= 1:
                     return [body.lines[start]], end
-                indices = [index for index in range(start + 1, end) if index + 1 in body.cuts]
-                notes = [body.lines[i] for i in indices if i in body.notes]
-                meters = [body.lines[i] for i in indices if i not in body.notes]
-                # Notes first, then the last meters that still fit beside them.
-                room = max(0, budget - 1 - len(notes))
-                kept = [*notes[: budget - 1], *meters[-room:]] if room else notes[: budget - 1]
-                return [body.lines[start], *kept], end
+                tails = [index for index in range(start + 1, end) if index + 1 in body.cuts]
+                # A detail row is the tail of its cut unit but says nothing
+                # without the meter directly above it, so the pair travels as
+                # one. Every other row is its own unit, exactly as before.
+                units = [[i - 1, i] if i in body.details else [i] for i in tails]
+                notes = [unit for unit in units if unit[0] in body.notes]
+                meters = [unit for unit in units if unit[0] not in body.notes]
+                notes = notes[: budget - 1]
+                # Notes first, then as many WHOLE trailing meter units as the
+                # rows left over hold — from the end, because the meters nearest
+                # the tail are the ones the scroll position is asking for. A
+                # pair that does not fit is dropped entire rather than halved.
+                room = budget - 1 - sum(len(unit) for unit in notes)
+                kept: list[list[int]] = []
+                for unit in reversed(meters):
+                    if len(unit) > room:
+                        break
+                    kept.insert(0, unit)
+                    room -= len(unit)
+                rows = [index for unit in (*notes, *kept) for index in unit]
+                return [body.lines[start], *(body.lines[i] for i in rows)], end
         end = self._window_end(body, budget)
         return body.lines[self._offset : end], end
 

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -1193,7 +1193,7 @@ class UsagePanel(Static):
         """
         body = self._body()
         budget = self._body_budget()
-        total = len(body.lines)
+        total = self._scrolling_rows(body)
         if total <= budget:
             return None
         offset = self._content_offset(event)
@@ -1241,7 +1241,7 @@ class UsagePanel(Static):
         """Move the offset so the thumb's top lands at ``thumb_top`` and repaint."""
         body = self._body()
         budget = self._body_budget()
-        target = self._offset_from_thumb_top(thumb_top, len(body.lines), budget)
+        target = self._offset_from_thumb_top(thumb_top, self._scrolling_rows(body), budget)
         self._offset = max(0, min(self._max_offset(), target))
         self._repaint()
 
@@ -1373,6 +1373,17 @@ class UsagePanel(Static):
         blank (the pinned-height tests read it).
         """
         return 2 + (1 if self._note_shown() else 0), budget
+
+    def _scrolling_rows(self, body: UsageBody) -> int:
+        """How many rows the scroll chrome counts: the METERS, not the annotations.
+
+        ONE source of truth for the three consumers — the painter, the hit test
+        and the drag — for the reason the bar's own comment gives: a bar drawn
+        from one total and dragged by another sits under the pointer in one place
+        and moves from another. Annotations are droppable decoration, so they are
+        not part of the list the reader is scrolling.
+        """
+        return len(body.skeleton().lines)
 
     def _scrollbar_thumb(self, total: int, budget: int) -> tuple[int, int]:
         """``(thumb_top, thumb_len)`` inside a ``budget``-tall track.
@@ -1625,10 +1636,18 @@ class UsagePanel(Static):
 
     def _compose_rows(self) -> list[Text]:
         body = self._body()
+        content = body.skeleton()
         lines = body.lines
         budget = self._body_budget()
         self._offset = max(0, min(self._offset, self._max_offset()))
-        scrolled = len(lines) > budget
+        # "Scrolled" is about the METERS, not the annotations. The card's scroll
+        # chrome — the position marker, the `↑↓ scroll` hint, the bar — is a
+        # statement about the numbers, and an annotation the window chose to drop
+        # is decoration the reader was never promised. Keyed off the composed
+        # body instead, a card whose meters ALL fit would raise a marker and a
+        # scroll hint that cannot move the moment a split had to be dropped,
+        # which is the dead key the hint's own rule exists to avoid.
+        scrolled = len(content.lines) > budget
         window, shown_end = self._window_rows(body, budget)
         # ``edge`` is tuned against the app ground; the raised overlay ground
         # needs one raised step to preserve the same intentionally quiet ratio.
@@ -1681,7 +1700,7 @@ class UsagePanel(Static):
         # `scrolled`. It adds no row and changes no width, so `_repaint`'s pinned
         # height and `_body_budget` are untouched.
         if scrolled:
-            self._paint_scrollbar(rows, budget, len(lines))
+            self._paint_scrollbar(rows, budget, len(content.lines))
         return rows
 
     def _window_rows(self, body: UsageBody, budget: int) -> tuple[list[Text], int]:

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -642,6 +642,26 @@ async def test_an_absent_availability_flag_still_counts_as_available() -> None:
     assert report.notes is None
 
 
+@pytest.mark.parametrize("flag", [None, 0, ""])
+@pytest.mark.asyncio
+async def test_a_falsy_but_non_false_flag_never_suspends_the_account(flag) -> None:
+    """Only the documented boolean suspends. This is a deliberate CHANGE from the
+    old truthiness test, which read ``null``, ``0`` and ``""`` as unavailable —
+    so a schema change that started sending one of them reddened every row of a
+    healthy account. Fail-open on those three, and the row's status still comes
+    from the total rather than from the flag alone."""
+    payload = {
+        "is_available": flag,
+        "balance_infos": [{"currency": "USD", "total_balance": "120.00"}],
+    }
+    client = _client_for(payload)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    assert report.notes is None
+    assert [lim.effective_status() for lim in report.limits] == ["ok"]
+
+
 @pytest.mark.asyncio
 async def test_one_unparsable_deepseek_balance_does_not_drop_the_others() -> None:
     """A garbage row is skipped; the currencies that parsed still report."""

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -538,6 +538,143 @@ async def test_deepseek_reports_a_balance_per_currency() -> None:
     assert units["deepseek:balance:usd"] == "usd"
 
 
+#: The SHAPE is DeepSeek's documented `/user/balance` schema and matches the
+#: live endpoint; the AMOUNTS are synthetic round numbers. The real figures are
+#: the operator's private account balance and are deliberately not committed.
+_DEEPSEEK_BALANCE_BODY = {
+    "is_available": True,
+    "balance_infos": [
+        {
+            "currency": "CNY",
+            "total_balance": "863.00",
+            "granted_balance": "63.00",
+            "topped_up_balance": "800.00",
+        },
+        {
+            "currency": "USD",
+            "total_balance": "120.00",
+            "granted_balance": "20.00",
+            "topped_up_balance": "100.00",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_deepseek_carries_the_granted_paid_split_per_currency() -> None:
+    """Granted credit EXPIRES, so a total alone overstates durable balance. The
+    currency rides on each number because the amount itself is deliberately
+    unitless for anything but USD."""
+    client = _client_for(_DEEPSEEK_BALANCE_BODY)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    details = {lim.id: lim.detail for lim in report.limits}
+    assert details["deepseek:balance:usd"] == "100.00 USD paid · 20.00 USD granted"
+    assert details["deepseek:balance:cny"] == "800.00 CNY paid · 63.00 CNY granted"
+
+
+@pytest.mark.asyncio
+async def test_deepseek_reports_no_split_when_the_body_carries_none() -> None:
+    """An empty detail renders no line at all, rather than an empty scaffold."""
+    payload = {
+        "is_available": True,
+        "balance_infos": [{"currency": "USD", "total_balance": "5.00"}],
+    }
+    client = _client_for(payload)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    assert [lim.detail for lim in report.limits] == [""]
+
+
+@pytest.mark.asyncio
+async def test_deepseek_states_a_status_rather_than_leaving_it_derived() -> None:
+    """A balance-only amount has no denominator, so ``UsageAmount.status()`` can
+    only ever say ``unknown`` — which drew a reported number as one we do not
+    have and tallied it in the footer as "not reported"."""
+    client = _client_for(_DEEPSEEK_BALANCE_BODY)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    assert {lim.effective_status() for lim in report.limits} == {"ok"}
+
+
+@pytest.mark.asyncio
+async def test_a_zeroed_deepseek_wallet_is_exhausted_not_unknown() -> None:
+    """Zero is definitive: the wallet cannot pay for the next request."""
+    payload = {
+        "is_available": True,
+        "balance_infos": [{"currency": "USD", "total_balance": "0.00"}],
+    }
+    client = _client_for(payload)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    assert [lim.effective_status() for lim in report.limits] == ["exhausted"]
+
+
+@pytest.mark.asyncio
+async def test_an_unavailable_deepseek_account_exhausts_every_funded_row() -> None:
+    """``is_available: false`` means the account cannot serve requests, so a row
+    with money in it is still not spendable."""
+    payload = {
+        "is_available": False,
+        "balance_infos": [{"currency": "USD", "total_balance": "120.00"}],
+    }
+    client = _client_for(payload)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    assert [lim.effective_status() for lim in report.limits] == ["exhausted"]
+
+
+@pytest.mark.asyncio
+async def test_an_absent_availability_flag_still_counts_as_available() -> None:
+    """Only a JSON ``false`` is evidence of suspension. Coercing a missing key
+    would paint a healthy account red on any schema change."""
+    payload = {"balance_infos": [{"currency": "USD", "total_balance": "120.00"}]}
+    client = _client_for(payload)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    assert [lim.effective_status() for lim in report.limits] == ["ok"]
+    assert report.notes is None
+
+
+@pytest.mark.asyncio
+async def test_one_unparsable_deepseek_balance_does_not_drop_the_others() -> None:
+    """A garbage row is skipped; the currencies that parsed still report."""
+    payload = {
+        "is_available": True,
+        "balance_infos": [
+            {"currency": "CNY", "total_balance": "not-a-number"},
+            {"currency": "USD"},
+            {"currency": "EUR", "total_balance": "7.50"},
+        ],
+    }
+    client = _client_for(payload)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    assert [lim.id for lim in report.limits] == ["deepseek:balance:eur"]
+
+
+@pytest.mark.asyncio
+async def test_deepseek_keeps_the_vendors_currency_order() -> None:
+    """The peer tools disagree with each other about which currency to prefer
+    (one takes the first entry, one hard-prefers USD), which is evidence there
+    is no right answer — so the vendor's own order is the tiebreak."""
+    client = _client_for(_DEEPSEEK_BALANCE_BODY)
+    async with client:
+        report = await fetch_usage(client, "deepseek", api_key="sk-ds")
+    assert report is not None
+    assert [lim.id for lim in report.limits] == [
+        "deepseek:balance:cny",
+        "deepseek:balance:usd",
+    ]
+
+
 #: A REAL Z.AI coding-plan quota body, captured from
 #: `GET https://api.z.ai/api/monitor/usage/quota/limit` on 2026-08-17. Pinned
 #: verbatim because the shape is the whole contract here: the TOKENS_LIMIT rows

--- a/tests/unit/providers/test_usage_cache.py
+++ b/tests/unit/providers/test_usage_cache.py
@@ -70,6 +70,17 @@ def test_report_round_trips_through_the_wire_format() -> None:
     assert limit.shared is True
 
 
+def test_round_trip_keeps_a_limits_detail_line() -> None:
+    """The decoder rebuilds a limit field by field rather than by splatting the
+    dict, so a field it forgets is dropped on the CACHED path only: the credit
+    split would show on a cold `/usage` and vanish on every warm one."""
+    report = _report()
+    report.limits[0].detail = "100.00 USD paid · 20.00 USD granted"
+    restored = report_from_dict(report_to_dict(report))
+    assert restored is not None
+    assert restored.limits[0].detail == "100.00 USD paid · 20.00 USD granted"
+
+
 def test_report_from_dict_rejects_garbage_as_a_miss() -> None:
     # A schema change or a corrupt row must read as a cache MISS, never an
     # exception on the /usage path.

--- a/tests/unit/providers/test_usage_cache.py
+++ b/tests/unit/providers/test_usage_cache.py
@@ -81,6 +81,21 @@ def test_round_trip_keeps_a_limits_detail_line() -> None:
     assert restored.limits[0].detail == "100.00 USD paid · 20.00 USD granted"
 
 
+def test_a_null_decodes_as_absent_rather_than_as_the_word_none() -> None:
+    """A JSON ``null`` is PRESENT, so ``limit.get(key, "")`` hands it to ``str()``
+    and the four-character string ``None`` lands in the field — as a tier row, and
+    as a bogus annotation line under a meter. Our own writer cannot emit null
+    (``asdict`` over a ``str`` field), so this is the hand-edited or
+    foreign-written row: exactly the row a decoder must not trust."""
+    payload = report_to_dict(_report())
+    payload["limits"][0]["detail"] = None
+    payload["limits"][0]["tier"] = None
+    restored = report_from_dict(payload)
+    assert restored is not None
+    assert restored.limits[0].detail == ""
+    assert restored.limits[0].tier == ""
+
+
 def test_report_from_dict_rejects_garbage_as_a_miss() -> None:
     # A schema change or a corrupt row must read as a cache MISS, never an
     # exception on the /usage path.

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -2626,6 +2626,42 @@ async def test_a_scoped_panel_keeps_the_stale_count_over_the_provider_name() -> 
     assert "anthropic" in wide and "1 stale" in wide, wide
 
 
+def _single_currency_split() -> list[UsageReport]:
+    """One balance carrying a split — the smallest body an annotation can grow."""
+    return [
+        _report(
+            _balance(
+                "deepseek:balance:usd",
+                "Balance (USD)",
+                120.0,
+                status="ok",
+                detail="100.00 USD paid · 20.00 USD granted",
+            ),
+            provider="deepseek",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(120, 34), (100, 19), (100, 18), (80, 14), (60, 12)])
+async def test_the_scroll_chrome_is_keyed_to_the_meters_not_the_annotations(size) -> None:
+    """The scroll chrome is a statement about the NUMBERS.
+
+    An annotation is decoration the window may drop, so a card whose meters all
+    fit is not a scrolled card — and must not raise a marker, a bar or an
+    `↑↓ scroll` hint that cannot move, which is chrome the detail-free tree did
+    not have and which the hint's own rule (a key that does nothing teaches the
+    user to distrust the others) exists to prevent.
+    """
+    async with _panel_app(size=size) as panel:
+        panel.show_reports(_single_currency_split())
+        body = panel._body()
+        framed = "\n".join(panel.render_lines_for_test())
+    chrome = "showing" in framed or "↑↓" in framed
+    assert chrome == (len(body.skeleton().lines) > panel._body_budget()), (size, framed)
+    assert ("█" in framed) == chrome, (size, framed)
+
+
 @pytest.mark.asyncio
 async def test_the_scrolled_panel_never_leads_with_an_annotation() -> None:
     """R1 by witness, on the REAL panel and its real budget.

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -203,29 +203,254 @@ def test_a_limit_detail_renders_directly_under_its_own_row() -> None:
     assert lines[index + 2].lstrip().startswith(MARK_KNOWN), lines
 
 
-def test_a_detail_is_never_kept_without_the_meter_it_annotates() -> None:
-    """The row and its detail are ONE cut unit. Compaction slices at cut points,
-    so a cut between them would leave `100.00 USD paid` floating under whatever
-    meter happened to precede it."""
-    report = _report(
-        _balance("deepseek:balance:cny", "Balance (CNY)", 863.0, status="ok", detail="CNY split"),
-        _balance("deepseek:balance:usd", "Balance (USD)", 120.0, status="ok", detail="USD split"),
+def _detail_shapes() -> list[tuple[str, list[UsageReport], float, float | None]]:
+    """The shapes whose windows have to hold the annotation contract.
+
+    One per way a detail can land in a block: on every meter, on the last meter
+    only (the trailing row is the pair — the frame QA reproduced), on the first
+    only (the frame Q2 is about: a wasted row of allowance with no meter lost),
+    on a single-currency block, on a dead account, in a block that has to keep a
+    staleness note ahead of its meters, and in a report with a sibling provider
+    below it so a window can end at a block boundary.
+    """
+    funded = _report(
+        _balance(
+            "deepseek:balance:cny",
+            "Balance (CNY)",
+            863.0,
+            status="ok",
+            detail="800.00 CNY paid · 63.00 CNY granted",
+        ),
+        _balance(
+            "deepseek:balance:usd",
+            "Balance (USD)",
+            120.0,
+            status="ok",
+            detail="100.00 USD paid · 20.00 USD granted",
+        ),
         provider="deepseek",
     )
-    body = build_usage_body([report], WIDTH, 0.0)
-    for index in sorted(body.details):
-        assert index not in body.cuts, (index, sorted(body.cuts))
+    one_currency = _report(
+        _balance(
+            "deepseek:balance:usd",
+            "Balance (USD)",
+            120.0,
+            status="ok",
+            detail="100.00 USD paid · 20.00 USD granted",
+        ),
+        provider="deepseek",
+    )
+    split_last = _report(
+        _balance("deepseek:balance:cny", "Balance (CNY)", 863.0, status="ok"),
+        _balance("deepseek:balance:eur", "Balance (EUR)", 42.0, status="ok"),
+        _balance(
+            "deepseek:balance:usd",
+            "Balance (USD)",
+            120.0,
+            status="ok",
+            detail="100.00 USD paid · 20.00 USD granted",
+        ),
+        provider="deepseek",
+    )
+    split_first = _report(
+        _balance(
+            "deepseek:balance:usd",
+            "Balance (USD)",
+            120.0,
+            status="ok",
+            detail="100.00 USD paid · 20.00 USD granted",
+        ),
+        _balance("deepseek:balance:eur", "Balance (EUR)", 42.0, status="ok"),
+        provider="deepseek",
+    )
+    dead = _report(
+        _balance(
+            "deepseek:balance:usd",
+            "Balance (USD)",
+            0.0,
+            status="exhausted",
+            detail="0.00 USD paid · 0.00 USD granted",
+        ),
+        provider="deepseek",
+    )
+    stale = _report(
+        _balance(
+            "deepseek:balance:usd",
+            "Balance (USD)",
+            120.0,
+            status="ok",
+            detail="100.00 USD paid · 20.00 USD granted",
+        ),
+        provider="deepseek",
+        identity="me@example.com",
+    )
+    # 10 minutes behind a `just now` header: past the TTL*1.25 threshold, so the
+    # block renders a note above its meters and the note has to survive the same
+    # compaction the meters do.
+    stale.fetched_at = 1
+    sibling = [
+        funded,
+        _report(_percent("anthropic:7d", "7 day", 41.0, shared=True), provider="anthropic"),
+    ]
+    return [
+        ("funded", [funded], 0.0, None),
+        ("one-currency", [one_currency], 0.0, None),
+        ("split-last", [split_last], 0.0, None),
+        ("split-first", [split_first], 0.0, None),
+        ("dead", [dead], 0.0, None),
+        ("stale", [stale], 600_000.0, 600_000.0),
+        ("siblings", sibling, 0.0, None),
+    ]
 
-    start, _ = body.blocks[0]
+
+def _row_indices(body, window) -> list[int]:
+    """Which of ``body``'s rows a window paints, by identity.
+
+    The window hands back the body's own ``Text`` objects, so identity — not
+    equality — is what says which row it is: two rows can legitimately carry the
+    same characters.
+    """
+    where = {id(line): index for index, line in enumerate(body.lines)}
+    return [where[id(row)] for row in window]
+
+
+def test_the_annotation_never_costs_a_meter_at_any_budget_or_offset() -> None:
+    """The window contract, swept over EVERY budget and EVERY offset.
+
+    A detail is droppable decoration attached to the meter above it. Two rules
+    must hold in every window, and the first version of this change (a meter and
+    its detail as one indivisible cut unit) broke the second in a way a
+    one-offset test could not see: with ``budget == 2`` the pair did not fit, so
+    the loop kept *nothing* and 100x18 painted a provider heading with no
+    numbers under it where the base tree painted one.
+
+    * no window paints a detail whose meter is not in the SAME window — not as
+      its first row, not at any scroll offset, not under compaction;
+    * the meters win every tie: at the same budget and the same position, the
+      window paints every detail-free row the tree without annotations painted
+      (and so never fewer rows than it used, or a row of the allowance would be
+      going to a split while a meter went unshown).
+
+    The bare body is the tree those rules were written against: derived from the
+    same rows with the details taken out, so the comparison needs no second
+    checkout and no invented baseline.
+    """
     panel = UsagePanel()
-    panel._offset = start
-    for budget in range(1, len(body.lines) + 1):
+    for name, reports, now, header in _detail_shapes():
+        body = build_usage_body(reports, WIDTH, now, header)
+        bare = body.skeleton()
+        assert body.details, f"{name}: the shape must carry an annotation to prove anything"
+        for budget in range(1, len(body.lines) + 3):
+            for offset in range(len(body.lines) + 1):
+                panel._offset = offset
+                window, _ = panel._window_rows(body, budget)
+                rows = _row_indices(body, window)
+                for index in rows:
+                    if index in body.details:
+                        assert index - 1 in rows, (
+                            name,
+                            budget,
+                            offset,
+                            [body.lines[shown].plain for shown in rows],
+                        )
+                # Same budget, same content position — the bare tree is the floor.
+                panel._offset = body.content_at(offset)
+                bare_window, _ = panel._window_rows(bare, budget)
+                bare_rows = _row_indices(bare, bare_window)
+                assert [body.content_at(index) for index in rows if index not in body.details] == (
+                    bare_rows
+                ), (name, budget, offset)
+                assert len(rows) >= len(bare_rows), (name, budget, offset)
+
+
+def test_a_budget_that_holds_a_meter_shows_it() -> None:
+    """Q1/Q2 by witness: the metric the frames were measured on.
+
+    QA's frame is `budget == 2` with the split on the trailing balance and
+    ``showing 6 of 6`` over an empty block. The second half of the finding is
+    that ``budget == 4`` painted the same three rows as ``budget == 3``, one row
+    of allowance going nowhere. Both are arithmetic, so both are asserted as
+    numbers: every budget up to the block's own height paints a heading plus one
+    row per meter that fits, and never fewer rows than the last budget did.
+    """
+    panel = UsagePanel()
+    reports = _detail_shapes()[2][1]  # split-last: heading, blank, 3 balances
+    body = build_usage_body(reports, WIDTH, 0.0)
+    painted: list[int] = []
+    for budget in range(2, 6):
+        panel._offset = body.blocks[0][0]
         window, _ = panel._window_rows(body, budget)
         rows = [row.plain for row in window]
-        text = "\n".join(rows)
-        for currency in ("CNY", "USD"):
-            if f"{currency} split" in text:
-                assert f"Balance ({currency})" in text, (budget, rows)
+        painted.append(len(rows))
+        assert any("Balance" in row for row in rows), (budget, rows)
+    # From budget 2 up, the allowance buys a meter at every step: 3 and 4 must not
+    # be the same three rows, and 4 spends its spare row on the last meter.
+    # (Budget 1 paints the heading alone, which the base tree did too.)
+    assert painted == [2, 3, 4, 5], painted
+    # And the annotation is not lost to the fix: given a card that fits the whole
+    # block, every row is painted, the split included.
+    panel._offset = body.blocks[0][0]
+    full, _ = panel._window_rows(body, len(body.lines))
+    assert _row_indices(body, full) == list(range(len(body.lines))), [row.plain for row in full]
+
+
+def _scrolling_reports() -> list[UsageReport]:
+    """The funded block plus enough providers below it that the card scrolls.
+
+    Reaching the clamp is the point: the R1 frame came from scrolling INTO the
+    deepseek block, which only happens when there is somewhere below it to go.
+    """
+    return [
+        _detail_shapes()[0][1][0],
+        *(
+            _report(_percent(f"a{index}:7d", "7 day", 41.0, shared=True), provider=f"p-{index}")
+            for index in range(6)
+        ),
+    ]
+
+
+def _width_reports() -> list[UsageReport]:
+    """The funded block plus the percentage window that squeezes its bar.
+
+    This is the shape D3 was measured on: the sibling's countdown and percentage
+    take the measured columns, so at 60 columns the balance rows collapse to a
+    single bar dot and their right edge — where the NUMBER ends — stops well
+    inside the card, leaving the row's tail as padding.
+    """
+    return [
+        _detail_shapes()[0][1][0],
+        _report(
+            _percent("anthropic:7d", "7 day", 41.0, shared=True, resets_at_ms=96 * 3600_000),
+            provider="anthropic",
+            identity="me@example.com",
+        ),
+    ]
+
+
+def test_an_annotation_never_paints_wider_than_its_meter() -> None:
+    """D3: at 60 columns the balance row's right edge is 35 cells while a split
+    is a fixed 37-cell string, so measuring the annotation against the card let
+    it protrude two cells past the numbers column and break the block's edge.
+
+    Asserted against the METER'S INK (trailing padding is not something a reader
+    can see): every width the panel can be asked for, the annotation fits inside
+    the row it annotates, and where it has to be cut it says so.
+    """
+    for width in (120, 100, 89, 80, 74, 69, 49, 40):
+        lines = build_usage_body(_width_reports(), width, 0.0).lines
+        meter = next(line for line in lines if "Balance (USD)" in line.plain)
+        detail = lines[lines.index(meter) + 1]
+        assert cell_len(detail.plain.rstrip()) <= cell_len(meter.plain.rstrip()), (
+            width,
+            meter.plain.rstrip(),
+            detail.plain.rstrip(),
+        )
+    # At the width the defect was measured on, the split is CUT — not wrapped,
+    # not allowed to spill — and the ellipsis is the only thing dropped from it.
+    narrow = build_usage_body(_width_reports(), 49, 0.0).lines
+    row = next(line for line in narrow if "USD paid" in line.plain)
+    assert row.plain.rstrip().endswith("…"), row.plain
+    assert cell_len(row.plain.rstrip()) <= 35, row.plain
 
 
 def test_amounts_print_the_unit_label_not_the_raw_key() -> None:
@@ -2399,3 +2624,38 @@ async def test_a_scoped_panel_keeps_the_stale_count_over_the_provider_name() -> 
     # Where both fit, the target is still shown — it is only dropped under
     # pressure, not removed from the design.
     assert "anthropic" in wide and "1 stale" in wide, wide
+
+
+@pytest.mark.asyncio
+async def test_the_scrolled_panel_never_leads_with_an_annotation() -> None:
+    """R1 by witness, on the REAL panel and its real budget.
+
+    Three `Down` presses used to put the CNY split directly above the USD meter —
+    a credit split read as belonging to the balance under it. `_max_offset` and
+    the window both measure over the meters now, so this walks every offset the
+    clamp actually reaches at a size that cuts mid-block and asserts, per frame,
+    that the first row is not an annotation and that no annotation is painted
+    without the meter directly above it.
+    """
+    async with _panel_app(size=(100, 22)) as panel:
+        panel.show_reports(_scrolling_reports())
+        body = panel._body()
+        assert body.details, "premise: the deepseek block carries annotations"
+        frames = 0
+        while True:
+            frames += 1
+            window, _ = panel._window_rows(body, panel._body_budget())
+            rows = _row_indices(body, window)
+            assert rows and rows[0] not in body.details, (
+                panel.view_offset,
+                [body.lines[index].plain for index in rows],
+            )
+            assert any(index not in body.details for index in rows), panel.view_offset
+            for index in rows:
+                if index in body.details:
+                    assert index - 1 in rows, (panel.view_offset, index)
+            before = panel.view_offset
+            panel.action_scroll_rows(1)
+            if panel.view_offset == before:
+                break
+    assert frames > 8, f"premise: this size scrolls far enough to cut mid-block ({frames})"

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -29,6 +29,8 @@ from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.usage_panel import (
     BAR_UNKNOWN,
+    MARK_KNOWN,
+    MARK_UNKNOWN,
     PANEL_MAX_WIDTH,
     PANEL_MIN_WIDTH,
     PANEL_PADDING_ROWS,
@@ -115,6 +117,115 @@ def test_a_remaining_only_balance_renders_its_number() -> None:
     assert "12.50 USD left" in joined, lines
     assert "70 left" in joined, lines
     assert "voucher $2.50 + cash $10.00" in joined, lines
+
+
+def _balance(limit_id: str, label: str, remaining: float, **kwargs) -> UsageLimit:
+    """A balance-only row: a `remaining` with no denominator to derive from."""
+    return UsageLimit(
+        id=limit_id,
+        label=label,
+        amount=UsageAmount(remaining=remaining, unit="usd"),
+        window="lifetime",
+        **kwargs,
+    )
+
+
+def test_a_statused_balance_row_is_drawn_as_a_number_we_have() -> None:
+    """The mark said "not reported" for a balance the endpoint had just
+    reported: a balance-only amount has no fraction BY CONSTRUCTION, so keying
+    the mark on the fraction could only ever draw it hollow."""
+    lines = _lines([_report(_balance("deepseek:balance:usd", "Balance (USD)", 120.0, status="ok"))])
+    row = next(line for line in lines if "Balance (USD)" in line)
+    assert row.startswith(f"{MARK_KNOWN} "), row
+    # The BAR stays dotted: a proportion genuinely is unknown here.
+    assert BAR_UNKNOWN in row, row
+
+
+def test_a_row_with_no_status_at_all_is_still_drawn_as_unknown() -> None:
+    """The mark keys on knowledge, not on having a row: a provider that reports
+    neither a fraction nor a status has told us nothing."""
+    lines = _lines([_report(UsageLimit(id="a:?", label="Mystery", amount=UsageAmount(unit="usd")))])
+    row = next(line for line in lines if "Mystery" in line)
+    assert row.startswith(f"{MARK_UNKNOWN} "), row
+
+
+def test_the_footer_does_not_call_a_reported_balance_unreported() -> None:
+    """`2 not reported` for two balances the panel is printing was the footer
+    contradicting the rows directly above it."""
+    stats = collect_stats(
+        [
+            _report(
+                _balance("deepseek:balance:cny", "Balance (CNY)", 863.0, status="ok"),
+                _balance("deepseek:balance:usd", "Balance (USD)", 120.0, status="ok"),
+                provider="deepseek",
+            )
+        ]
+    )
+    assert stats.unknown == 0
+    assert stats.describe() == "2 windows"
+
+
+def test_an_exhausted_balance_reads_as_exhausted_in_the_tally() -> None:
+    """A dead account and a funded one must not tally alike."""
+    stats = collect_stats(
+        [
+            _report(
+                _balance("deepseek:balance:usd", "Balance (USD)", 0.0, status="exhausted"),
+                provider="deepseek",
+            )
+        ]
+    )
+    assert (stats.exhausted, stats.unknown) == (1, 0)
+    assert stats.describe() == "1 window · 1 exhausted"
+
+
+def test_a_limit_detail_renders_directly_under_its_own_row() -> None:
+    """The split is an annotation on one meter, so it has to sit against that
+    meter rather than at the end of the block."""
+    lines = _lines(
+        [
+            _report(
+                _balance(
+                    "deepseek:balance:usd",
+                    "Balance (USD)",
+                    120.0,
+                    status="ok",
+                    detail="100.00 USD paid · 20.00 USD granted",
+                ),
+                _balance("deepseek:balance:cny", "Balance (CNY)", 863.0, status="ok"),
+                provider="deepseek",
+            )
+        ]
+    )
+    index = next(i for i, line in enumerate(lines) if "Balance (USD)" in line)
+    assert lines[index + 1].strip() == "100.00 USD paid · 20.00 USD granted", lines
+    # And the row without a split gets no line of its own.
+    assert lines[index + 2].lstrip().startswith(MARK_KNOWN), lines
+
+
+def test_a_detail_is_never_kept_without_the_meter_it_annotates() -> None:
+    """The row and its detail are ONE cut unit. Compaction slices at cut points,
+    so a cut between them would leave `100.00 USD paid` floating under whatever
+    meter happened to precede it."""
+    report = _report(
+        _balance("deepseek:balance:cny", "Balance (CNY)", 863.0, status="ok", detail="CNY split"),
+        _balance("deepseek:balance:usd", "Balance (USD)", 120.0, status="ok", detail="USD split"),
+        provider="deepseek",
+    )
+    body = build_usage_body([report], WIDTH, 0.0)
+    for index in sorted(body.details):
+        assert index not in body.cuts, (index, sorted(body.cuts))
+
+    start, _ = body.blocks[0]
+    panel = UsagePanel()
+    panel._offset = start
+    for budget in range(1, len(body.lines) + 1):
+        window, _ = panel._window_rows(body, budget)
+        rows = [row.plain for row in window]
+        text = "\n".join(rows)
+        for currency in ("CNY", "USD"):
+            if f"{currency} split" in text:
+                assert f"Balance ({currency})" in text, (budget, rows)
 
 
 def test_amounts_print_the_unit_label_not_the_raw_key() -> None:


### PR DESCRIPTION
# PR Description

## Summary of Changes

`/usage` drew a DeepSeek balance the endpoint had **just reported** as a figure we do not have, and the footer said so out loud.

Three defects, all visible in one frame (real `OperatorApp`, `120x34`, canned body):

```
deepseek

○ Balance (CNY)  ········································         863 left
○ Balance (USD)  ········································  120.00 USD left

3 windows · 2 not reported
```

1. **A known balance is drawn as unknown.** `_limit_row` picked the mark from `limit.amount.fraction() is not None`. A balance-only amount has no denominator, so `fraction()` is `None` *by construction* → hollow `○` and a dotted bar, forever. `effective_status()` was never consulted.
2. **The footer contradicted the rows above it.** `collect_stats` tallies `effective_status()`, which for a balance-only amount is `unknown`, rendered as `2 not reported` — for two balances that were reported, printed two lines higher.
3. **A dead account was indistinguishable from a funded one.** `is_available: false` + `total_balance: "0.00"` rendered with the same hollow mark, the same dotted bar and the same dim ramp as `120.00 USD left`. The only signal was the digits themselves.

Plus: `granted_balance` / `topped_up_balance` are documented, returned live, and parsed by nobody — so the split was discarded. Granted credit **expires**, so a single total overstates how much durable balance an account has.

Release: patch — `/usage` tells the truth about DeepSeek credit; no API or config change.

## Related Issue(s)

- Related: none (found while reading the live `/usage` panel)

## What changed

- **`local_operator/providers/usage.py`**
  - `fetch_deepseek_balance` sets an **explicit `status`** per row — `exhausted` when the account cannot serve (`is_available` is `False`) or the total is `<= 0`, else `ok`. This is the same shape `fetch_radient_balance` already uses. Without it the row is permanently `unknown` in both the mark and the tally, because `UsageAmount.status()` needs a denominator that a balance never has.
  - `is_available` is read **strictly**: only a JSON `false` means unavailable, and that is a deliberate **change** for the other falsy values — the old truthiness test read `null`, `0` and `""` as unavailable, so a schema change that started sending any of them reddened every row of a healthy account. A missing key or a non-boolean is fail-open. Pinned by `test_a_falsy_but_non_false_flag_never_suspends_the_account`.
  - `granted_balance` / `topped_up_balance` are parsed and carried as a new `UsageLimit.detail` string (`100.00 USD paid · 20.00 USD granted`), built only from the parts that parsed — a body with neither produces no line at all. The currency is repeated on each number deliberately: the CNY row's `amount.unit` is `unknown` on purpose, so this line is the only place a number and its currency appear together.
  - Both currency rows are kept in the **vendor's array order**. The peer tools disagree with each other here (one takes the first entry, one hard-prefers USD), which is evidence there is no right answer, so the vendor's order is the tiebreak.
  - Module docstring records what is now surfaced **and** the finding that DeepSeek publishes **no usage/spend endpoint** — `/user/balance` is the only account route in their API docs. No usage window is invented.
- **`local_operator/tui/widgets/usage_panel.py`**
  - `_limit_row` keys the mark on knowledge (`effective_status() != "unknown"`), not on the fraction. The **bar stays dotted**: a proportion genuinely is unknown for a balance, and dots say so honestly.
  - `build_usage_body` renders `limit.detail` as one indented `dim` line directly under its row, truncated to the INK of the row it annotates rather than to the card — at 60 columns the balance row's right edge is 35 cells while a split is a fixed 37-cell string, so measuring it against the card let it out-paint its own meter (round 1's D3).
  - **The meter is the cut point; the detail is droppable annotation of strictly lower priority.** This replaces the first draft's "one cut unit" rule, which was wrong (it is what round 1 filed): making a meter and its detail indivisible meant a budget that could not hold both kept *neither*, so 100x18 and 100x16 painted a provider heading with no numbers under it where the base tree painted one. Windows are now chosen over a detail-free view of the body (`UsageBody.skeleton`) and the annotations are painted afterwards, out of the rows the meters did not need. Two invariants, both swept over every budget x offset: **a detail is never painted without its meter in the same window** (any offset, any budget) and **the meter wins every tie** — the window paints exactly the detail-free rows the base tree painted, so a card that fits one number shows it.
- **`local_operator/providers/usage_cache.py`** *(not in the original scope — see "Deviation" below)*
  - `report_from_dict` decodes `detail`. That rebuild is field-by-field rather than `UsageLimit(**limit)`, so an omitted field is dropped **on the cached path only** — the split would have appeared on a cold `/usage` and silently vanished on every warm one.

### Deviation from the brief

The brief's file list covered `usage.py` and `usage_panel.py`. It missed `usage_cache.py`, whose decoder rebuilds `UsageLimit` field by field. Since `/usage` serves from that cache on most opens, the feature would have been invisible in the common case. Fixed here with a round-trip test rather than deferred, because the brief's own acceptance ("the split renders") is not true without it.

## Testing Details

### Gates (all green on head `937f855fc`, and on the remediation head `f3be14ca`)

| gate | command | result |
|---|---|---|
| flake8 | `.venv/bin/python -m flake8 local_operator tests` | **0** |
| black (CI pin 26.1.0) | `uvx --from black==26.1.0 black --check .` | **1265 files unchanged** |
| isort (CI pin 5.13.2) | `uvx isort==5.13.2 --check .` | **clean** (skipped 2) |
| pyright (pin 1.1.411) | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings** |
| unit suite | `.venv/bin/python -m pytest tests/unit -q` | **19253 passed**, 18 skipped, 2 failed + 3 errors — all pre-existing parallelism flakes, see below |
| TUI suite | `env -u NO_COLOR TERM=xterm-256color … pytest tests/unit/tui -q` | green |

Re-run on the remediation head `f3be14ca`, over the whole tree exactly as CI spells it:

| gate | command | result |
|---|---|---|
| flake8 | `.venv/bin/python -m flake8 local_operator tests` | **0** |
| black (CI pin 26.1.0) | `uvx --from black==26.1.0 black --check .` | **1265 files unchanged** |
| isort (CI pin 5.13.2) | `uvx isort==5.13.2 --check-only .` | **clean** (2 files skipped by config) |
| pyright (pin 1.1.411) | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings** |
| touched suites | `env -u NO_COLOR TERM=xterm-256color … pytest tests/unit/tui/test_usage_panel.py tests/unit/providers/test_usage.py tests/unit/providers/test_usage_cache.py -q -n0` | **283 passed** |
| full unit suite + TUI e2e (CI) | `.github/workflows/ci.yml` on `f3be14ca7`: all five `test (3.12, n)` shards, `tui-e2e` (macos + ubuntu), `lint`, `type-check`, `version-bump-guard`, `coverage-report` | **all pass** ([run](https://github.com/damianvtran/local-operator/actions/runs/34731343566)) |
| full unit suite (local) | `.venv/bin/python -m pytest tests/unit -q` | started on `f3be14ca7`, still crawling after ~25 min (load average ~140 on a box running several sibling worktrees; 2 xdist workers under the conftest memory cap) and **cancelled** so it stopped competing for the box — the gate is the CI row above, read from the same head. |

**Note on the CLI pins:** neither `black` nor `isort` is installed in this worktree's venv, so `python -m black` errors rather than checking; both ran at the CI pins through `uvx`, which is what CI itself resolves.

The 2 failures (`test_attach_frame_size.py::test_a_quiescent_follower_recovers_without_waiting_for_more_traffic`, `test_steering_approval.py::test_empty_assistant_message_mounts_no_block`) and 3 errors (`OSError: could not create numbered dir with prefix home … after 10 tries`) touch no file in this diff. Confirmed unrelated two ways: all 121 of those tests **pass in isolation** (`-n0`, `121 passed in 469.95s`), and the same two files **pass on the stashed clean base** under the same parallelism (`216 passed in 111.96s`). They are tmpdir/worker contention on a machine running several worktrees.

### The new tests fail on the unfixed code (three targeted mutations, each reverted)

| mutation | test | result |
|---|---|---|
| mark keys on `fraction` again | `test_a_statused_balance_row_is_drawn_as_a_number_we_have` | `'○ Balance (USD)  ···…  120.00 USD left'.startswith('● ')` → **failed** |
| the pre-fix window rule (both mutations that "fixed" it) | `test_the_annotation_never_costs_a_meter_at_any_budget_or_offset` | **43 orphaned-detail frames, 26 meters-below-base frames of 214** → failed; 0 and 0 on the shipped rule |
| cache decoder line removed | `test_round_trip_keeps_a_limits_detail_line` | `- 100.00 USD paid · 20.00 USD granted` → **failed** |

### Live fetch against the real key (this branch's parser)

Run against the operator's real stored DeepSeek credential. **Amounts withheld** — that is a private balance; the structure is what the change is about:

```
row 78 (key len 35): notes=None
   id=deepseek:balance:usd label='Balance (USD)' status='ok' fraction=None
   unit='usd' amount_present=True detail_shape='<amt> USD paid · <amt> USD granted'
```

`status='ok'` with `fraction=None` is exactly the case that used to render hollow: a row we know about, for which no proportion exists. The split parsed from the live body, not a fixture.

### Warm-cache path, real SQLite

The panel serves from cache on most opens, so the split was driven through a real `UsageCacheStore` (`set` → `get`) on disk rather than through `asdict` alone:

```
live   : [('deepseek:balance:usd', 'ok', '100.00 USD paid · 20.00 USD granted')]
warm   : [('deepseek:balance:usd', 'ok', '100.00 USD paid · 20.00 USD granted')]
```

### Rendered frames — real `OperatorApp`, both states

Captured with the real app (not the lightweight test host, which declares no `CSS_PATH` and so renders none of the card's padding or fill), same `120x34`, same fixed clock, same canned body; the seed is built by the **real fetcher**, so before/after differ only by the code under test. Amounts are synthetic round numbers.

**Funded account (both currencies):**

| | frame |
|---|---|
| before | [rendered frame](https://gist.githubusercontent.com/damianvtran/1c27751fc13eae866abb1883e6351c3c/raw/2db38deeece108d7efb09d850214bdce419fdb87/ds-before-rich.svg) |
| after | [rendered frame](https://gist.githubusercontent.com/damianvtran/1c27751fc13eae866abb1883e6351c3c/raw/aed73be4652de1c094cdc23531d4c3c14f76968b/ds-after-rich.svg) |

```
before                                                 after
○ Balance (CNY)  ·········         863 left            ● Balance (CNY)  ·········         863 left
○ Balance (USD)  ·········  120.00 USD left              800.00 CNY paid · 63.00 CNY granted
                                                       ● Balance (USD)  ·········  120.00 USD left
                                                         100.00 USD paid · 20.00 USD granted
footer: 3 windows · 2 not reported                     footer: 3 windows
```

**Dead account (`is_available: false`, `0.00`):**

| | frame |
|---|---|
| before | [rendered frame](https://gist.githubusercontent.com/damianvtran/1c27751fc13eae866abb1883e6351c3c/raw/2bcdb6e454d4554cec78199b8d5aa49e4924fed9/ds-before-empty.svg) |
| after | [rendered frame](https://gist.githubusercontent.com/damianvtran/1c27751fc13eae866abb1883e6351c3c/raw/36cdeafb8a5188348c9bfacb0568d7018a4561d0/ds-after-empty.svg) |

```
before                                                 after
○ Balance (USD)  ·········    0.00 USD left            ● Balance (USD)  ·········    0.00 USD left   (danger red)
                                                         0.00 USD paid · 0.00 USD granted
footer: 3 windows · 2 not reported                     footer: 2 windows · 1 exhausted
```

The dead-account row now takes the `danger` ramp and the footer names the state, so it is no longer pixel-identical to a funded one.

### Geometry (the numbers behind the pixels)

Screen `118x32` in every frame; `virtual_size == size` throughout, so nothing overflowed or scrolled.

| state | panel region | panel size | virtual | scrollbar |
|---|---|---|---|---|
| rich, before | `[8, 7, 104, 14]` | `100x12` | `104x14` | none |
| rich, after | `[8, 5, 104, 16]` | `100x14` | `104x16` | none |
| empty, before | `[8, 7, 104, 14]` | `100x12` | `104x14` | none |
| empty, after | `[8, 6, 104, 15]` | `100x13` | `104x15` | none |

The card grows by exactly the number of detail rows added (+2 funded, +1 dead), stays centred (the region origin moves up by half the growth), and gains no scrollbar — a card the whole body fits shows every annotation. Body row/cut counts: rich `10 rows / 3 cuts`, empty `9 rows / 2 cuts`: the cut points count the *meters*, and the annotations are extra rows painted inside a window the meters chose. The scroll chrome (position marker, `↑↓` hint, bar) counts the meters too, so a card whose balances all fit raises no chrome when a split has to be dropped.

## Round 1 remediation (head `f3be14ca74e762a144baeda1fbc8ddbac2d870d2`)

Three concurrent round-1 streams filed on `937f855fc` — a design review (D1/D2/D3), an agent review (R1-R4) and QA (Q1/Q2). D1, Q1 and R1 are the same defect found three ways, and it was **this PR's own headline claim that was wrong**: a meter and its detail were made one indivisible cut unit, so a budget that could not hold both kept neither. Corrected model, now the shipped one:

1. **A detail never renders without the meter it annotates in the same window** — not as a window's first row, not at any scroll offset, not under compaction.
2. **The meter always wins a tie** — at every budget and every offset the window shows exactly the detail-free rows the base tree showed, and never fewer rows painted than it used.

Meters painted at the block start; funded two-currency shape; `build_usage_body` + `_window_rows` driven directly, base from a `3aec94b92` checkout:

| body budget | base `3aec94b92` | head `937f855fc` | head `f3be14ca` |
|---|---|---|---|
| 1 | 0 | 0 | 0 (pre-existing: a one-row budget is the heading) |
| 2 | **1** | **0** | **1** |
| 3 | **2** | **1** | **2** |
| 4 | **2** | **1** | **2** |
| 5 | 2 | 2 | 2 (+1 annotation) |
| 6 | 2 | 2 | 2 (+2 annotations) |

Also fixed in the same round: the annotation out-painting its own meter at 60 columns (D3, now truncated to the meter's ink), a JSON-null `detail`/`tier` decoding to the literal `"None"` (R2), the `is_available` doc text (R3, above), the `exhausted`-vs-`usage_health` note (R4), and the dead scroll chrome a dropped annotation used to raise (the chrome counts the meters through one helper shared by the painter and the drag).

Frames — [gist](https://gist.github.com/damianvtran/dc5c84df138f6aa256facdffe5305437), same seed and fixed clock across all three trees (base / pre-remediation head / fixed):

| frame | before (head `937f855fc`) | base `3aec94b92` | after `f3be14ca` |
|---|---|---|---|
| funded 100x18 | [heading, no numbers](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/3abbe114aa71c9bfe8c4408c627326985944a9b5/beforehead-funded-100x18.svg) | [one meter](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/0ac038706c19782fbc3235fcd8f46fe3aa064dee/beforebase-funded-100x18.svg) | [one meter](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/6a0adc8a0d4f545c3b61c96c87c91717fd50eeee/after-funded-100x18.svg) |
| funded 100x19 | [one meter](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/df87173f61dd2e7db11440da90fd83a12a09c80b/beforehead-funded-100x19.svg) | [two meters](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/d57239d3f26371a5487cb6321c284a8d009f6fa0/beforebase-funded-100x19.svg) | [two meters](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/99ceea7f6e9635b6505983d57fa0fbe1ea52da4a/after-funded-100x19.svg) |
| funded 100x20 | [one meter](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/c5e22400dc0dbba29214eacea2cdab99122004bc/beforehead-funded-100x20.svg) | [two meters](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/e571637171ac49aa8c700b00833329428a838388/beforebase-funded-100x20.svg) | [two meters](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/42db405d10cbf71513348dda96fc769e53cac18b/after-funded-100x20.svg) |
| funded 100x18, 3 `Down` | [bare CNY split under the rule](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/73c0de674e58cd9c9e7e15a93205f4584e8467ef/beforehead-funded-100x18-down3.svg) | — | [the USD meter and its own split](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/e2ce0fd72a1e837fcea9aafd02a7e71e3f3a9620/after-funded-100x18-down3.svg) |
| funded 60x34 | [splits past the numbers column](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/430244f4236e39065331e5a29af93afb2c85f8de/beforehead-funded-60x34.svg) | [no split](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/c8d8936b1f1f6a88b0f1c57e265e13dd95cefee2/beforebase-funded-60x34.svg) | [split cut to the meter's edge](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/05ff554bdd69287a2c5d964b3249de625694e969/after-funded-60x34.svg) |
| split-on-last 120x18 (QA's shape) | [`showing 6 of 6`, zero numbers](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/c3ea716e664338f08b4080f16c5f53cddfa849b6/beforehead-split-last-120x18.svg) | [one meter](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/f8080ddb9612b46b426dc643e0ee54c8f89fb4c3/beforebase-split-last-120x18.svg) | [one meter](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/c83fea2ee723f49371db02df1e1714501941aba3/after-split-last-120x18.svg) |
| funded 120x34 (card fits) | — | — | [both splits shown](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/ea3fe9226923844aa1591e4fb160acf944f0e082/after-funded-120x34.svg) |
| funded 100x22, 3 `Down` | — | — | [no orphan](https://gist.githubusercontent.com/damianvtran/dc5c84df138f6aa256facdffe5305437/raw/df26fd3fd40d25c4628da3ff96a8edaac615c4ea/after-funded-100x22-down3.svg) |

Pinned by `test_the_annotation_never_costs_a_meter_at_any_budget_or_offset` (budget x every offset, seven seeded shapes, both directions), `test_a_budget_that_holds_a_meter_shows_it`, `test_the_scrolled_panel_never_leads_with_an_annotation`, `test_the_scroll_chrome_is_keyed_to_the_meters_not_the_annotations`, `test_an_annotation_never_paints_wider_than_its_meter`, `test_a_null_decodes_as_absent_rather_than_as_the_word_none` and `test_a_falsy_but_non_false_flag_never_suspends_the_account`.


## Out of scope (deliberately not implemented here)

- **Local spend** (tokens × price for these sessions) — that is `/analytics`' question, not the quota panel's.
- **DeepSeek peak/off-peak pricing.** DeepSeek bills Peak traffic at **2x** the catalog rate (Beijing 09:00–12:00 and 14:00–18:00, Mon–Fri). `model/prices.py` resolves one flat rate from models.dev, so `/analytics` cost during Peak is roughly half the real spend, and `cost_micro` on historical rows was priced at record time. Real, but a separate change to the **cost model** with its own evidence.
- **The operator's credential store holds a second, invalid DeepSeek key** (24 chars, row id 36) beside the real one; the resolver alternates, so a DeepSeek usage fetch 401s roughly half the time and serves last-good. Confirmed again during this work (`row 36 … fetch returned None (rejected)`). Reported separately — the store is **not touched** by this change and no workaround for it was added.

## Checklist

- [x] Conventional commit
- [x] Comments explain why/constraints, not what
- [x] No version bump in `pyproject.toml` (stays at the last released version)
- [x] Evidence kept out of the repository (frames in a gist)
- [x] New tests verified to fail on the unfixed code

