### PR TITLE
feat(web_fetch): retry transient failures and diagnose bot-blocks honestly

### DIFF
--- a/docs/design/web_fetch.md
+++ b/docs/design/web_fetch.md
@@ -9,8 +9,11 @@ bearing, not decoration.
 **Companion document:** `web_fetch_robustness.md` extends this one with the
 retry policy, the anti-bot/challenge taxonomy, the blocked-retry request profile
 and the model-facing diagnostics for a refused or stalled fetch. Read it
-alongside §6 (pipeline), §7 (safety) and §9 (config) — it refines those three
-and contradicts none of them.
+alongside §6 (pipeline), §7 (safety) and §9 (config) — it refines those three,
+and it contradicts ONE line of §7 item 7 on purpose: an escalated attempt after a
+refusal wears a browser-shaped header set instead of the plain lop
+`User-Agent`. That exception, its gate and its why are stated at §7 item 7 below
+and in the companion's §4.1/§4.3.
 
 ---
 
@@ -369,6 +372,17 @@ endpoints, internal services, `file://`, localhost admin panels). Policy:
 7. **No credential leakage:** do not forward ambient cookies/auth; each fetch is
    anonymous (this is the deliberate difference from `browser`, which uses the
    user's logged-in session). Set a plain `User-Agent` identifying lop.
+
+   **One stated exception, added by `web_fetch_robustness.md` (§4):** after an
+   origin has ALREADY refused an honest, self-identifying request (or stalled on
+   it), a single second attempt may be made with a browser-shaped header set
+   (`User-Agent` + `Accept`/`Accept-Language`/`Sec-Fetch-*`). It is off the
+   default path — the plain lop `User-Agent` remains the posture, the exception
+   is paid only on a refusal, the identity change happens at most once per fetch,
+   `web_fetch.blocked_retry: false` removes it entirely, and it carries none of
+   the user's cookies, credentials or session. The distinction this policy exists
+   to protect is *anonymous vs authenticated*; a spoofed UA is still anonymous,
+   which is why the exception is narrow rather than a reversal.
 
 This is a policy the reviewer must scrutinize; it is the security-sensitive part
 of the change. It is *not* a redesign of a subsystem, so it doesn't trip the

--- a/docs/design/web_fetch.md
+++ b/docs/design/web_fetch.md
@@ -6,6 +6,12 @@ go-ahead on the flagged decisions at the end.
 Grounded against the tree at the time of writing; file:line citations are load-
 bearing, not decoration.
 
+**Companion document:** `web_fetch_robustness.md` extends this one with the
+retry policy, the anti-bot/challenge taxonomy, the blocked-retry request profile
+and the model-facing diagnostics for a refused or stalled fetch. Read it
+alongside §6 (pipeline), §7 (safety) and §9 (config) — it refines those three
+and contradicts none of them.
+
 ---
 
 ## 1. The problem, as the code actually has it

--- a/docs/design/web_fetch_robustness.md
+++ b/docs/design/web_fetch_robustness.md
@@ -1,7 +1,35 @@
 # Design: `web_fetch` robustness — transient failures, bot-blocks, and honest diagnostics
 
-Status: proposal (architect). Do not implement from this without the manager's
-go-ahead on the decisions in §12.
+Status: **implemented**. The manager ratified §12 as: `blocked_retry` default on
+(1), the 0.6 stall fraction ships fixed with no knob (2), no card hint row and
+no UI parity PR (3), the empty-`str(exc)` fix folded in (4), ship (5).
+
+Three things the implementation had to settle that this document did not, each
+recorded here rather than only in the PR so the next reader of the design sees
+the shipped contract:
+
+1. **Enrichment probes get a bounded SLICE of the deadline** (25 %), not the
+   whole budget. §6.2 made the probes share the call's deadline, which is
+   correct, but §3.3 did not say what stops a stalling `.md` probe from spending
+   the budget the real fetch — and its escalation — needs. Measured during
+   implementation: a 3 s fetch of a silent origin spent 1.8 s on the probe and
+   had nothing left to escalate with. `_ENRICHMENT_BUDGET_FRACTION` is the fix.
+2. **The `blocked` lead drops the "(The body below is the error response…)"
+   note.** §5.2 replaces the challenge body with our own statement, so that note
+   would describe the wrong thing. Other non-2xx classes keep it unchanged.
+3. **§6.6 case 5's literal assertion is wrong and was implemented as its
+   intent.** It asks that an unmatched 403's `describe()` "does not contain the
+   word 'bot'", but §2.2's own prescribed wording for that case is "No anti-bot
+   vendor signature was found … rather than bot protection" — which contains the
+   word precisely in order to *deny* the claim. The test asserts the claim is
+   absent (`"blocked by"` never appears, the denial does), which is the property
+   §2.2 is actually about.
+
+A fourth, smaller one: `describe()` pre-wraps its prose to the TUI card's row
+width. The card paints one body row per LINE and clips the overflow with an
+ellipsis (pre-existing behaviour, visible on the `Fetched:` row in both the
+before and after frames), so an unwrapped 150-column sentence would have lost
+the name of the escalation tool off the right edge.
 
 Companion to `docs/design/web_fetch.md`, which remains the contract for the
 pipeline, SSRF policy, caching and card. This document extends it; it does not

--- a/docs/design/web_fetch_robustness.md
+++ b/docs/design/web_fetch_robustness.md
@@ -1,0 +1,911 @@
+# Design: `web_fetch` robustness — transient failures, bot-blocks, and honest diagnostics
+
+Status: proposal (architect). Do not implement from this without the manager's
+go-ahead on the decisions in §12.
+
+Companion to `docs/design/web_fetch.md`, which remains the contract for the
+pipeline, SSRF policy, caching and card. This document extends it; it does not
+replace it. Where the two could be read as disagreeing, §11 says which wins.
+
+Grounded against the tree at `origin/main` (`c938fead6`). Every `file:line`
+citation and every measurement below was taken in this worktree
+(`~/workspace/repos/lo-webfetch-robust`, its own `.venv`) on 2026-09-12. Numbers
+are measured, not estimated; where a number is a judgement call it says so.
+
+---
+
+## 1. The problem, as the code actually has it
+
+The operator asked a shopping question in the desktop app. Every `web_fetch` in
+that turn came back `is_error=True`, the model-facing body was the origin's
+Akamai block page presented under a warning lead, the `browser` escalation was
+unavailable (extension not paired), and the agent then spent ~40 tool calls
+probing URL shapes with no working next step.
+
+The UI rendered that faithfully — each red cross matches an `is_error=True`
+result in the transcript. The defect is in the harness tool, and it is three
+defects, not one.
+
+### 1.1 There are no retries anywhere in the fetch path
+
+`WebFetchService._follow` (`local_operator/web_fetch/service.py:510-551`) makes
+exactly one `_stream_once` call per hop, and `_stream_once`
+(`service.py:597-637`) converts any `httpx.TimeoutException` or `httpx.HTTPError`
+into a terminal `FetchError`. A read timeout, a connection reset, a mid-body EOF,
+a 500, a 502, a 503 or a 429 therefore fails the whole call on the first try.
+`run_fetch` turns that into an error result (`tool.py:442-443`).
+
+This is not theoretical on real hosts. Measured in this worktree, with the
+shipped UA and the shipped 20 s timeout:
+
+```
+https://www.canadiantire.ca/en/pdp/certified-6-outlet-...-0527211p.html
+  -> httpx.ReadTimeout after 20.21s   (and after 5.02s with timeout=5)
+```
+
+The same host answers a browser-shaped request in **0.07-0.25 s with a 403**.
+So the stall is not a slow origin: it is the anti-bot layer black-holing a
+request it has already decided to refuse. Today that costs the agent the full
+timeout budget and yields no information.
+
+### 1.2 There is exactly one request identity, and it is a blocked one on real sites
+
+`USER_AGENT` (`service.py:65`) is the only request header the engine sets
+(`service.py:539`). No `Accept`, no `Accept-Language`, no `Sec-Fetch-*`. Measured
+flip on a site the operator plausibly reads, 3/3 reproductions:
+
+```
+https://medium.com/   lop UA      -> 403, 5,507 bytes, cf-mitigated: challenge,
+                                     body <title>Just a moment...</title>
+https://medium.com/   browser-shaped profile
+                                  -> 200, ~53,067 bytes, the real page
+```
+
+Confirmed to still hold **through the SSRF-pinned path** (`_pin_request` to
+`162.159.153.4`, `Host`/SNI preserved): 403 with the lop profile, 200 with the
+browser-shaped one. So the fix rides the existing guarded path; it does not need
+a second client.
+
+Controls that do **not** flip, and which are the reason this must not become
+site-specific logic: `walmart.ca`, `reddit.com`, `nytimes.com`, `amazon.ca`,
+`instagram.com`, `tiktok.com`, `zillow.com` all return 200 with the plain lop UA.
+
+### 1.3 A blocked response is presented as content, and a stalled one as nothing
+
+`_header_line` (`tool.py:156-181`) leads a non-2xx with an unmissable warning and
+then prints the rendered body. For a block page that body is the challenge
+markup — 5.5 KB of Cloudflare interstitial, or Akamai's "Access Denied /
+Reference #18.…". Measured through the real CLI:
+
+```
+$ .venv/bin/python -m local_operator.cli fetch test "https://medium.com/"
+error: ⚠ HTTP 403 Forbidden — this is an error/block page, not page content. https://medium.com/
+markdownify · text/html; charset=utf-8 · cache miss
+(The body below is the error response, not the requested page.)
+
+Just a moment...
+```
+
+The agent is told *that* it failed and shown a body it cannot use. It is not told
+**why** (bot protection, not a missing page, not an auth wall), **whether
+retrying could help**, or **what to do next**. Nothing in the result names the
+escalation, so the agent invents one — which is exactly the ~40-call flail.
+
+The stalled case is worse. Measured through the real CLI:
+
+```
+$ .venv/bin/python -m local_operator.cli fetch test "https://www.canadiantire.ca/...0527211p.html"
+   (20.5 s later)
+error: timed out fetching 'https://www.canadiantire.ca/...0527211p.html': 
+```
+
+`httpx.ReadTimeout.__str__()` is the **empty string**, so `service.py:634`'s
+f-string produces a message that ends in `': '` with nothing after it. The reader
+cannot tell a connect failure from a read stall from a slow page, and the message
+looks like a truncation bug.
+
+### 1.4 What the code already does right, and must keep doing
+
+- SSRF: `validate_public_url` runs per hop (`service.py:530-532`) and the socket
+  is pinned to the vetted IP with `Host`/SNI preserved (`_pin_request`,
+  `service.py:185-214`). TLS verification is never disabled.
+- Only 2xx is cached (`tool.py:478-479`), so a transient outage is never replayed
+  for the TTL.
+- `web_fetch` and `read <url>` share one engine (`run_fetch`, `tool.py:334`).
+- Requests are GET-only — `client.stream("GET", …)` at `service.py:618-620` is the
+  single request site in the package (verified by grep: no `.post`, `.put`, or
+  generic `.request` call exists in `local_operator/web_fetch/`).
+
+Every change below preserves all four.
+
+---
+
+## 2. Failure taxonomy and detectors
+
+One classifier, `classify_failure`, living in a new
+`local_operator/web_fetch/failure.py`. It returns a small frozen dataclass
+(`FetchFailure(kind, retryable, detail, marker, vendor)`) and is the single place
+any of these strings live, so the engine, the tool text and the tests cannot
+drift.
+
+| Class | Detector | Retry? |
+|---|---|---|
+| `transport` | `httpx.ConnectError`, `httpx.ConnectTimeout`, `httpx.ReadError`, `httpx.WriteError`, `httpx.RemoteProtocolError`, `httpx.PoolTimeout` | yes |
+| `stall` | `httpx.ReadTimeout` / `httpx.WriteTimeout` (headers or body never arrived) | yes, once, on a shortened budget (§3.3) |
+| `server` | status in {500, 502, 503, 504} | yes |
+| `ratelimit` | status 429 | yes, honouring `Retry-After` (§3.4) |
+| `blocked` | status in {403, 401-with-anti-bot-marker, 503-with-challenge-marker} **and** a marker below | not a retry — a **profile escalation**, once (§4) |
+| `client` | any other 4xx (404, 410, 451, …) | no |
+| `ok` | 2xx/3xx | n/a |
+
+### 2.1 The anti-bot markers, and why these are the stable ones
+
+Matched case-insensitively against **response headers first, body second**.
+Headers are the stable signal; body strings are the fallback for vendors that do
+not brand their headers. All of the following were captured live in this
+worktree today, not copied from memory:
+
+**Cloudflare** — header `cf-mitigated: challenge` (captured verbatim on
+`https://medium.com/`; Cloudflare sets it specifically to let non-browser clients
+distinguish a challenge from a real 403, which is why it is the most stable
+marker we have). Body fallbacks: `<title>Just a moment...</title>`,
+`Attention Required! | Cloudflare`, `challenges.cloudflare.com` in a CSP or
+script src. Secondary corroboration: `server: cloudflare` plus `cf-ray`.
+
+**Akamai** — header `server: AkamaiGHost` (captured verbatim on
+`shoppersdrugmart.ca` and `canadiantire.ca`). Body fallbacks: the
+`<TITLE>Access Denied</TITLE>` / `<H1>Access Denied</H1>` pair, the literal
+`errors.edgesuite.net`, and `Reference #` followed by a dotted id. The
+`Reference #` token is the piece a human support agent asks for, which is why it
+is worth extracting (§5).
+
+**DataDome** — headers `x-datadome`, `x-dd-b`, or a `datadome=` cookie in
+`set-cookie`; body `captcha-delivery.com`.
+
+**PerimeterX / HUMAN** — body `_pxhd` / `px-captcha` / `perimeterx.net`;
+`set-cookie` names beginning `_px`.
+
+**Generic** — `server: Imperva`/`X-Iinfo` (Imperva/Incapsula), and a 403 whose
+body is under 2 KB and contains both `access denied` and no `<body>` text beyond
+a title, which catches the long tail of WAF stock pages.
+
+Markers are matched against the **first 8 KB** of the decoded body only. A
+challenge page is always small; scanning a 5 MB body for substrings is wasted
+work, and a marker appearing 3 MB into a real article is a false positive we do
+not want.
+
+### 2.2 What an *unmatched* 403 does — and this is the honesty-critical part
+
+An unmatched 403 is treated as `blocked` **for the retry decision** (it earns the
+one profile-escalation attempt, because a plain-403 WAF with no branding is
+common and the escalation is cheap) but is **never labelled with a vendor**. Its
+model-facing text says:
+
+> `403 Forbidden — the origin refused this request. No anti-bot vendor signature
+> was found, so this may be an access restriction rather than bot protection.`
+
+versus the matched case:
+
+> `403 Forbidden — blocked by Cloudflare bot protection (challenge).`
+
+Claiming "bot protection" on a 403 that is really "you are not a subscriber"
+would send the agent to `browser` when it should ask the user for credentials.
+The distinction costs one boolean and buys the agent a correct next step.
+
+### 2.3 The blackhole case
+
+`stall` exists as a separate class from `transport` because its remedy is
+different. Measured on `canadiantire.ca`: the lop profile never gets headers back
+(ReadTimeout at 20 s), while a browser-shaped profile gets a 403 in 0.07-0.25 s.
+A stall is therefore frequently a *silent* block, and the right response is the
+same profile escalation §4 describes — on a **shortened** budget, because the
+whole point is not to spend another 20 s learning nothing.
+
+---
+
+## 3. Retry policy — exact numbers
+
+### 3.1 Attempts
+
+**Maximum 3 network attempts per hop, and at most one profile escalation per
+fetch.** Concretely, per redirect hop:
+
+- attempt 1: default profile
+- attempt 2: default profile, after backoff — only for `transport`, `server`,
+  `ratelimit`
+- attempt 3: default profile, after backoff — same classes only
+
+and, orthogonally, **one** browser-shaped attempt (§4) when the *final* outcome
+of the hop is `blocked` or `stall`. A fetch therefore issues at most 4 requests
+to one hop, and a `blocked` result costs exactly 2.
+
+Why 3 and not 5: the value of a retry is concentrated in the first one. A single
+retry covers the overwhelming majority of one-off resets and 502s from a
+rolling deploy; a third covers a short 503 window; a fourth is mostly waiting.
+Against that, this tool runs inside a live turn the user is watching, and every
+attempt is latency the user sees. 3 is the point where added coverage stops
+paying for added wall-clock.
+
+### 3.2 Backoff shape and jitter
+
+`delay(n) = min(BASE * 2**(n-1), CAP) * (1 + random.uniform(-J, +J))` with
+`BASE = 0.5 s`, `CAP = 4.0 s`, `J = 0.25` (full ±25 % jitter, same family as the
+TUI's sidebar backoff at `tui/app.py:1618`).
+
+So: retry 1 waits 0.5 s ± 0.125, retry 2 waits 1.0 s ± 0.25. Total added *sleep*
+in the worst non-rate-limited case is ~1.9 s.
+
+Jitter exists because a turn can issue several `web_fetch` calls in parallel (the
+tool description explicitly encourages it) and they will frequently hit the same
+origin. Un-jittered backoff synchronises those retries into a burst, which is
+precisely what a struggling origin does not need.
+
+### 3.3 Staying inside the per-call `timeout_seconds` budget
+
+**This is a hard invariant: a `web_fetch` with `timeout_seconds=T` must not take
+materially longer than T, retries or not.** Today `timeout` is handed to the
+client as the per-request timeout (`service.py:538`), so a retried fetch would
+multiply it. It becomes a **deadline for the whole call** instead:
+
+- `_fetch_owned` computes `deadline = monotonic() + timeout` once.
+- Each attempt gets `remaining = deadline - monotonic()`, and its httpx timeout
+  is `httpx.Timeout(connect=min(5.0, remaining), read=remaining,
+  write=remaining, pool=min(5.0, remaining))`. (Verified: `client.stream()`
+  accepts a per-request `timeout`, and `httpx.Timeout` takes granular
+  connect/read/write/pool values.)
+- Before sleeping a backoff, check it fits: if `delay > remaining - 0.25 s`, stop
+  retrying and return the failure now rather than sleeping into the deadline.
+- **Attempt budgeting for the stall class:** attempt 1 of a hop is capped at
+  `min(remaining, 0.6 * timeout)`. That is what converts the canadiantire case
+  from "20 s then nothing" into "12 s then a fast browser-shaped probe that
+  returns a real 403 in ~0.25 s". The 0.6 split is a judgement call; the
+  evidence that would tune it is the distribution of time-to-first-byte on
+  genuinely slow-but-working origins, which we do not have. 0.6 is chosen because
+  a page that has sent no headers in 12 s is overwhelmingly more likely to be
+  black-holed than slow. It applies **only when there is a fallback attempt left
+  to spend** — the last attempt always gets the full remaining budget, so a
+  genuinely slow origin is never penalised on its final try.
+
+Worst-case added latency versus today, stated plainly:
+
+| Scenario | Today | After | Delta |
+|---|---|---|---|
+| 200 first try | t | t | **0** (same one request) |
+| 404 / other non-retryable 4xx | t | t | **0** |
+| block detected (medium.com) | 0.06 s | ~0.3 s | +~0.25 s (one extra request) |
+| stall (canadiantire, T=20) | 20.2 s | ~12.3 s | **−8 s** |
+| persistent 500 | t | t + ~1.9 s sleep + 2 requests | bounded by T |
+| any case, hard ceiling | T | T | **0** — the deadline is the bound |
+
+The last row is the one that matters: the deadline never moves, so no
+configuration of retries can make a call exceed its stated timeout.
+
+### 3.4 `Retry-After`
+
+Honoured on 429 and on 503 (both define it). Parsed as delta-seconds; the
+HTTP-date form is also parsed (`email.utils.parsedate_to_datetime`) because CDNs
+do emit it. Then:
+
+- If `retry_after <= min(remaining - 0.25, 10.0)`: sleep exactly that (plus
+  jitter), then retry. Honouring the origin's own number is the polite and
+  effective behaviour.
+- If it is larger: **do not sleep**. Return the failure immediately, with the
+  value surfaced in the text (`the origin asked us to wait 120s`) and in
+  `details`. Blocking a live turn for two minutes to obey a header is worse for
+  the user than telling the agent to come back later, and the agent can act on
+  the number.
+
+A `Retry-After` of 0 or an unparseable value falls back to the normal backoff.
+
+### 3.5 Interruptibility
+
+Unchanged in shape and must stay so. `_fetch_or_abort` (`tool.py:291-317`) races
+the whole `service.fetch()` coroutine against the abort signal, so it already
+covers everything inside it. The backoff sleeps are plain `await
+asyncio.sleep(...)` inside that coroutine, so a cancellation lands on them
+immediately and the `finally` block still reaps the task. **No change to
+`_fetch_or_abort`**, and a test asserts that an abort during a backoff sleep
+returns promptly rather than after the sleep.
+
+### 3.6 What the user-visible duration does
+
+The card's duration is wall-clock for the tool call, so a retried call honestly
+shows a longer duration — which is correct and needs no change. What changes is
+that the *reason* is legible: the attempt count rides in the header meta line
+(§5) and in `details["attempts"]`, so a 2.4 s fetch that used to look like a slow
+network now reads `… · 3 attempts`.
+
+### 3.7 Only GET is retried, and that is trivially true here
+
+Confirmed by inspection: `client.stream("GET", …)` at `service.py:618` is the
+only request the package issues; there is no POST/PUT path to guard. Retrying a
+GET is safe by HTTP semantics (idempotent), and there is no code path through
+which a caller could make this tool issue a non-idempotent request. If a future
+change adds one, the retry predicate must gate on method — a comment at the retry
+site will say so.
+
+---
+
+## 4. The blocked-retry profile
+
+### 4.1 The default identity does not change
+
+I agree with the manager's lean and state the reason affirmatively: **the honest
+`local-operator/web_fetch` UA remains the default on every first attempt.**
+
+- It is truthful, and truthfulness is the norm for an automated client. A site
+  that wants to allow or deny us should be able to.
+- The controls in §1.2 show it is not generally blocked — seven major sites
+  serve it fine. Changing the default would be paying a lie on ~100 % of
+  requests to fix a minority.
+- `robots.txt`-conscious operators and site owners can identify us today; a
+  Chrome-by-default client removes that.
+
+The browser-shaped profile is therefore **the price of a refusal, not the
+default posture** — paid only after the origin has already refused the honest
+request.
+
+### 4.2 Exact headers on the escalated attempt
+
+Sent as a per-request header override on the same pinned, validated request
+(verified: per-request headers merge over client headers and override them
+key-by-key):
+
+```
+User-Agent:      Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+                 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36
+Accept:          text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,
+                 image/webp,*/*;q=0.8
+Accept-Language: en-US,en;q=0.9
+Sec-Fetch-Site:  none
+Sec-Fetch-Mode:  navigate
+Sec-Fetch-User:  ?1
+Sec-Fetch-Dest:  document
+Upgrade-Insecure-Requests: 1
+```
+
+This is exactly the set measured to flip medium.com. Deliberately **not**
+included: `sec-ch-ua*` client hints (they are Chrome-version-coupled and were
+measured not to matter), cookies (the no-cookie policy in
+`web_search/io.py:25-30` is a deliberate boundary and stays), and any
+`Referer` (inventing a referrer is a fabrication, not a profile).
+
+The `Host` header and `sni_hostname` extension from `_pin_request` are merged
+**last** so the escalated attempt cannot accidentally unpin itself.
+
+The UA string is a module constant next to `USER_AGENT` with a comment saying it
+is a *compatibility profile*, when it is sent, and that it must not be used
+anywhere else.
+
+### 4.3 Conditions, count, and gating
+
+- Fires when the hop's outcome classifies as `blocked` **or** `stall`.
+- Fires **once per fetch**, not once per hop — a redirect chain cannot multiply
+  it — and never on an enrichment probe (`_try_enrichment` keeps failing silently;
+  an enrichment probe is an optimisation and must not spend a second request).
+- Config-gated: `web_fetch.blocked_retry: true` by default. Default on because
+  the measured win is real and the cost is one request on an already-failed
+  fetch; the switch exists for an operator who wants the client to be honest even
+  in the face of a refusal, and for a clean A/B during rollout.
+- The escalated attempt gets the same deadline arithmetic as any other.
+- If the escalated attempt also fails, the **escalated** outcome is what is
+  reported (it is the more informative one: canadiantire goes from "timed out"
+  to "403 from Akamai"), with `details` recording both.
+
+---
+
+## 5. The model-facing result for a confirmed block
+
+### 5.1 `is_error` / `ok` stay as they are
+
+A block remains `is_error=True`, `ok=False`, `http_error=True`. It is a failure
+to retrieve the page; nothing about better diagnostics changes that, and the card
+and the row model already branch correctly on it (`tool_card.py:782-793`,
+`tool-row-model.ts`). **No enum or shape change** — this is what keeps the second
+repo out of the blast radius (§8.2).
+
+### 5.2 The challenge body is not inlined — decision, with the reasoning
+
+**Make the call: do not inline the challenge body. Replace it with a one-line
+origin statement plus the extracted reference id.**
+
+The body is unusable by construction — it is markup whose entire purpose is to be
+executed by a browser. Inlining it costs ~5.5 KB of context (medium.com,
+measured) to tell the agent nothing, and the current presentation actively
+invites the misread that this is page content. The counter-argument — that a
+block page occasionally carries a human-readable reason — is real for *other*
+non-2xx classes, which is why this narrowing applies **only to the `blocked`
+class**. A 404's body, a 451's body and a 500's body still render exactly as
+today: some of them genuinely explain themselves.
+
+The reference id is the one durable piece of a block page (`Reference
+#18.47182117.…` is what a human would quote to the site's support), so it is
+extracted by regex and carried on a single line. Cloudflare's `cf-ray` is
+carried the same way.
+
+New preview for a confirmed block:
+
+```
+⚠ HTTP 403 Forbidden — blocked by Akamai bot protection, not page content.
+https://www.shoppersdrugmart.ca/?lang=en&query=power+bar
+markdownify · text/html · cache miss · 2 attempts (default, browser-profile)
+
+The origin's bot protection refused this request. A browser-shaped retry was
+also refused, so no headless fetch of this URL will succeed.
+Origin reference: 18.47182117.1789248907.62349a41
+Next step: use the `browser` tool on this URL — it drives the real browser
+(a write-tier, approval-gated action), which is the only path that clears an
+interactive challenge.
+```
+
+And for the stall-turned-block (canadiantire):
+
+```
+⚠ HTTP 403 Forbidden — blocked by Akamai bot protection, not page content.
+https://www.canadiantire.ca/en/pdp/…-0527211p.html
+markdownify · text/html · cache miss · 2 attempts (default timed out after 12.0s,
+browser-profile)
+…
+```
+
+And when nothing is retrievable at all (both attempts stalled), the terminal text
+names the class and the count rather than trailing off:
+
+```
+read timed out after 20.0s (2 attempts: default, browser-profile) —
+the origin accepted the connection but never sent a response.
+https://…
+```
+
+That last line is the direct fix for the empty-`str(exc)` defect in §1.3: the
+message is built from the **classified** failure, never from `str(exc)`, so it
+can never be empty. `str(exc)` is appended only when it is non-empty.
+
+### 5.3 `details` keys — additive only
+
+Added to the existing `result_like` mapping (`tool.py:452-464`). Every key is
+new; no existing key changes type, name or meaning, so `_fetch_result_output`
+(`tool_card.py:744`), the UI row model, and any stored transcript keep working
+untouched:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `attempts` | `int` | total network attempts for this fetch (1 when nothing retried) |
+| `failure_kind` | `str` | one of `transport`/`stall`/`server`/`ratelimit`/`blocked`/`client`, absent on success |
+| `block_vendor` | `str \| None` | `cloudflare`/`akamai`/`datadome`/`perimeterx`/`imperva`, or absent when unmatched (§2.2) |
+| `block_reference` | `str \| None` | the extracted origin reference / `cf-ray` |
+| `profile` | `str` | `default` or `browser` — which profile produced the reported outcome |
+| `retry_after_s` | `float \| None` | the honoured or reported `Retry-After` |
+| `suggested_tool` | `str \| None` | `"browser"` when the block is confirmed unretrievable |
+
+A cache hit continues to carry none of these except `attempts: 0`, which is
+truthful (no network attempt was made).
+
+### 5.4 The card: no structural change, and why that is the right call
+
+`_fetch_result_output` builds its rows from `details`
+(`tool_card.py:744-809`). Two things happen with **no code change at all**
+because of how the card already works:
+
+1. The error row keeps rendering from `http_error` + `status`.
+2. The new body text flows through `_strip_fetch_header` correctly — verified by
+   running the real function against the proposed new header block in this
+   worktree: the lead and meta lines are stripped and the new explanatory lines
+   survive, and the existing 404 shape still strips identically.
+
+I therefore recommend **not** adding a card hint row in this change. The reasons:
+
+- The information the agent needs is model-facing text; the human reading the
+  card already sees `⚠ HTTP 403 Forbidden — error/block page`, which is accurate.
+- A new row means a TUI change, a designer round, **and** a parity obligation in
+  `local-operator-ui` (`docs/evidence/tui-parity/tool-row-spec.md:282` pins the
+  fetch header rows in order). That is a second repo's work for a cosmetic gain.
+- The card body already prints the new explanation text under the structured
+  rows, so the "next step: browser" sentence **is visible to the user** — it
+  arrives as body, not as a pinned row.
+
+Because the card's *painted output changes* (the body text differs even though no
+row logic does), a rendered before/after frame is still required by the
+repository's visual-validation rule — see §7. This is a "capture the frame, no
+designer round" change: there is no layout, spacing, colour or row-structure
+delta to review. If the reviewer disagrees and wants the hint pinned as a row,
+that flips it into a user-visible change with a designer round and a parity PR;
+§12 lists it as a decision.
+
+---
+
+## 6. Files, functions, and tests
+
+### 6.1 New: `local_operator/web_fetch/failure.py` (~140 lines)
+
+- `FetchFailure` frozen dataclass: `kind`, `retryable`, `vendor`, `reference`,
+  `detail`, `status`, `retry_after_s`.
+- `classify_exception(exc) -> FetchFailure` — the httpx exception taxonomy.
+- `classify_response(status, headers, body_head) -> FetchFailure | None` — the
+  status + marker taxonomy; `None` for 2xx/3xx.
+- `BLOCK_MARKERS` — the header and body marker tables from §2.1, each entry
+  carrying its vendor label, with a comment recording the live capture that
+  justifies it (`cf-mitigated: challenge` on medium.com; `server: AkamaiGHost`
+  on shoppersdrugmart.ca).
+- `extract_reference(body_head, headers) -> str | None`.
+- `describe(failure, attempts, profiles) -> str` — the one place the
+  model-facing sentences are composed, so tool text and card text cannot drift.
+
+A new module rather than more mass in `service.py` (already 777 lines): this is a
+pure, table-driven, easily-tested classifier with no I/O, and keeping it pure is
+what makes the marker tests cheap.
+
+### 6.2 `local_operator/web_fetch/service.py`
+
+- `USER_AGENT` (`:65`) unchanged. Add `BROWSER_PROFILE_HEADERS` beside it with the
+  §4.2 set and the "only on a refusal" comment.
+- Add `_RETRY_BASE_S`, `_RETRY_CAP_S`, `_RETRY_JITTER`, `_STALL_FIRST_ATTEMPT_
+  FRACTION` module constants, each commented with the measurement in §3.
+- `_stream_once` (`:597-637`): accept `extra_headers` and a per-request
+  `httpx.Timeout`; on exception, raise a `FetchError` **carrying** the
+  `FetchFailure` (add a `failure` attribute to `FetchError` — additive, existing
+  `str(error)` call sites at `tool.py:377,443` keep working). Also return the
+  first 8 KB of body separately for marker scanning, avoiding a second decode.
+- `_follow` (`:510-551`): becomes the retry loop. Per hop, call a new
+  `_attempt_with_retries(...)` that owns attempts, classification, backoff and
+  the deadline check. The `validate_public_url` + `_pin_request` calls stay
+  exactly where they are and run **per attempt**, not per hop — so a retry
+  re-validates, and a host that becomes private between attempts is refused.
+  **This is the single most important line of the change** and gets its own test.
+- `_fetch_owned` (`:492-508`): computes the deadline, owns the one-per-fetch
+  escalation budget, passes both down.
+- `_render` (`:639-693`): for a `blocked` classification, substitute the
+  one-line statement for the challenge body (§5.2) and set the new fields.
+- `coerce_fetch_settings` (`:87-106`): clamp the two new numeric knobs.
+
+### 6.3 `local_operator/web_fetch/models.py`
+
+Additive on `WebFetchSettings` and `DEFAULT_WEB_FETCH_CONFIG` (`:68`):
+
+```python
+max_attempts: int = 3          # per hop; clamped 1..5 (1 = today's behaviour)
+blocked_retry: bool = True     # one browser-shaped attempt after a refusal
+```
+
+Plus the new optional `FetchResult` fields (`attempts`, `failure_kind`,
+`block_vendor`, `block_reference`, `profile`, `retry_after_s`), all defaulted so
+every existing construction site stays valid.
+
+**Migration safety — checked, and the answer is "nothing to do."**
+`config_migrations.py` has no `web_fetch` handling at all; the only mention is a
+comment at `:160` noting that the cleanup migration's rewrite fills in absent
+top-level defaults. Settings load through `coerce_fetch_settings`, which merges
+`DEFAULT_WEB_FETCH_CONFIG` under the user's mapping (`service.py:95-97`), so an
+existing `config.yml` without the new keys gets the defaults. Verified
+empirically that `WebFetchSettings` is `extra="ignore"`, so a config written by a
+*newer* lop and read by an older one is also safe. **No migration is needed and
+none should be written** — adding one would be a migration that does nothing.
+
+### 6.4 `local_operator/web_fetch/tool.py`
+
+- `_header_line` (`:156-181`): append ` · N attempts (…)` to the meta line when
+  `attempts > 1`; the block class gets the §5.2 lead. The card's strip regexes
+  (`_FETCH_HEADER_META_RE`, `tool_card.py:841`) match structurally on
+  `… · … cache ` and were **verified in this worktree** to still strip the new
+  meta line.
+- `run_fetch` (`:452-464`): populate the new `details` keys.
+- `:478` cacheability: unchanged — `http_ok` still gates it, so no retried
+  failure is ever cached. Add a test, not a code change.
+- `_DESCRIPTION` (`:56-68`): one added clause telling the model that a confirmed
+  block names `browser` as the next step. This is the cheapest possible
+  improvement to the flail behaviour.
+
+### 6.5 `local_operator/web_fetch/cli.py`
+
+`fetch status` gains an `attempts`/`blocked-retry` line; `fetch set` gains
+`attempts` and `blocked-retry` keys. Small, mirrors the existing setters.
+
+### 6.6 Unit tests to add (`tests/unit/web_fetch/`)
+
+**`test_failure.py` (new)** — pure classifier:
+1. `cf-mitigated: challenge` header → `blocked`, vendor `cloudflare`.
+2. `Just a moment...` body with no branded header → `blocked`, `cloudflare`.
+3. `server: AkamaiGHost` + `Access Denied` body → `blocked`, `akamai`, and
+   `extract_reference` returns `18.47182117.1789248907.62349a41`.
+4. `x-datadome` header → `blocked`, `datadome`.
+5. **Unmatched 403** → `blocked`, `vendor is None`, and `describe()` does **not**
+   contain the word "bot" (§2.2 — the anti-mislabelling assertion).
+6. 404 → `client`, `retryable is False`.
+7. 500/502/503/504 → `server`, retryable.
+8. 429 with `Retry-After: 7` → `ratelimit`, `retry_after_s == 7.0`; and with an
+   HTTP-date value; and with garbage → `None`.
+9. `httpx.ReadTimeout` → `stall`; `ConnectError` → `transport`.
+10. A 5 MB 200 body containing `access denied` at offset 3 MB → **not** blocked
+    (the 8 KB scan window).
+
+**`test_service.py` (extend)**:
+11. 500 then 200 (MockTransport) → one `FetchResult`, `attempts == 2`, content
+    from the 200.
+12. Persistent 500 → error after exactly `max_attempts` requests; the transport
+    call count is asserted.
+13. 404 → exactly **one** request (non-retryable classes are not retried).
+14. 429 with `Retry-After: 1` → honoured, slept once (clock monkeypatched).
+15. 429 with `Retry-After: 900` → **not** slept, returns immediately,
+    `retry_after_s == 900`.
+16. **SSRF across retries**: a host that resolves public on attempt 1 and
+    `127.0.0.1` on attempt 2 → the retry is refused, not followed. The
+    resolver mock asserts `validate_public_url` was called once per attempt.
+17. **Pinning across retries**: every attempt, including the browser-profile one,
+    targets the vetted IP with the original `Host` and `sni_hostname`.
+18. **Blocked-retry**: 403+challenge on the default profile, 200 on a request
+    carrying the Chrome UA → success, `attempts == 2`, `profile == "browser"`.
+19. **Blocked-retry fires once**: 403 on both → exactly 2 requests, no third.
+20. `blocked_retry: false` → exactly 1 request on a 403.
+21. **Deadline**: `timeout_seconds=2` against a transport that always 503s →
+    total elapsed < 2.5 s and fewer than `max_attempts` requests when the
+    deadline binds (asserted structurally on a fake clock, per AGENTS.md
+    "prefer a structural invariant to a numeric one").
+22. **Stall shortening**: a transport that never responds → attempt 1 is given
+    ≤ 0.6·T, and the escalated attempt happens.
+23. **Empty-`str(exc)` regression**: a `ReadTimeout("")` produces a message that
+    names the class and the attempt count and does **not** end in `': '`.
+24. Enrichment probes never trigger the escalation (a blocked `.md` twin costs
+    exactly one request).
+25. `max_attempts: 1` reproduces today's exact behaviour byte-for-byte on a 200.
+
+**`test_tool.py` (extend)**:
+26. **No-cache-on-non-2xx across retries**: 500,500,500 → nothing written to the
+    cache dir; then 200 → cached. Asserted on the cache directory, not a mock.
+27. A retried *success* IS cached (the 500→200 case writes an entry).
+28. `details` carries `attempts`, `failure_kind`, `block_vendor`,
+    `suggested_tool` on a block, and existing keys are unchanged (an explicit
+    "old keys still present with old types" assertion).
+29. **Abort during backoff** returns promptly (structural: the abort signal is
+    set during the sleep and the result is the abort result).
+30. A blocked result's preview does **not** contain `Just a moment` /
+    `<html` — i.e. the challenge body is genuinely gone — but **does** contain
+    the reference id and the `browser` next step.
+31. A 404's body IS still inlined (the §5.2 narrowing is only for `blocked`).
+
+**`test_efficiency.py` (extend)**:
+32. The blocked preview is < 400 chars where today's medium.com preview is
+    ~5.5 KB of markup — the context-cost regression guard.
+
+Per AGENTS.md "prove the test can still fail", the retry-count and
+escalation tests get a documented mutation check in the PR evidence (set
+`max_attempts=1`, watch 11/12/18 fail).
+
+---
+
+## 7. Live evidence plan
+
+All of it runs under `env HOME=/tmp/wf-evidence
+LOCAL_OPERATOR_CONFIG_DIR=/tmp/wf-evidence/.local-operator` per the AGENTS.md
+isolation rule (config dir alone is not enough), against the **worktree's own
+venv**, and both a before (on `origin/main` in a throwaway checkout) and an after
+capture go on the PR.
+
+1. **medium.com: 403 → 200.**
+   `.venv/bin/python -m local_operator.cli fetch test "https://medium.com/"`
+   Before (captured today): `error: ⚠ HTTP 403 … / Just a moment...`.
+   Expected after: `[200] https://medium.com/ … · 2 attempts (default,
+   browser-profile)` and real article text in the preview.
+2. **The stalled host becomes a bounded, informative result.**
+   Same command against the canadiantire PDP URL.
+   Before (captured today): 20.5 s, `error: timed out fetching '…': ` (empty
+   reason). Expected after: ~12.3 s, `⚠ HTTP 403 Forbidden — blocked by Akamai
+   bot protection` with the reference id and the `browser` next step, and the
+   elapsed time printed alongside.
+3. **Local server that 500s then 200s.** A `http.server.ThreadingHTTPServer`
+   subprocess on a free port, `allow_private: true` for that run only; first GET
+   500, second 200. Expected: one success, `attempts: 2`, server access log
+   showing exactly 2 requests, elapsed ≈ 0.5 s + jitter.
+4. **Persistent 5xx proves the count and the bound.** Same server, always 503.
+   Expected: exactly 3 requests in the access log, total elapsed ≈ 1.9 s + 3×RTT
+   and comfortably under `timeout_seconds`; error text naming
+   `503 Service Unavailable (3 attempts)`.
+5. **Deadline holds.** Same server with a 30 s sleep, `--timeout-seconds 3`.
+   Expected: returns in < 3.5 s, not 3 × 3 s.
+6. **`Retry-After` honoured and refused.** Local server returning 429 with
+   `Retry-After: 1` (expect one ~1 s sleep then success) and with
+   `Retry-After: 600` (expect immediate return, no sleep, the number in the text).
+7. **The shopper's URL proves the new diagnostic, honestly.** The original four
+   URLs from the incident. Expected: still failures — this design does not claim
+   to retrieve them — but each now says Akamai, carries the reference id, and
+   names `browser`. The PR states plainly that `shoppersdrugmart.ca/` and
+   `/?<query>` return 403 to every client tested (curl with a full Chrome header
+   set, httpx with HTTP/2 and a cookie jar, all profiles), while
+   `https://www.shoppersdrugmart.ca/en` returns 200 — so the fix here is
+   diagnosis and escalation, not retrieval.
+8. **A normal 200 is unchanged.** `example.com`, a JSON endpoint, a markdown
+   file, and a PDF fetched on `origin/main` and on the branch with the same
+   isolated config; the previews are diffed and must be **byte-identical**, and
+   `attempts` must be 1. This is the regression that matters most.
+9. **Card frame.** Per AGENTS.md visual validation: drive the real TUI with
+   `run_test`, put a blocked fetch card on screen, `app.save_screenshot()`,
+   render and *look* at the SVG — before and after, consecutive frames — plus the
+   geometry numbers. No designer round is requested (§5.4) but the frames are
+   attached.
+10. **QA independence.** The qa-tester repeats 1-8 from its own matrix on the
+    branch, including the wrong-input cases (`--max-bytes 1`, a private URL, a
+    `file://` URL) to confirm the SSRF and validation paths are untouched.
+
+---
+
+## 8. Risks to watch on rollout
+
+1. **SSRF re-validation on the retry path.** The one way to get this badly wrong
+   is to hoist `validate_public_url`/`_pin_request` out of the attempt loop "for
+   efficiency", which would let a rebinding host be re-contacted on attempt 2
+   without a check. Test 16/17 exist for exactly this; it is the reviewer's top
+   focus.
+2. **The honesty of the browser-shaped profile — stated plainly.** On a blocked
+   retry we send a Chrome User-Agent and browser-shaped headers. That is a
+   deliberate misrepresentation of the client, and it deserves to be named rather
+   than buried. It is proportionate because: it is sent only *after* the origin
+   refused an honest, self-identifying request; it is one extra request, not a
+   posture; it sends no cookies and no credentials, so it does not impersonate a
+   *user*, only a generic browser; the operator can turn it off
+   (`blocked_retry: false`); and the alternative — telling the user "this page
+   cannot be read" when a header set would have read it — is worse service for no
+   ethical gain. It does **not** attempt to solve challenges, execute challenge
+   JS, rotate identities, or use a proxy. Those would be circumvention; this is a
+   retry.
+3. **`WebReadIO` client-cache interaction.** Clients are keyed by
+   `("fetch", scheme, host, port, timeout, id(transport))` (`service.py:535`).
+   Moving to a per-request timeout means `timeout` stops varying that key, which
+   is *good* (fewer pool entries) but must not accidentally share a client across
+   two different timeouts in a way that changes behaviour — it cannot, because
+   the timeout now rides on the request. Watch the pool-eviction path
+   (`io.py:70-79`) under the new attempt volume; the ≤32 idle bound still holds.
+4. **Singleflight and retries.** `run_fetch` collapses duplicate in-flight reads
+   (`tool.py:420-435`). Retries happen *inside* the shared coroutine, so N
+   subscribers still cost one retry sequence — correct, and worth a note so
+   nobody "fixes" it into per-subscriber retries. A cancelled final subscriber
+   cancels the retry loop mid-backoff, which the abort test covers.
+5. **Politeness / extra origin load.** Worst case this triples GET volume to an
+   origin that is already failing. Mitigated by: retries only on classes that
+   indicate the origin *wants* another try, `Retry-After` honoured, jitter to
+   avoid synchronised bursts from parallel fetches, a hard 3, and no retry at all
+   on 4xx. Net new load on a healthy origin is **zero** — a 200 still costs one
+   request.
+6. **False-positive block classification.** A legitimate page containing "Access
+   Denied" in its text could in principle be misclassified — but only on a
+   non-2xx response, since `classify_response` is never consulted for a 2xx. The
+   8 KB window and the header-first ordering keep this small. Test 10 guards it.
+7. **Marker drift.** Vendors rename things. The failure mode is graceful: an
+   unmatched 403 still gets the escalation and an honest unbranded message
+   (§2.2). The markers are in one table with captured evidence in comments, so
+   refreshing them is a small, obvious edit.
+8. **Latency on the block path.** +0.25 s on a failing fetch. Acceptable; the
+   stall path is 8 s *faster*.
+
+### 8.1 The approval boundary — decisive, and it constrains the design
+
+`web_fetch` is `approval_tier="read"` (`tool.py:545`); `browser` is
+`approval_tier="write"` (`builtin.py:9677`, whose comment says it "navigates and
+can write a screenshot file, so it rides the write approval gate rather than
+auto-approved read").
+
+**`web_fetch` must therefore never drive the paired browser itself, on any code
+path, as any kind of fallback.** Doing so would launder a write-tier,
+approval-gated action — navigating the operator's real, logged-in browser — through
+an auto-approved read call the user never approved. It would also hand that
+capability to any subagent holding `web_fetch`, silently widening the tool
+surface past what the subagent was granted. The escalation stays a **named next
+step the agent takes through the `browser` tool**, subject to its own approval
+prompt. The design's contribution is to make that next step *legible* in the
+result text rather than something the agent has to guess at.
+
+This is also why §5.2's text says "use the `browser` tool" rather than doing it.
+
+### 8.2 Second-repo (parity) exposure
+
+`local-operator-ui` ports the row rules
+(`docs/evidence/tui-parity/tool-row-spec.md:282` pins the fetch header rows in
+order). Because §5.4 adds **no row** and §5.3 adds **only optional details keys**,
+the parity spec stays true and no UI PR is needed. Verified that the UI's row
+model keys off the tool name and category only
+(`renderer/src/features/chat/components/trace/tool-row-model.ts:389`) and reads
+none of the fetch detail keys, so new keys are invisible to it. If §12's decision
+3 goes the other way, that changes and a parity PR is in scope.
+
+---
+
+## 9. What this design does NOT do, and why
+
+1. **No remote reader backends.** No `r.jina.ai`, no Parallel, no third-party
+   proxy — `docs/design/web_fetch.md` rejects them because they send the user's
+   URL to a third party. Unchanged and reaffirmed.
+2. **No headless browser, no JS execution, no challenge solving.** That is what
+   the `browser` tool is, it is write-tier for good reason (§8.1), and a second
+   browser stack in the fetch path would be both a footprint disaster and an
+   approval-boundary breach.
+3. **No cookie jar, no session persistence, no login.** `web_search/io.py:25-30`
+   deliberately refuses cookies; a fetch is not the user's session. A retained
+   jar was measured not to flip shoppersdrugmart anyway.
+4. **No proxy support, no IP rotation, no residential exit.** Circumvention, not
+   robustness.
+5. **No per-site rules, allowlists, or URL rewriting.** The controls in §1.2 are
+   the argument: most sites are fine with the honest UA, and a site table is a
+   maintenance liability that rots silently. In particular, no "rewrite
+   `shoppersdrugmart.ca/` to `/en`" special case, even though it would have
+   "fixed" the incident URL.
+6. **No caching of failures, and no negative cache.** `tool.py:478` stays as it
+   is; a transient outage must never be replayed for the TTL.
+7. **No change to the default request identity** (§4.1).
+8. **No retry of the enrichment probes.** They are an optimisation; retrying them
+   multiplies request volume for no user-visible gain.
+9. **No new card row, no designer round** (§5.4) — unless §12.3 says otherwise.
+10. **No config migration** (§6.3) — additive defaults already cover old files,
+    and a no-op migration is worse than none.
+11. **No change to `_fetch_or_abort`** — it already covers everything it needs to
+    (§3.5).
+12. **No fix for `shoppersdrugmart.ca/?query=…` itself.** It cannot be fetched
+    headlessly by any client we can honestly be; the design improves the
+    diagnosis and names the escalation, and the PR will say so in those words.
+
+---
+
+## 10. Alternatives considered and rejected
+
+- **Just raise the timeout.** Makes the canadiantire case *worse* (longer stall,
+  same nothing) and does not touch the block case.
+- **Make the browser-shaped profile the default.** Flips medium.com, but pays a
+  misrepresentation on every request including the ~100 % that do not need it,
+  and removes site owners' ability to identify us. Rejected (§4.1).
+- **Retry everything, including 4xx.** Wasted requests; a 404 will not become a
+  200. Rejected.
+- **A generic retry decorator around `service.fetch()`.** Simpler to write, but
+  it retries the *whole* redirect chain and the enrichment probes, multiplying
+  request volume, and it cannot re-validate per hop. Rejected in favour of
+  per-attempt retries inside `_follow`.
+- **Do nothing and tell the agent to use `browser` in the prompt.** Genuinely
+  considered — it is the smallest change. Rejected because the `browser`
+  extension was not paired in the incident, so the escalation was unavailable;
+  because it does nothing for the transient and stall classes; and because the
+  ~5.5 KB challenge body would still be burning context.
+
+---
+
+## 11. Relationship to `docs/design/web_fetch.md`
+
+Nothing here contradicts it. Three places refine it:
+
+- §7 item 7 of that doc says "Set a plain `User-Agent` identifying lop". That
+  remains the default and the posture; this document adds a **single
+  compatibility attempt after a refusal**, which is a narrowing exception, not a
+  reversal. The original doc's intent — no ambient credentials, no user session —
+  is fully preserved.
+- §6 of that doc describes one request per hop; this makes it up to three plus one
+  escalation, under a whole-call deadline that did not previously exist.
+- §16's risk list gains the four risks in §8 above.
+
+`docs/design/web_fetch.md` gains a one-line pointer under its title directing
+readers here for the retry/blocked-response contract. **Recommendation: a
+separate document (this one) plus that pointer**, rather than a §17 appended to
+the existing doc — the original is a shipped feature's design record and reads as
+a coherent whole; bolting a post-incident robustness contract onto its end would
+bury it. A separate, cross-linked document is easier to find and easier to
+supersede.
+
+---
+
+## 12. Decisions I want the manager to make before coding
+
+1. **`blocked_retry` default.** I recommend **true** (measured win, one request,
+   only after a refusal). Flipping it to false-by-default makes the feature
+   nearly dead code, since nobody will find the switch. Confirm.
+2. **The 0.6 stall fraction** (§3.3). It is the only number here that is a
+   judgement rather than a measurement. I recommend shipping 0.6 and watching it;
+   the evidence that would settle it is a distribution of time-to-first-byte
+   across slow-but-working origins, which we would have to collect. Confirm, or
+   tell me to make it configurable (I lean against: another knob nobody tunes).
+3. **Card hint row: no.** I recommend the model-facing-text-only change with a
+   rendered frame but **no designer round and no UI parity PR** (§5.4, §8.2). If
+   you want the `browser` escalation pinned as a structured card row instead, say
+   so now — it adds a designer round here and a parity PR in `local-operator-ui`.
+4. **Scope of the empty-error fix.** The manager flagged it as "fold it in if
+   cheap". It is cheap and it is the same code path (the terminal failure text is
+   built by `describe()` either way), so I have folded it in. Confirm you want it
+   in this PR rather than split.
+5. **Ship-or-hold.** This is a bounded robustness fix to an existing tool with no
+   new dependency, no new tool, no schema break and no security-model change. It
+   touches the SSRF-adjacent retry path, which is why §8.1 and tests 16/17 exist.
+   Under the team's default disposition my read is **ship**, with the reviewer
+   told to scrutinise the per-attempt re-validation specifically. Confirm.

--- a/docs/design/web_fetch_robustness.md
+++ b/docs/design/web_fetch_robustness.md
@@ -1,8 +1,11 @@
 # Design: `web_fetch` robustness — transient failures, bot-blocks, and honest diagnostics
 
 Status: **implemented**. The manager ratified §12 as: `blocked_retry` default on
-(1), the 0.6 stall fraction ships fixed with no knob (2), no card hint row and
-no UI parity PR (3), the empty-`str(exc)` fix folded in (4), ship (5).
+(1), no card hint row and no UI parity PR (3), the empty-`str(exc)` fix folded in
+(4), ship (5). **§12.2 (the 0.6 stall fraction) was ratified and then REVERSED**
+during remediation when the measurement showed it turned a slow-but-working
+origin into a failure — see the §3.3 decision record, which supersedes both §12.2
+and this line.
 
 Three things the implementation had to settle that this document did not, each
 recorded here rather than only in the PR so the next reader of the design sees
@@ -226,8 +229,14 @@ The distinction costs one boolean and buys the agent a correct next step.
 different. Measured on `canadiantire.ca`: the lop profile never gets headers back
 (ReadTimeout at 20 s), while a browser-shaped profile gets a 403 in 0.07-0.25 s.
 A stall is therefore frequently a *silent* block, and the right response is the
-same profile escalation §4 describes — on a **shortened** budget, because the
-whole point is not to spend another 20 s learning nothing.
+same profile escalation §4 describes.
+
+**What shipped is narrower than this section first assumed, and §3.3 records
+why:** a stall consumes the whole slice it was granted, so with the first-attempt
+cap removed there is normally nothing left to fund the escalation and it does not
+run. The re-measured live behaviour at the defaults is one honest attempt,
+~20 s, and the classified terminal message. The escalation remains reachable
+whenever a stall leaves budget behind (a later hop's short remainder).
 
 ---
 
@@ -283,16 +292,34 @@ multiply it. It becomes a **deadline for the whole call** instead:
   connect/read/write/pool values.)
 - Before sleeping a backoff, check it fits: if `delay > remaining - 0.25 s`, stop
   retrying and return the failure now rather than sleeping into the deadline.
-- **Attempt budgeting for the stall class:** attempt 1 of a hop is capped at
-  `min(remaining, 0.6 * timeout)`. That is what converts the canadiantire case
-  from "20 s then nothing" into "12 s then a fast browser-shaped probe that
-  returns a real 403 in ~0.25 s". The 0.6 split is a judgement call; the
-  evidence that would tune it is the distribution of time-to-first-byte on
-  genuinely slow-but-working origins, which we do not have. 0.6 is chosen because
-  a page that has sent no headers in 12 s is overwhelmingly more likely to be
-  black-holed than slow. It applies **only when there is a fallback attempt left
-  to spend** — the last attempt always gets the full remaining budget, so a
-  genuinely slow origin is never penalised on its final try.
+- **Attempt budgeting for the stall class: none, and this is a DECISION this
+  document records as shipped rather than a gap.**
+
+  The design originally capped the first attempt of a hop at
+  `min(remaining, 0.6 * timeout)` while a fallback remained, to leave the
+  browser-shaped probe something to spend on a black-holing origin. **That cap is
+  gone. The shipped behaviour is the opposite: every attempt — including the
+  first, honest one — gets the full remaining budget, and the escalation is
+  opportunistic, funded only by whatever the hop's own outcome left behind.**
+
+  Why it had to go: `httpx`'s read timeout bounds the wait for response HEADERS
+  as well as inter-chunk gaps, so "cap the first attempt" is really "give the
+  fetch a 12 s timeout whenever a fallback exists" — and with the shipped
+  defaults a fallback always exists. An origin whose time-to-first-byte fell
+  between 0.6·T and T therefore **succeeded before this change and failed after
+  it**, as a terminal `stall` naming a vendor we never reached. Re-measured on a
+  fake clock: a 13 s-first-byte origin at T=20 returns 200 in one attempt on the
+  pre-change engine, and returns `FAILURE kind=stall granted=[12.0, 8.0]` under
+  the cap. The regression guard for that is
+  `tests/unit/web_fetch/test_service.py::test_slow_but_working_origin_still_succeeds`.
+
+  What it costs: a real black-hole now spends the whole budget on the honest
+  attempt, so the escalation has nothing left to spend and does not run.
+  `canadiantire.ca` is back to ~20 s rather than ~12 s — the −8 s row this table
+  used to claim was bought with a timeout reduction, and is withdrawn. What the
+  user gets instead is the thing §1.3 was actually about: a classified, readable
+  terminal message ("The origin accepted the connection but never sent a
+  response", plus the next step) rather than an empty string after a colon.
 
 Worst-case added latency versus today, stated plainly:
 
@@ -300,13 +327,22 @@ Worst-case added latency versus today, stated plainly:
 |---|---|---|---|
 | 200 first try | t | t | **0** (same one request) |
 | 404 / other non-retryable 4xx | t | t | **0** |
+| slow-but-working origin (first byte > 0.6·T) | t | t | **0** — it still succeeds; the 0.6 cap had turned this into a failure |
 | block detected (medium.com) | 0.06 s | ~0.3 s | +~0.25 s (one extra request) |
-| stall (canadiantire, T=20) | 20.2 s | ~12.3 s | **−8 s** |
+| stall (canadiantire, T=20) | 20.2 s | ~20 s | **0** — the escalation is not funded (see the decision record above); the gain is the message, not the seconds |
 | persistent 500 | t | t + ~1.9 s sleep + 2 requests | bounded by T |
 | any case, hard ceiling | T | T | **0** — the deadline is the bound |
 
 The last row is the one that matters: the deadline never moves, so no
-configuration of retries can make a call exceed its stated timeout.
+configuration of retries can make a call exceed its stated timeout. **That claim
+now includes the resolver**, which it did not at first: `getaddrinfo` has no
+timeout of its own in the stdlib, so the per-attempt timeout used to be computed
+BEFORE a lookup that could outlast the whole budget. The lookup now runs under
+`asyncio.wait_for(remaining)` and the request's own timeout is recomputed from
+what is left after it. The honest reading: the call cannot exceed T; an abandoned
+resolver thread cannot extend it (it may linger in the executor until the
+resolver's own timeout ends it), and that distinction is stated in
+`service.py::_request_once`.
 
 ### 3.4 `Retry-After`
 
@@ -417,8 +453,8 @@ anywhere else.
   in the face of a refusal, and for a clean A/B during rollout.
 - The escalated attempt gets the same deadline arithmetic as any other.
 - If the escalated attempt also fails, the **escalated** outcome is what is
-  reported (it is the more informative one: canadiantire goes from "timed out"
-  to "403 from Akamai"), with `details` recording both.
+  reported (it is the more informative one when it produced a response), with
+  `details` recording both.
 
 ---
 
@@ -507,24 +543,44 @@ untouched:
 | `suggested_tool` | `str \| None` | `"browser"` when the block is confirmed unretrievable |
 
 A cache hit continues to carry none of these except `attempts: 0`, which is
-truthful (no network attempt was made).
+truthful (no network attempt was made) **and no `profiles`** — a hit made no
+request, so it has no request identity either. `attempts`/`profiles` also ride
+the **terminal** failure path (no response ever arrived): they travel on the
+`FetchError` from the engine, so the structured payload cannot disagree with the
+preview that states "2 attempts".
 
-### 5.4 The card: no structural change, and why that is the right call
+### 5.4 The card: no NEW row, and the row logic that did change
 
 `_fetch_result_output` builds its rows from `details`
-(`tool_card.py:744-809`). Two things happen with **no code change at all**
-because of how the card already works:
+(`tool_card.py:744-809`). The decision this section records still stands: **no new
+card row, and no `local-operator-ui` parity obligation.** The design review round
+that followed found the card's *existing* rows were saying things the model text
+did not, though, and four small changes landed on those rows only:
 
-1. The error row keeps rendering from `http_error` + `status`.
-2. The new body text flows through `_strip_fetch_header` correctly — verified by
-   running the real function against the proposed new header block in this
-   worktree: the lead and meta lines are stripped and the new explanatory lines
-   survive, and the existing 404 shape still strips identically.
+1. The error row keeps rendering from `http_error` + `status`, but a CONFIRMED
+   block now prints the same classified sentence the model-facing lead uses
+   ("blocked by Akamai bot protection"), imported from `failure.py` rather than
+   re-typed. Before this, one screen carried two wordings of one fact and the
+   vendor's name was only on the line the card discards.
+2. The attempt count and identity sequence ride the existing `Rendered:` row
+   ("`Rendered: text · 4 lines · 2 attempts (default, browser-profile)`").
+   Without it, the medium.com case — 403 on the honest profile, 200 on the
+   escalation — was character-for-character an ordinary one-attempt success on
+   the card, which is the silent behaviour this whole change exists to end.
+3. The statement body is fitted to the card's own width at paint time instead of
+   arriving pre-wrapped to 76 cells: a constant is wrong at 80 columns (clipped
+   mid-word) and wrong at 150 (the block stopped half-way across).
+4. A terminal failure (a stall, a transport error) is a FETCH card too. It
+   carries no `render_method`/`final_url`, so it used to fall through to the
+   generic output body and read as a different tool; `failure_kind` is the key
+   both shapes carry, and the tool's own first sentence is promoted to the
+   danger row rather than duplicated in the body.
 
-I therefore recommend **not** adding a card hint row in this change. The reasons:
+The reasons the pinned row is still **not** warranted are unchanged:
 
 - The information the agent needs is model-facing text; the human reading the
-  card already sees `⚠ HTTP 403 Forbidden — error/block page`, which is accurate.
+  card now sees `⚠ HTTP 403 Forbidden — blocked by Akamai bot protection`, which
+  is accurate and names the vendor.
 - A new row means a TUI change, a designer round, **and** a parity obligation in
   `local-operator-ui` (`docs/evidence/tui-parity/tool-row-spec.md:282` pins the
   fetch header rows in order). That is a second repo's work for a cosmetic gain.
@@ -532,13 +588,10 @@ I therefore recommend **not** adding a card hint row in this change. The reasons
   rows, so the "next step: browser" sentence **is visible to the user** — it
   arrives as body, not as a pinned row.
 
-Because the card's *painted output changes* (the body text differs even though no
-row logic does), a rendered before/after frame is still required by the
-repository's visual-validation rule — see §7. This is a "capture the frame, no
-designer round" change: there is no layout, spacing, colour or row-structure
-delta to review. If the reviewer disagrees and wants the hint pinned as a row,
-that flips it into a user-visible change with a designer round and a parity PR;
-§12 lists it as a decision.
+Because the card's painted output changes, rendered before/after frames are
+required by the repository's visual-validation rule — see §7. The designer round
+this section originally argued against did happen and drove items 1-4 above; it
+is on the PR as `### Design review — round 1`.
 
 ---
 
@@ -668,8 +721,9 @@ none should be written** — adding one would be a migration that does nothing.
     total elapsed < 2.5 s and fewer than `max_attempts` requests when the
     deadline binds (asserted structurally on a fake clock, per AGENTS.md
     "prefer a structural invariant to a numeric one").
-22. **Stall shortening**: a transport that never responds → attempt 1 is given
-    ≤ 0.6·T, and the escalated attempt happens.
+22. **No first-attempt cap**: a transport that never responds → attempt 1 is
+    granted the FULL remaining budget (not 0.6·T), and a slow-but-working origin
+    whose first byte lands between 0.6·T and T still succeeds.
 23. **Empty-`str(exc)` regression**: a `ReadTimeout("")` produces a message that
     names the class and the attempt count and does **not** end in `': '`.
 24. Enrichment probes never trigger the escalation (a blocked `.md` twin costs
@@ -716,9 +770,12 @@ capture go on the PR.
 2. **The stalled host becomes a bounded, informative result.**
    Same command against the canadiantire PDP URL.
    Before (captured today): 20.5 s, `error: timed out fetching '…': ` (empty
-   reason). Expected after: ~12.3 s, `⚠ HTTP 403 Forbidden — blocked by Akamai
-   bot protection` with the reference id and the `browser` next step, and the
-   elapsed time printed alongside.
+   reason). RE-MEASURED after remediation, at the defaults: **20.38 s**, one
+   attempt, `Read timed out after 19.8s — the origin accepted the connection but
+   never sent a response`, with the URL and the `browser` next step. The ~12.3 s
+   `⚠ HTTP 403 Forbidden — blocked by Akamai` this plan originally expected was an
+   artefact of the 0.6 first-attempt cap and is withdrawn (§3.3); the escalation
+   that found that 403 is only reachable while a stall leaves budget behind.
 3. **Local server that 500s then 200s.** A `http.server.ThreadingHTTPServer`
    subprocess on a free port, `allow_private: true` for that run only; first GET
    500, second 200. Expected: one success, `attempts: 2`, server access log
@@ -859,7 +916,10 @@ none of the fetch detail keys, so new keys are invisible to it. If §12's decisi
 7. **No change to the default request identity** (§4.1).
 8. **No retry of the enrichment probes.** They are an optimisation; retrying them
    multiplies request volume for no user-visible gain.
-9. **No new card row, no designer round** (§5.4) — unless §12.3 says otherwise.
+9. **No new card row, no UI parity PR** (§5.4). The designer round the original
+   text hoped to avoid did run, and it changed only the CONTENT of existing rows —
+   so the second-repo parity obligation still does not apply (review round 1,
+   D1-D5).
 10. **No config migration** (§6.3) — additive defaults already cover old files,
     and a no-op migration is worse than none.
 11. **No change to `_fetch_or_abort`** — it already covers everything it needs to
@@ -893,13 +953,16 @@ none of the fetch detail keys, so new keys are invisible to it. If §12's decisi
 
 ## 11. Relationship to `docs/design/web_fetch.md`
 
-Nothing here contradicts it. Three places refine it:
+**This document does contradict that one in exactly one place, and the earlier
+revision's claim of non-contradiction was wrong.** §7 item 7 of that doc says
+"each fetch is anonymous … Set a plain `User-Agent` identifying lop", and an
+escalated attempt sends a Chrome UA with `Sec-Fetch-*`. The contradiction is
+narrow — one compatibility attempt after a refusal, never the default posture,
+never ambient credentials, never the user's session — and it is now stated as an
+exception in that doc's §7 item 7 rather than denied here (review round 1, R6).
 
-- §7 item 7 of that doc says "Set a plain `User-Agent` identifying lop". That
-  remains the default and the posture; this document adds a **single
-  compatibility attempt after a refusal**, which is a narrowing exception, not a
-  reversal. The original doc's intent — no ambient credentials, no user session —
-  is fully preserved.
+Two other places refine that doc:
+
 - §6 of that doc describes one request per hop; this makes it up to three plus one
   escalation, under a whole-call deadline that did not previously exist.
 - §16's risk list gains the four risks in §8 above.
@@ -924,6 +987,10 @@ supersede.
    the evidence that would settle it is a distribution of time-to-first-byte
    across slow-but-working origins, which we would have to collect. Confirm, or
    tell me to make it configurable (I lean against: another knob nobody tunes).
+   — **RATIFIED, THEN REVERSED.** The remediation round produced exactly the
+   measurement this item asked for, and it says the opposite: the cap turns a
+   13 s-first-byte origin into a terminal `stall`. The fraction is removed
+   entirely; §3.3 is the record.
 3. **Card hint row: no.** I recommend the model-facing-text-only change with a
    rendered frame but **no designer round and no UI parity PR** (§5.4, §8.2). If
    you want the `browser` escalation pinned as a structured card row instead, say

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -1872,6 +1872,27 @@ SETTINGS: tuple[Setting, ...] = (
         help="Try .md, llms.txt and content negotiation before scraping HTML.",
         choices=_bool_choices("try cleaner sources first", "scrape HTML directly"),
     ),
+    Setting(
+        key="web_fetch.max_attempts",
+        path=("web_fetch", "max_attempts"),
+        section="web_fetch",
+        label="Attempts per hop",
+        kind=Kind.INT,
+        default=3,
+        help="Retries share the call's timeout, so more attempts never take longer.",
+        minimum=1,
+        maximum=5,
+    ),
+    Setting(
+        key="web_fetch.blocked_retry",
+        path=("web_fetch", "blocked_retry"),
+        section="web_fetch",
+        label="Browser-profile retry",
+        kind=Kind.BOOL,
+        default=True,
+        help="After a refusal, retry once with browser-shaped headers.",
+        choices=_bool_choices("retry refusals once", "stay self-identifying"),
+    ),
     # -- tools --------------------------------------------------------------
     # ``path`` mirrors ``tools.builtin.BASH_SHELL_PATH``; the two are pinned
     # together by ``test_bash_shell_row_shares_the_consumer_path`` rather than

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -88,6 +88,7 @@ import json
 import math
 import os
 import re
+import textwrap
 import time
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
@@ -107,6 +108,17 @@ from local_operator.tui.widgets.transcript import (
     TranscriptView,
     wrap_cells,
 )
+
+# The blocked-refusal sentence and the attempt summary live in the web_fetch
+# package and are imported rather than re-typed. That is a deliberate exception
+# to this widget's "no service-package import" habit (see ``_humanize_bytes``):
+# a FORMAT has one obvious right answer and can be duplicated safely, while this
+# sentence is a BEHAVIOUR — it names a vendor we detected and must stay
+# silent-or-explicit about bot protection — and the review that prompted this
+# round found the two hand-rolled copies had already drifted apart. ``failure``
+# is a pure module (no I/O, no settings, no client); ``httpx``, its only
+# third-party import, is already a hard dependency of this app.
+from local_operator.web_fetch.failure import attempt_summary, block_lead
 
 #: Control-sequence stripping lives in `local_operator.ansi` because the
 #: headless renderer needs the identical behaviour and must not import a
@@ -733,12 +745,22 @@ def _is_fetch_details(tool_name: str, details: dict[str, Any] | None) -> bool:
     apart. A fetch's details carry ``render_method`` and ``final_url`` (a file
     read carries neither), so the presence of those keys is what selects the
     fetch card without a fragile name check on every ``read``.
+
+    A TERMINAL fetch failure carries neither of those keys — no response ever
+    arrived, so there is no final URL and nothing was rendered — and it used to
+    fall through to the generic output body. That made one tool's two failure
+    shapes read as two different tools, the stall one indistinguishable from a
+    bash error (design review round 1, D5). ``failure_kind`` is the key BOTH
+    shapes carry, so it keys the fetch treatment as well. A file read never has
+    it: nothing in the read path classifies a failure.
     """
     if tool_name == "web_fetch":
         return True
     if tool_name != "read" or not isinstance(details, Mapping):
         return False
-    return "render_method" in details and "final_url" in details
+    if "render_method" in details and "final_url" in details:
+        return True
+    return isinstance(details.get("failure_kind"), str)
 
 
 def _fetch_result_output(details: dict[str, Any] | None) -> list[str]:
@@ -746,10 +768,20 @@ def _fetch_result_output(details: dict[str, Any] | None) -> list[str]:
 
     Rendered from ``details`` (which never reaches the provider) rather than the
     model-facing preview, so the card can always show the final URL, status,
-    content-type, render method, byte/line counts, cache state, and \u2014 when the
-    render looked sparse \u2014 a one-line nudge toward ``browser``. The preview body
+    content-type, render method, byte/line counts, cache state, and — when the
+    render looked sparse — a one-line nudge toward ``browser``. The preview body
     itself is appended by the body painter from the result text; this helper owns
     only the header rows, mirroring ``_search_result_output``'s split of duties.
+
+    Two round-1 refinements live here. The attempt count rides the ``Rendered:``
+    row (D1): §3.6 promises the reader can see that a fetch took more than one
+    try, and the header meta line that carries it model-side is stripped from the
+    card, so without this the successful-on-escalation fetch was
+    character-for-character a one-attempt success. And the byte count is dropped
+    for the ``blocked`` class (DN2): the number describes the discarded challenge
+    page, which the card deliberately never shows, while the line count beside it
+    describes the statement that replaced it — two subjects on one row, with the
+    subject the reader cannot check winning.
     """
     if not isinstance(details, Mapping):
         return []
@@ -789,7 +821,17 @@ def _fetch_result_output(details: dict[str, Any] | None) -> list[str]:
         http_error = not (200 <= status < 300)
     if http_error and isinstance(status, int):
         reason = _HTTP_REASONS.get(status, "Error")
-        rows.append(f"⚠ HTTP {status} {reason} — error/block page, not page content.")
+        # A CONFIRMED bot-block carries the classified sentence — the same one
+        # the model-facing lead uses — so the card does not print two wordings of
+        # one fact with the vendor-less one winning on the surface the user reads
+        # (design review round 1, D2). An UNSIGNED refusal keeps the generic copy,
+        # which is right as it stands: it claims nothing we did not detect.
+        vendor = details.get("block_vendor")
+        if details.get("failure_kind") == "blocked" and vendor:
+            clause = block_lead(str(vendor))
+            rows.append(f"⚠ HTTP {status} {reason} — {clause}.")
+        else:
+            rows.append(f"⚠ HTTP {status} {reason} — error/block page, not page content.")
     rows.append(fetched)
 
     render_bits = " · ".join(
@@ -799,11 +841,34 @@ def _fetch_result_output(details: dict[str, Any] | None) -> list[str]:
             f"{lines_n} lines" if isinstance(lines_n, int) else "",
             # D2: humanise (KB/MB) so the structured row agrees with the binary
             # notice body two lines below, which already prints e.g. "2.4 MB".
-            _humanize_bytes(byte_n) if isinstance(byte_n, int) else "",
+            # Suppressed for a replaced body: see the docstring (DN2).
+            (
+                _humanize_bytes(byte_n)
+                if isinstance(byte_n, int) and details.get("failure_kind") != "blocked"
+                else ""
+            ),
         )
         if part
     )
     if render_bits:
+        # D1: ``Rendered: markdownify · 3 lines · 2 attempts (default,
+        # browser-profile)``. The escalation that WON is the case a reader most
+        # needs to see — it is the reason a slow fetch succeeded — and it was
+        # exactly the case that looked character-for-character like an ordinary
+        # one, because the meta line carrying the count model-side is stripped
+        # from the card. Appended to this row rather than given its own: §5.4's
+        # "no new card row" decision stands, and this row has the room that
+        # ``Fetched:`` does not.
+        # Bound to locals so the narrowing holds for the type checker and the
+        # call reads as one decision rather than three inline guards.
+        attempts_n = details.get("attempts")
+        profiles_n = details.get("profiles")
+        summary = attempt_summary(
+            attempts_n if isinstance(attempts_n, int) else 1,
+            profiles_n if isinstance(profiles_n, list) else (),
+        )
+        if summary:
+            render_bits += f" · {summary}"
         rows.append(f"Rendered: {render_bits}")
     if details.get("low_quality"):
         rows.append("sparse/JS-gated — try `browser` for the full page.")
@@ -1160,6 +1225,12 @@ class ToolCard(ExpandableActionBlock):
         #: result, so the body painter and the rest-visibility rule can select
         #: the fetch presentation. Set in :meth:`_absorb_result`.
         self._is_fetch_card = False
+        #: True when the card's BODY is our own prose rather than page content
+        #: (a replaced challenge body, or a terminal failure whose whole text is
+        #: the diagnosis). Only then may the painter re-wrap it: re-flowing an
+        #: origin's own bytes — a code sample, a log excerpt — would change what
+        #: the card claims the origin said.
+        self._fetch_statement = False
         #: Rows the card currently occupies (1 collapsed, N expanded).
         self._row_count = 1
         #: ``_row_count`` as of the last content APPLIED to the widget, or -1
@@ -1856,7 +1927,14 @@ class ToolCard(ExpandableActionBlock):
         # then the rendered preview body, so the card shows what was fetched and
         # a slice of the content, with the spill footer already inside the text.
         fetch_output: list[str] = []
+        # Reset per result: a card is written once, but a rebuilt card must never
+        # inherit the previous body's reflow permission.
+        self._fetch_statement = False
         if not search_output and _is_fetch_details(name, details):
+            # Bound once: everything below reads the same mapping, and the
+            # narrowing has to survive the type checker to keep the guards
+            # readable (one alias instead of an isinstance per key).
+            fetch_details = details if isinstance(details, Mapping) else {}
             fetch_header = _fetch_result_output(details)
             if fetch_header:
                 # D1: the structured rows above OWN the metadata (status, final
@@ -1867,6 +1945,23 @@ class ToolCard(ExpandableActionBlock):
                 # is purely the CARD's presentation, mirroring how web_search lets
                 # its structured rows replace, not duplicate, the model text.
                 body = _strip_fetch_header(self._clean_output(result_text))
+                # D5: a TERMINAL failure has no HTTP status to lead with, and its
+                # body IS the tool's diagnosis — the same sentence the settled row
+                # already shows. Promoting it to the card's danger row is the same
+                # move `_strip_fetch_header` makes for the response family (the
+                # lead becomes a structured row, the body keeps the rest), and it
+                # adds no wording: the sentence is the tool's own.
+                terminal = isinstance(fetch_details.get("failure_kind"), str)
+                if terminal and "render_method" not in fetch_details and body:
+                    if not fetch_header[0].startswith("⚠ "):
+                        fetch_header = [f"⚠ {body[0]}"] + fetch_header
+                        body = body[1:]
+                    while body and not body[0].strip():
+                        body.pop(0)
+                # D3: only a body that is OUR prose may be re-wrapped at paint
+                # time — the replaced challenge statement, or a terminal
+                # failure's diagnosis. Origin content is painted as it arrived.
+                self._fetch_statement = fetch_details.get("failure_kind") == "blocked" or terminal
                 fetch_output = fetch_header + [""] + body
         # Remembered so the body painter and the rest-visibility rule can select
         # the fetch presentation without re-inspecting details every repaint.
@@ -2327,6 +2422,23 @@ class ToolCard(ExpandableActionBlock):
         so the rendered preview beneath them \u2014 the actual page content \u2014 reads at
         normal contrast, the same hierarchy the search card uses to keep its
         structural rows from competing with the result.
+
+        Three things this painter now owes the design review round 1:
+
+        - **A statement body is fitted to the card's own width** (D3). It used to
+          arrive pre-wrapped to 76 cells, which is simultaneously too wide for an
+          80-column card (clipped mid-word) and far too narrow for a 150-column
+          one (the block stopped half-way across). A constant cannot be right at
+          both ends; ``line_width`` is.
+        - **The statement's two roles are separated** (D4). ``Next step:`` is the
+          one actionable sentence and rides ``signal``; the opaque
+          ``Origin reference:`` is quotable metadata and recedes to ``dim``. The
+          body itself stays ``snippet`` — ``dim`` measures 3.32:1 on the light
+          tinted panel, below the floor for prose.
+        - **The danger row is recognised structurally in the header region**, so a
+          failure with no HTTP status (a stall, a transport error) can lead with
+          its own classified sentence without a page line further down that
+          happens to open with ⚠ being promoted to danger ink.
         """
         signal = bindings.style("tool.fetch.signal")
         muted = bindings.style("tool.fetch.snippet")
@@ -2335,29 +2447,72 @@ class ToolCard(ExpandableActionBlock):
         line_width = max(1, width - 2 - OUTPUT_INDENT)
         indent = " " * OUTPUT_INDENT
         shown = self._output[:EXPAND_MAX_LINES]
-        for line in shown:
+        # ``_absorb_result`` joins the structured rows to the body with one blank
+        # separator, so everything before it is header and everything after is
+        # content. That is a property of how the card BUILDS its rows, not of
+        # what they happen to say.
+        header_end = next(
+            (index for index, line in enumerate(shown) if not line.strip()), len(shown)
+        )
+        for index, line in enumerate(shown):
             stripped = line.strip()
+            is_header = index < header_end
+            # Wrapping is allowed for OUR prose only: the statement body, and the
+            # promoted terminal-failure lead. A ``⚠ HTTP …`` row is a fixed-shape
+            # status line and clips like every other structured row; the promoted
+            # lead is a sentence that carries the attempt count, and clipping it
+            # would hide the count the body no longer repeats (D5).
+            wrap = not is_header
             if stripped.startswith("⚠ HTTP"):
                 # See `bindings.BY_ELEMENT["tool.fetch.error"].note` (F1).
                 ink = danger
+            elif is_header and stripped.startswith("⚠ "):
+                ink = danger
+                wrap = True
             elif stripped.startswith("Fetched:"):
                 # See `bindings.BY_ELEMENT["tool.fetch.signal"].note` (D3).
                 self._append_fetched_row(row, line, line_width, indent, dim, signal)
                 continue
             elif stripped.startswith("Rendered:"):
                 ink = dim
+            elif stripped.startswith("Next step:"):
+                ink = signal
+            elif stripped.startswith("Origin reference:"):
+                ink = dim
             elif stripped.startswith("sparse/JS-gated"):
                 # See `bindings.BY_ELEMENT["tool.fetch.signal"].note`.
                 ink = signal
             else:
                 ink = muted
-            row.append("\n" + indent, style=dim)
-            row.append(truncate_cells(line, line_width), style=ink)
+            for segment in self._fetch_segments(line, line_width, wrap=wrap):
+                row.append("\n" + indent, style=dim)
+                row.append(truncate_cells(segment, line_width), style=ink)
         hidden = len(self._output) - len(shown)
         if hidden > 0:
             marker = f"… {hidden} more line{'s' if hidden != 1 else ''}"
             row.append("\n" + indent, style=dim)
             row.append(truncate_cells(marker, line_width), style=dim)
+
+    def _fetch_segments(self, line: str, line_width: int, *, wrap: bool) -> list[str]:
+        """The painted row(s) for one body line: the line itself, or its reflow.
+
+        Reflowing is limited to a line that is OUR prose (``_fetch_statement``),
+        because wrapping is a claim about the text: a code sample, a log excerpt
+        or a table silently re-flowed would change what the card says the origin
+        sent. Long tokens are never broken — a URL stays one token and is clipped
+        by ``truncate_cells`` exactly as it was before — and an empty line stays
+        an empty line rather than becoming no row at all.
+        """
+        if not wrap or not self._fetch_statement or not line.strip():
+            return [line]
+        wrapped = textwrap.wrap(
+            line,
+            width=line_width,
+            break_long_words=False,
+            break_on_hyphens=False,
+            drop_whitespace=True,
+        )
+        return wrapped or [line]
 
     def _append_fetched_row(
         self,

--- a/local_operator/web_fetch/cli.py
+++ b/local_operator/web_fetch/cli.py
@@ -133,7 +133,15 @@ def _set_field(args: argparse.Namespace) -> int:
     try:
         if key == "enabled":
             set_fetch_enabled(manager, value in ("on", "true", "1", "yes"))
-        elif key == "allow-private":
+            # The ONE key here that is not live: the tool's presence in the
+            # inventory is reconciled by the session, not re-read per call, so a
+            # running session has to re-add or drop the tool to see this.
+            print(
+                f"web_fetch {key} set to {value}. "
+                "Reload a running session to add or remove the tool."
+            )
+            return 0
+        if key == "allow-private":
             set_allow_private(manager, value in ("on", "true", "1", "yes"))
         elif key == "ttl":
             set_cache_ttl(manager, int(value))
@@ -151,7 +159,12 @@ def _set_field(args: argparse.Namespace) -> int:
     except ValueError as error:
         print(f"error: {error}")
         return 1
-    print(f"web_fetch {key} set to {value}. Reload a running session to apply the master switch.")
+    # Every remaining key is read per fetch (the service resolves settings on
+    # every call), so a running session picks it up on the NEXT fetch with no
+    # reload at all. The message used to claim otherwise for all of them, which
+    # was wrong for the four live knobs and actively misleading for the two retry
+    # ones this change added (review round 1, N1).
+    print(f"web_fetch {key} set to {value}. Takes effect on the next fetch.")
     return 0
 
 

--- a/local_operator/web_fetch/cli.py
+++ b/local_operator/web_fetch/cli.py
@@ -38,11 +38,14 @@ def add_fetch_subparser(
     setter = commands.add_parser("set", help="Set a single fetch config field")
     setter.add_argument(
         "key",
-        choices=("enabled", "ttl", "allow-private", "backend"),
+        choices=("enabled", "ttl", "allow-private", "backend", "attempts", "blocked-retry"),
     )
     setter.add_argument(
         "value",
-        help="on/off for enabled & allow-private; seconds for ttl; auto/stdlib for backend",
+        help=(
+            "on/off for enabled, allow-private & blocked-retry; seconds for ttl; "
+            "auto/stdlib for backend; 1-5 for attempts"
+        ),
     )
 
 
@@ -83,6 +86,8 @@ def format_fetch_status(manager: ConfigManager) -> str:
         f"Cache TTL: {settings.cache_ttl_seconds}s | cached URLs: {cache_count}",
         f"Allow private/loopback targets: {'yes' if settings.allow_private else 'no'}",
         f"Enrichment (.md / llms.txt): {'on' if settings.enrich else 'off'}",
+        f"Attempts per hop: {settings.max_attempts} | "
+        f"browser-profile retry on a refusal: {'on' if settings.blocked_retry else 'off'}",
     ]
     return "\n".join(rows)
 
@@ -115,8 +120,10 @@ async def _test_fetch(args: argparse.Namespace) -> int:
 def _set_field(args: argparse.Namespace) -> int:
     from local_operator.web_fetch.service import (
         set_allow_private,
+        set_blocked_retry,
         set_cache_ttl,
         set_fetch_enabled,
+        set_max_attempts,
         set_render_backend,
     )
 
@@ -134,6 +141,10 @@ def _set_field(args: argparse.Namespace) -> int:
             if value not in ("auto", "stdlib"):
                 raise ValueError("backend must be 'auto' or 'stdlib'")
             set_render_backend(manager, value)
+        elif key == "attempts":
+            set_max_attempts(manager, int(value))
+        elif key == "blocked-retry":
+            set_blocked_retry(manager, value in ("on", "true", "1", "yes"))
         else:  # pragma: no cover - argparse choices guard this
             print(f"error: unknown fetch field {key}")
             return 1

--- a/local_operator/web_fetch/failure.py
+++ b/local_operator/web_fetch/failure.py
@@ -1,0 +1,508 @@
+"""Failure taxonomy for ``web_fetch``: what went wrong, and what to do about it.
+
+One classifier, so the engine's retry decision, the model-facing text and the
+tests cannot drift into three different opinions about the same response. It is
+deliberately PURE — no I/O, no settings, no httpx client — which is what makes
+the marker table cheap to test against real captured bodies.
+
+Three questions it answers, in the order the engine asks them:
+
+1. **What class of failure is this?** (:func:`classify_exception` for a
+   transport-level throw, :func:`classify_response` for a status code.) The
+   class is what decides whether another attempt could possibly help.
+2. **Is this a bot-protection refusal, and whose?** The marker tables below are
+   header-first because headers are the stable signal; body strings are the
+   fallback for vendors that do not brand their headers.
+3. **What does the agent read?** (:func:`describe`.) Building the terminal text
+   from the CLASSIFICATION rather than from ``str(exc)`` is what fixes the
+   defect where ``httpx.ReadTimeout.__str__()`` is the empty string and the
+   error message ended in ``': '`` with nothing after it.
+
+Why the honesty distinction in §2.2 of ``docs/design/web_fetch_robustness.md``
+is load-bearing: an UNMATCHED 403 earns the same escalation attempt (a plain
+WAF with no branding is common and the retry is cheap) but is NEVER labelled
+with a vendor. Telling the agent "bot protection" about a 403 that really means
+"you are not a subscriber" sends it to ``browser`` when it should be asking the
+user for credentials.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from typing import Literal, Mapping, Sequence
+
+import httpx
+
+#: The failure classes. ``ok`` is not modelled — a 2xx/3xx returns ``None`` from
+#: :func:`classify_response`, so "no failure" is the absence of one of these
+#: rather than a value that has to be checked for everywhere.
+FailureKind = Literal["transport", "stall", "server", "ratelimit", "blocked", "client"]
+
+#: Vendors we can name from a signature. Anything unmatched stays ``None`` and
+#: is described without a vendor claim (§2.2) — the anti-mislabelling rule.
+BlockVendor = Literal["cloudflare", "akamai", "datadome", "perimeterx", "imperva"]
+
+#: Markers are matched against the first 8 KB of the decoded body only. A
+#: challenge page is always small; scanning a 5 MB body for substrings is wasted
+#: work, and a marker appearing 3 MB into a real article is a false positive we
+#: do not want.
+MARKER_SCAN_BYTES = 8 * 1024
+
+#: Statuses that can carry a challenge. A 403 is the common refusal; 401 appears
+#: on some WAFs; 503 is Cloudflare's "under attack" interstitial. Anything else
+#: is classified by its own class, never as a block.
+_BLOCKABLE_STATUSES = frozenset({401, 403, 503})
+
+#: Header signatures, vendor by vendor. Each entry is ``(header, substring)``
+#: matched case-insensitively against the response headers, which are the STABLE
+#: signal — a vendor renames body copy far more often than it renames a header.
+#:
+#: Every one of these was captured live on 2026-09-12 through this package's own
+#: pinned request path, not copied from memory:
+#:
+#: - ``cf-mitigated: challenge`` verbatim on ``https://medium.com/`` (403, 5,507
+#:   bytes). Cloudflare sets it SPECIFICALLY so a non-browser client can tell a
+#:   challenge apart from a real 403, which makes it the most stable marker we
+#:   have — and the reason it is checked before any body string.
+#: - ``server: AkamaiGHost`` verbatim on
+#:   ``https://www.shoppersdrugmart.ca/?lang=en&query=power+bar`` (403, 382
+#:   bytes) and on ``canadiantire.ca``.
+#: - ``x-datadome`` / ``datadome=`` cookie: DataDome's own documented markers.
+#: - ``x-iinfo``: Imperva/Incapsula's request-trace header.
+_HEADER_MARKERS: tuple[tuple[BlockVendor, str, str], ...] = (
+    ("cloudflare", "cf-mitigated", "challenge"),
+    ("akamai", "server", "akamaighost"),
+    ("datadome", "x-datadome", ""),
+    ("datadome", "x-dd-b", ""),
+    ("datadome", "set-cookie", "datadome="),
+    ("perimeterx", "set-cookie", "_px"),
+    ("imperva", "server", "imperva"),
+    ("imperva", "x-iinfo", ""),
+)
+
+#: Body signatures, used only when no header matched. Lower confidence by
+#: construction, which is why they come second and why each is a string a
+#: challenge page carries and an ordinary page does not.
+_BODY_MARKERS: tuple[tuple[BlockVendor, str], ...] = (
+    ("cloudflare", "<title>just a moment..."),
+    ("cloudflare", "attention required! | cloudflare"),
+    ("cloudflare", "challenges.cloudflare.com"),
+    ("akamai", "errors.edgesuite.net"),
+    ("datadome", "captcha-delivery.com"),
+    ("perimeterx", "px-captcha"),
+    ("perimeterx", "perimeterx.net"),
+    ("perimeterx", "_pxhd"),
+)
+
+#: The Akamai stock page: ``<TITLE>Access Denied</TITLE>`` plus ``<H1>Access
+#: Denied</H1>``. Checked as a PAIR, and only on a small body, because "access
+#: denied" alone is ordinary prose on a real page (§8 risk 6).
+_ACCESS_DENIED_TITLE = re.compile(r"<title>\s*access denied\s*</title>", re.I)
+_ACCESS_DENIED_HEADING = re.compile(r"<h1>\s*access denied\s*</h1>", re.I)
+
+#: A generic WAF stock page is short. 2 KB is the ceiling below which "access
+#: denied" with no other content is a refusal rather than an article about one.
+_STOCK_PAGE_MAX_BYTES = 2048
+
+#: Akamai's ``Reference #18.47182117.1789248907.62349a41`` — the piece a human
+#: support agent asks for, and the one durable fact on an otherwise useless
+#: page. Akamai HTML-escapes the punctuation (``Reference&#32;&#35;18&#46;…``),
+#: so the body is unescaped before this runs or the id never matches.
+_REFERENCE_RE = re.compile(r"reference\s*#\s*([0-9a-z.\-]+)", re.I)
+#: The edgesuite URL carries the same id and appears even when the ``Reference``
+#: line is worded differently; used as the fallback.
+_EDGESUITE_RE = re.compile(r"errors\.edgesuite\.net/([0-9a-z.\-]+)", re.I)
+
+
+@dataclass(frozen=True)
+class FetchFailure:
+    """One classified failure. Frozen because it is shared across the retry loop,
+    the render step and the tool text, and none of them may edit it.
+
+    ``retryable`` means "another attempt WITH THE SAME REQUEST IDENTITY could
+    plausibly succeed" — it is not the same question as "is an escalation worth
+    it" (:attr:`escalatable`). A ``blocked`` response is emphatically not
+    retryable: the origin has made a decision about this client and repeating
+    the request unchanged just spends the user's turn.
+    """
+
+    kind: FailureKind
+    retryable: bool
+    vendor: BlockVendor | None = None
+    reference: str | None = None
+    detail: str = ""
+    status: int | None = None
+    retry_after_s: float | None = None
+
+    @property
+    def escalatable(self) -> bool:
+        """Whether a browser-shaped retry (§4) is the right next attempt.
+
+        ``blocked`` is the obvious case. ``stall`` is the measured one: on
+        ``canadiantire.ca`` the honest profile never gets headers back (read
+        timeout at 20 s) while a browser-shaped profile gets a 403 in
+        0.07-0.25 s — so a stall is frequently a SILENT block, and the remedy is
+        the same escalation rather than more waiting.
+        """
+        return self.kind in ("blocked", "stall")
+
+
+def classify_exception(exc: BaseException, *, timeout_s: float | None = None) -> FetchFailure:
+    """Classify a transport-level throw into a failure class.
+
+    ``timeout_s`` is the budget the attempt was given, carried into the detail
+    text so the message can say *how long* it waited. That number is the caller's
+    to know: httpx does not put it on the exception, and
+    ``httpx.ReadTimeout.__str__()`` is the EMPTY STRING, which is precisely how
+    the shipped error message came to read ``timed out fetching '<url>': `` with
+    nothing after the colon.
+    """
+    waited = f" after {timeout_s:.1f}s" if timeout_s else ""
+    if isinstance(exc, (httpx.ReadTimeout, httpx.WriteTimeout)):
+        return FetchFailure(
+            kind="stall",
+            retryable=False,  # an escalation, not a repeat of the same request
+            detail=(
+                f"read timed out{waited} — the origin accepted the connection but "
+                "never sent a response"
+            ),
+        )
+    if isinstance(exc, httpx.ConnectTimeout):
+        return FetchFailure(
+            kind="transport",
+            retryable=True,
+            detail=(
+                f"could not open a connection{waited} — the origin never completed " "the handshake"
+            ),
+        )
+    if isinstance(exc, httpx.PoolTimeout):
+        return FetchFailure(
+            kind="transport",
+            retryable=True,
+            detail=f"timed out waiting for a free connection{waited}",
+        )
+    if isinstance(exc, httpx.ConnectError):
+        return FetchFailure(
+            kind="transport",
+            retryable=True,
+            detail="the connection was refused or the host could not be reached",
+        )
+    if isinstance(exc, (httpx.ReadError, httpx.WriteError, httpx.RemoteProtocolError)):
+        return FetchFailure(
+            kind="transport",
+            retryable=True,
+            detail="the connection dropped mid-transfer",
+        )
+    if isinstance(exc, httpx.TimeoutException):
+        # A timeout subclass we have not enumerated: treat it as a stall, which
+        # is the conservative reading (one escalation, no blind repeat).
+        return FetchFailure(kind="stall", retryable=False, detail=f"the request timed out{waited}")
+    # Any other httpx.HTTPError. Retryable because the alternatives — a DNS or
+    # SSRF refusal — never reach here: those raise FetchError before a request
+    # is made.
+    return FetchFailure(
+        kind="transport",
+        retryable=True,
+        detail=f"the transport failed ({type(exc).__name__})",
+    )
+
+
+def _header_value(headers: Mapping[str, str], name: str) -> str:
+    """Case-insensitive header read. Headers arrive lower-cased from the engine,
+    but this module is also called directly from tests with whatever a capture
+    happened to carry."""
+    if name in headers:
+        return headers[name]
+    for key, value in headers.items():
+        if key.lower() == name:
+            return value
+    return ""
+
+
+def detect_vendor(headers: Mapping[str, str], body_head: str) -> BlockVendor | None:
+    """Name the anti-bot vendor behind a refusal, or ``None`` when unsigned.
+
+    Headers first, body second — see the module docstring. ``None`` is a real
+    answer here, not a failure to classify: it is what keeps an unbranded 403
+    from being described as bot protection (§2.2).
+    """
+    for vendor, header, needle in _HEADER_MARKERS:
+        value = _header_value(headers, header)
+        if not value:
+            continue
+        if not needle or needle in value.lower():
+            return vendor
+    lowered = body_head.lower()
+    for vendor, needle in _BODY_MARKERS:
+        if needle in lowered:
+            return vendor
+    return None
+
+
+def _is_stock_block_page(body_head: str) -> bool:
+    """The long tail of WAF stock pages: a tiny body that is an ``Access
+    Denied`` title AND heading and essentially nothing else.
+
+    Both halves are required, and so is the size bound: a real article that
+    quotes "Access Denied" in its text must not be classified as a block, and
+    an article is never 2 KB of nothing but that phrase twice.
+    """
+    if len(body_head) > _STOCK_PAGE_MAX_BYTES:
+        return False
+    return bool(_ACCESS_DENIED_TITLE.search(body_head)) and bool(
+        _ACCESS_DENIED_HEADING.search(body_head)
+    )
+
+
+def extract_reference(body_head: str, headers: Mapping[str, str]) -> str | None:
+    """The origin's own reference for this refusal, or ``None``.
+
+    This is the single piece of a block page worth keeping: ``Reference
+    #18.47182117.…`` is what a human quotes to the site's support desk, and
+    Cloudflare's ``cf-ray`` plays the same role. Everything else on the page is
+    markup whose purpose is to be executed by a browser.
+
+    The body is HTML-unescaped first because Akamai emits the id as
+    ``Reference&#32;&#35;18&#46;44182117&#46;…`` — verified on a live capture,
+    and the reason a naive regex over the raw bytes finds nothing.
+    """
+    unescaped = html.unescape(body_head)
+    match = _REFERENCE_RE.search(unescaped) or _EDGESUITE_RE.search(unescaped)
+    if match:
+        return match.group(1).strip(".")
+    ray = _header_value(headers, "cf-ray")
+    return ray.strip() or None
+
+
+def parse_retry_after(value: str) -> float | None:
+    """``Retry-After`` as seconds, or ``None`` when absent/unparseable.
+
+    Both wire forms are accepted: delta-seconds (the common one) and the
+    HTTP-date form, which CDNs do emit. A zero or negative value returns
+    ``None`` so the caller falls back to its normal backoff rather than
+    treating "retry immediately" as a hostile instruction to hammer the origin.
+    """
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except ValueError:
+        try:
+            when = parsedate_to_datetime(raw)
+        except (TypeError, ValueError):
+            return None
+        if when is None:
+            return None
+        import datetime as _dt
+
+        now = _dt.datetime.now(_dt.timezone.utc)
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=_dt.timezone.utc)
+        seconds = (when - now).total_seconds()
+    return seconds if seconds > 0 else None
+
+
+def classify_response(
+    status: int, headers: Mapping[str, str], body_head: str
+) -> FetchFailure | None:
+    """Classify a RESPONSE, or return ``None`` for a 2xx/3xx.
+
+    ``body_head`` must already be bounded to :data:`MARKER_SCAN_BYTES`; this
+    function does not re-bound it, so passing a whole 5 MB body would defeat the
+    scan window the false-positive guard rests on.
+    """
+    if status < 400:
+        return None
+
+    retry_after = parse_retry_after(_header_value(headers, "retry-after"))
+
+    if status in _BLOCKABLE_STATUSES:
+        vendor = detect_vendor(headers, body_head)
+        if vendor is not None or (status == 403 and _is_stock_block_page(body_head)):
+            return FetchFailure(
+                kind="blocked",
+                retryable=False,
+                vendor=vendor,
+                reference=extract_reference(body_head, headers),
+                status=status,
+            )
+        if status == 403:
+            # An UNMATCHED 403 still earns the escalation (a plain WAF with no
+            # branding is common and the extra request is cheap), but carries no
+            # vendor — so `describe` cannot claim bot protection it did not see.
+            return FetchFailure(kind="blocked", retryable=False, status=status)
+
+    if status == 429:
+        return FetchFailure(
+            kind="ratelimit", retryable=True, status=status, retry_after_s=retry_after
+        )
+    if status in (500, 502, 503, 504):
+        return FetchFailure(kind="server", retryable=True, status=status, retry_after_s=retry_after)
+    if 500 <= status < 600:
+        return FetchFailure(kind="server", retryable=True, status=status, retry_after_s=retry_after)
+    # Every other 4xx: a 404 will not become a 200, and a 451 will not become
+    # legal. Retrying spends the user's turn for nothing.
+    return FetchFailure(kind="client", retryable=False, status=status)
+
+
+#: The escalation sentence. Named as a NEXT STEP rather than performed:
+#: ``web_fetch`` is read-tier and ``browser`` is write-tier, so driving the
+#: real browser from inside a fetch would launder an approval-gated action
+#: through an auto-approved call (design §8.1). The agent takes this step
+#: itself, through the tool's own approval prompt.
+#:
+#: Pre-wrapped, and that is deliberate rather than cosmetic: the TUI card paints
+#: one body row per LINE and truncates the overflow with an ellipsis (visible on
+#: any long row, not a regression this text introduced), so a single 150-column
+#: sentence would lose its own point — the name of the tool to use — off the
+#: right edge. Each line here fits a standard card width, so the human reading
+#: the card sees the whole instruction and the model reads ordinary prose.
+_BROWSER_NEXT_STEP = (
+    "Next step: use the `browser` tool on this URL. It drives the real\n"
+    "browser (a write-tier, approval-gated action), which is the only\n"
+    "path that clears an interactive challenge."
+)
+
+#: Vendor label for prose. Kept separate from the enum so the enum stays a
+#: machine key (it rides in ``details["block_vendor"]``) and the prose can be
+#: capitalised without the two drifting.
+_VENDOR_LABELS: dict[str, str] = {
+    "cloudflare": "Cloudflare",
+    "akamai": "Akamai",
+    "datadome": "DataDome",
+    "perimeterx": "PerimeterX/HUMAN",
+    "imperva": "Imperva",
+}
+
+
+def vendor_label(vendor: str | None) -> str | None:
+    """The prose form of a vendor key (``akamai`` → ``Akamai``), or ``None``.
+
+    ``None`` in, ``None`` out, on purpose: the caller's "no signature" case must
+    stay distinguishable rather than degrading to a label that reads like a
+    detection (§2.2).
+    """
+    if not vendor:
+        return None
+    return _VENDOR_LABELS.get(vendor, vendor)
+
+
+def block_lead(failure: FetchFailure) -> str:
+    """The one-line reason that leads a blocked result's header.
+
+    Two shapes, and the difference is the whole point (§2.2): a SIGNED refusal
+    names the vendor and says "bot protection"; an unsigned one says only that
+    the origin refused, and explicitly raises the possibility that this is an
+    access restriction. The word "bot" never appears in the unsigned form.
+    """
+    if failure.vendor is not None:
+        label = _VENDOR_LABELS.get(failure.vendor, failure.vendor)
+        return f"blocked by {label} bot protection, not page content"
+    return "the origin refused this request"
+
+
+def describe(
+    failure: FetchFailure,
+    *,
+    attempts: int = 1,
+    profiles: Sequence[str] = (),
+    url: str | None = None,
+) -> str:
+    """The model-facing explanation for ``failure``.
+
+    The ONE place these sentences live, so the tool preview, the CLI and the
+    card cannot drift. It is built entirely from the classification — never from
+    ``str(exc)``, which for ``httpx.ReadTimeout`` is the empty string — so the
+    text can never be empty and never ends in a dangling colon.
+
+    ``profiles`` is the identity each attempt used, in order, so the reader can
+    tell "we asked three times and it kept failing" from "we asked twice, the
+    second time wearing a browser's headers, and it still refused" — which are
+    different facts with different next steps.
+    """
+    lines: list[str] = []
+    used_browser = "browser" in tuple(profiles)
+
+    if failure.kind == "blocked":
+        # Wrapped to card width for the reason given on ``_BROWSER_NEXT_STEP``.
+        if failure.vendor is not None:
+            first = "The origin's bot protection refused this request."
+            if used_browser:
+                first += (
+                    " A browser-shaped retry was\nalso refused, so no headless "
+                    "fetch of this URL will succeed."
+                )
+        else:
+            # No signature: state the refusal and the ambiguity, and let the
+            # agent decide between `browser` and asking the user for access.
+            first = (
+                "The origin refused this request. No anti-bot vendor\n"
+                "signature was found, so this may be an access restriction\n"
+                "(login, region, or policy) rather than bot protection."
+            )
+            if used_browser:
+                first += "\nA browser-shaped retry was refused the same way."
+        lines.append(first)
+        if failure.reference:
+            lines.append(f"Origin reference: {failure.reference}")
+        lines.append(_BROWSER_NEXT_STEP)
+    elif failure.kind == "stall":
+        lines.append(_with_attempts(failure.detail or "the request timed out", attempts, profiles))
+        if used_browser:
+            lines.append(
+                "A browser-shaped retry was tried as well, since a stalled\n"
+                "request is frequently a silent block."
+            )
+            lines.append(_BROWSER_NEXT_STEP)
+    elif failure.kind == "transport":
+        lines.append(_with_attempts(failure.detail or "the transport failed", attempts, profiles))
+    elif failure.kind == "ratelimit":
+        text = "the origin is rate-limiting this client (HTTP 429)"
+        if failure.retry_after_s:
+            text += f" and asked us to wait {failure.retry_after_s:.0f}s"
+        lines.append(_with_attempts(text, attempts, profiles))
+        if failure.retry_after_s:
+            lines.append(
+                "Retry after that interval rather than immediately; the wait\n"
+                "was not spent inside this call."
+            )
+    elif failure.kind == "server":
+        status = failure.status or 500
+        lines.append(_with_attempts(f"the origin returned HTTP {status}", attempts, profiles))
+    else:
+        status = failure.status or 400
+        lines.append(f"the origin returned HTTP {status}")
+
+    if url:
+        lines.append(url)
+    return "\n".join(lines)
+
+
+def _with_attempts(text: str, attempts: int, profiles: Sequence[str]) -> str:
+    """Append the attempt count and the identities used, when there was more
+    than one. A single attempt says nothing — the count only carries
+    information once it is not 1."""
+    if attempts <= 1:
+        return text
+    names = ", ".join(_profile_label(p) for p in profiles) if profiles else ""
+    suffix = f" ({attempts} attempts: {names})" if names else f" ({attempts} attempts)"
+    return text + suffix
+
+
+def _profile_label(profile: str) -> str:
+    return "browser-profile" if profile == "browser" else profile
+
+
+def attempt_summary(attempts: int, profiles: Sequence[str]) -> str:
+    """``2 attempts (default, browser-profile)`` for the header's meta line, or
+    ``""`` when a single attempt makes the count uninformative."""
+    if attempts <= 1:
+        return ""
+    if profiles:
+        names = ", ".join(_profile_label(p) for p in profiles)
+        return f"{attempts} attempts ({names})"
+    return f"{attempts} attempts"

--- a/local_operator/web_fetch/failure.py
+++ b/local_operator/web_fetch/failure.py
@@ -141,11 +141,21 @@ class FetchFailure:
     def escalatable(self) -> bool:
         """Whether a browser-shaped retry (§4) is the right next attempt.
 
-        ``blocked`` is the obvious case. ``stall`` is the measured one: on
-        ``canadiantire.ca`` the honest profile never gets headers back (read
-        timeout at 20 s) while a browser-shaped profile gets a 403 in
-        0.07-0.25 s — so a stall is frequently a SILENT block, and the remedy is
-        the same escalation rather than more waiting.
+        ``blocked`` is the obvious case, and the one the measured win rests on:
+        the origin answered FAST (a 403), so almost the whole call budget is
+        still unspent when the probe runs, and on medium.com that probe gets 200
+        and 53 KB of the real page.
+
+        ``stall`` is subtler now, and worth stating plainly. A read timeout
+        consumes the WHOLE slice it was granted, so a genuine black-hole spends
+        the call's budget on the first, honest attempt and there is nothing left
+        to fund a probe — which is the intended behaviour, not a gap: the probe
+        would have to be paid for out of a budget the origin already burned, and
+        capping the first attempt to reserve it is exactly the change that was
+        reverted (see the note at the top of ``service.py``). The escalation is
+        therefore OPPORTUNISTIC: it runs whenever a stall left budget behind,
+        which happens when the stall was truncated by a later hop's short
+        remainder rather than by the full call timeout.
         """
         return self.kind in ("blocked", "stall")
 
@@ -249,8 +259,14 @@ def _is_stock_block_page(body_head: str) -> bool:
     Both halves are required, and so is the size bound: a real article that
     quotes "Access Denied" in its text must not be classified as a block, and
     an article is never 2 KB of nothing but that phrase twice.
+
+    The bound is compared against the ENCODED length because ``body_head`` is
+    decoded text, and a character count over a str is not the "2 KB" the
+    constant claims: the same 2 048 characters can be up to ~8 KB of UTF-8 on the
+    wire. The unit in the name is the unit the comparison must use, or a reader
+    tunes this against the wrong quantity.
     """
-    if len(body_head) > _STOCK_PAGE_MAX_BYTES:
+    if len(body_head.encode("utf-8", errors="replace")) > _STOCK_PAGE_MAX_BYTES:
         return False
     return bool(_ACCESS_DENIED_TITLE.search(body_head)) and bool(
         _ACCESS_DENIED_HEADING.search(body_head)
@@ -355,16 +371,16 @@ def classify_response(
 #: through an auto-approved call (design §8.1). The agent takes this step
 #: itself, through the tool's own approval prompt.
 #:
-#: Pre-wrapped, and that is deliberate rather than cosmetic: the TUI card paints
-#: one body row per LINE and truncates the overflow with an ellipsis (visible on
-#: any long row, not a regression this text introduced), so a single 150-column
-#: sentence would lose its own point — the name of the tool to use — off the
-#: right edge. Each line here fits a standard card width, so the human reading
-#: the card sees the whole instruction and the model reads ordinary prose.
+#: A single unwrapped sentence on purpose. It used to be hard-wrapped to 76
+#: cells "so a 150-column sentence would not lose its own point off the right
+#: edge" — but the wrap was the thing losing it: at 80 columns the 76-cell line
+#: was clipped mid-word by the card's own painter, and at 150 the block stopped
+#: half-way across. The card now fits these lines to its real width at paint
+#: time (``tool_card.py::_append_fetch_body``), which is right at every width.
 _BROWSER_NEXT_STEP = (
-    "Next step: use the `browser` tool on this URL. It drives the real\n"
-    "browser (a write-tier, approval-gated action), which is the only\n"
-    "path that clears an interactive challenge."
+    "Next step: use the `browser` tool on this URL. It drives the real browser "
+    "(a write-tier, approval-gated action), which is the only path that clears "
+    "an interactive challenge."
 )
 
 #: Vendor label for prose. Kept separate from the enum so the enum stays a
@@ -391,18 +407,54 @@ def vendor_label(vendor: str | None) -> str | None:
     return _VENDOR_LABELS.get(vendor, vendor)
 
 
-def block_lead(failure: FetchFailure) -> str:
-    """The one-line reason that leads a blocked result's header.
+def block_lead(vendor: str | None) -> str:
+    """The one line that states WHY a refusal happened, shared by every surface.
+
+    This is the single source for a sentence that otherwise exists three times —
+    the tool preview's warning lead (``tool.py``), the TUI card's danger row, and
+    the tests that assert both. It took a review round to notice that the copy had
+    already drifted between two of those copies, which is the whole argument for
+    not hand-rolling it a third time.
 
     Two shapes, and the difference is the whole point (§2.2): a SIGNED refusal
     names the vendor and says "bot protection"; an unsigned one says only that
     the origin refused, and explicitly raises the possibility that this is an
-    access restriction. The word "bot" never appears in the unsigned form.
+    access restriction. The unsigned form never claims a bot wall — claiming one
+    on a 403 that really means "you are not a subscriber" would send the agent to
+    ``browser`` when it should be asking the user for credentials.
+
+    Takes the VENDOR rather than a :class:`FetchFailure` because both callers
+    hold the vendor (from ``details["block_vendor"]``) and not the classification
+    — the tool and the card rebuild their text from the persisted ``details``
+    shape, which is what lets a stored transcript render a year later.
     """
-    if failure.vendor is not None:
-        label = _VENDOR_LABELS.get(failure.vendor, failure.vendor)
+    label = vendor_label(vendor)
+    if label:
         return f"blocked by {label} bot protection, not page content"
-    return "the origin refused this request"
+    return (
+        "the origin refused this request, which may be bot protection or an " "access restriction"
+    )
+
+
+#: The §3.4 sentence for a ``Retry-After`` the call would not sleep on. Named
+#: because BOTH surfaces need it and they disagree about nothing: the model-facing
+#: text for a response-bearing 429 is built by ``tool.py::_header_line`` (never by
+#: :func:`describe`, which needs a failure with no response), so a single shared
+#: sentence is the only way the number reaches the agent in both shapes.
+#:
+#: `describe` says the same thing in its own words for the terminal case; this is
+#: the response-bearing one.
+def retry_after_note(retry_after_s: float) -> str:
+    """``The origin asked us to wait 600s before retrying; …``
+
+    The number is the one the call already returned in ``details``. Stating it in
+    the text is what makes §3.4's "do not sleep, tell the agent" useful rather
+    than a silent one-attempt stop.
+    """
+    return (
+        f"The origin asked us to wait {retry_after_s:.0f}s before retrying; the "
+        "wait was not spent inside this call."
+    )
 
 
 def describe(
@@ -423,29 +475,37 @@ def describe(
     tell "we asked three times and it kept failing" from "we asked twice, the
     second time wearing a browser's headers, and it still refused" — which are
     different facts with different next steps.
+
+    **The prose is deliberately NOT pre-wrapped.** It used to be hand-wrapped to
+    76 cells, which is a width that is wrong at 80 columns (the sentence was cut
+    mid-word) and wrong at 150 (the block stopped half-way across the card) — and
+    a constant cannot be right at both. The TUI card re-wraps these lines to the
+    card's own width at paint time (``tool_card.py::_append_fetch_body``), so the
+    text is a paragraph here and a fitted block on screen. One consequence worth
+    naming: the model-facing preview now carries long lines rather than 76-cell
+    ones, which costs no tokens and loses no characters.
     """
     lines: list[str] = []
     used_browser = "browser" in tuple(profiles)
 
     if failure.kind == "blocked":
-        # Wrapped to card width for the reason given on ``_BROWSER_NEXT_STEP``.
         if failure.vendor is not None:
             first = "The origin's bot protection refused this request."
             if used_browser:
                 first += (
-                    " A browser-shaped retry was\nalso refused, so no headless "
+                    " A browser-shaped retry was also refused, so no headless "
                     "fetch of this URL will succeed."
                 )
         else:
             # No signature: state the refusal and the ambiguity, and let the
             # agent decide between `browser` and asking the user for access.
             first = (
-                "The origin refused this request. No anti-bot vendor\n"
-                "signature was found, so this may be an access restriction\n"
-                "(login, region, or policy) rather than bot protection."
+                "The origin refused this request. No anti-bot vendor signature was "
+                "found, so this may be an access restriction (login, region, or "
+                "policy) rather than bot protection."
             )
             if used_browser:
-                first += "\nA browser-shaped retry was refused the same way."
+                first += " A browser-shaped retry was refused the same way."
         lines.append(first)
         if failure.reference:
             lines.append(f"Origin reference: {failure.reference}")
@@ -454,8 +514,8 @@ def describe(
         lines.append(_with_attempts(failure.detail or "the request timed out", attempts, profiles))
         if used_browser:
             lines.append(
-                "A browser-shaped retry was tried as well, since a stalled\n"
-                "request is frequently a silent block."
+                "A browser-shaped retry was tried as well, since a stalled request "
+                "is frequently a silent block."
             )
             lines.append(_BROWSER_NEXT_STEP)
     elif failure.kind == "transport":
@@ -466,10 +526,7 @@ def describe(
             text += f" and asked us to wait {failure.retry_after_s:.0f}s"
         lines.append(_with_attempts(text, attempts, profiles))
         if failure.retry_after_s:
-            lines.append(
-                "Retry after that interval rather than immediately; the wait\n"
-                "was not spent inside this call."
-            )
+            lines.append(retry_after_note(failure.retry_after_s))
     elif failure.kind == "server":
         status = failure.status or 500
         lines.append(_with_attempts(f"the origin returned HTTP {status}", attempts, profiles))
@@ -479,6 +536,14 @@ def describe(
 
     if url:
         lines.append(url)
+    # Sentence case on the lead, uniformly. These sentences were written to be
+    # CHAINED after the tool's own error prefix, so they opened lowercase — but a
+    # card paints this text as its own body, where the first line is read with
+    # nothing in front of it and a lowercase opening reads as a fragment (design
+    # review round 1, DN3). Doing it once here rather than per-branch keeps every
+    # terminal class in one voice.
+    if lines and lines[0][:1].islower():
+        lines[0] = lines[0][:1].upper() + lines[0][1:]
     return "\n".join(lines)
 
 
@@ -488,7 +553,7 @@ def _with_attempts(text: str, attempts: int, profiles: Sequence[str]) -> str:
     information once it is not 1."""
     if attempts <= 1:
         return text
-    names = ", ".join(_profile_label(p) for p in profiles) if profiles else ""
+    names = ", ".join(_profile_label(p) for p in _collapsed(profiles)) if profiles else ""
     suffix = f" ({attempts} attempts: {names})" if names else f" ({attempts} attempts)"
     return text + suffix
 
@@ -497,12 +562,27 @@ def _profile_label(profile: str) -> str:
     return "browser-profile" if profile == "browser" else profile
 
 
+def _collapsed(profiles: Sequence[str]) -> list[str]:
+    """Consecutive duplicate identities collapsed to one.
+
+    ``2 attempts (default, default)`` is accurate and reads like a bug: the
+    sequence exists to show a CHANGE of identity, and repeating the only identity
+    there was adds nothing to it. ``(default, browser-profile)`` — the shape that
+    matters — is untouched, because those two entries differ.
+    """
+    out: list[str] = []
+    for profile in profiles:
+        if not out or out[-1] != profile:
+            out.append(profile)
+    return out
+
+
 def attempt_summary(attempts: int, profiles: Sequence[str]) -> str:
     """``2 attempts (default, browser-profile)`` for the header's meta line, or
     ``""`` when a single attempt makes the count uninformative."""
     if attempts <= 1:
         return ""
     if profiles:
-        names = ", ".join(_profile_label(p) for p in profiles)
+        names = ", ".join(_profile_label(p) for p in _collapsed(profiles))
         return f"{attempts} attempts ({names})"
     return f"{attempts} attempts"

--- a/local_operator/web_fetch/models.py
+++ b/local_operator/web_fetch/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 #: How the body was turned into text. Surfaced in ``details`` and the card so a
 #: reader can tell a good markdown render from the degraded stdlib fallback or a
@@ -51,6 +51,27 @@ class FetchResult(BaseModel):
     low_quality: bool = False
     cache: Literal["hit", "miss"] = "miss"
 
+    # --- retry / block diagnostics (all defaulted: every existing construction
+    # site stays valid, and a cached entry written by an older lop reads back
+    # with these absent rather than failing validation).
+    #
+    # These exist because a failed fetch used to tell the agent only THAT it
+    # failed. `attempts` explains a longer duration, `failure_kind` says whether
+    # another try could help, and the block fields say who refused and what to
+    # quote to them. They ride in `details`, which never reaches the provider,
+    # so they cost no tokens.
+    attempts: int = 1  # network attempts spent; 0 on a cache hit (none were)
+    failure_kind: str | None = None  # FailureKind, absent on success
+    block_vendor: str | None = None  # None on an UNSIGNED refusal — never guessed
+    block_reference: str | None = None  # the origin's own reference / cf-ray
+    profile: str = "default"  # request identity that produced this outcome
+    # Identity used by each attempt, in order. Carried as a sequence rather than
+    # derived from `profile` + `attempts` because "three tries, all honest" and
+    # "two tries, the second wearing a browser's headers" are different facts and
+    # only the sequence distinguishes them.
+    profiles: list[str] = Field(default_factory=lambda: ["default"])
+    retry_after_s: float | None = None  # honoured or reported Retry-After
+
 
 class WebFetchSettings(BaseModel):
     """Validated view of the loose ``values.web_fetch`` YAML mapping."""
@@ -63,6 +84,17 @@ class WebFetchSettings(BaseModel):
     allow_private: bool = False  # SSRF: allow loopback/private/link-local targets
     render_backend: RenderBackend = "auto"  # auto = markdownify if [fetch] present
     enrich: bool = True  # try .md / llms.txt / content-negotiation before scraping HTML
+    # Network attempts per redirect hop, INCLUDING the first. 1 reproduces the
+    # pre-retry behaviour exactly. 3 is where added coverage stops paying for
+    # added wall-clock: the value of a retry is concentrated in the first one,
+    # and this tool runs inside a live turn the user is watching.
+    max_attempts: int = 3
+    # One browser-shaped attempt after the origin has already refused an honest,
+    # self-identifying request. Default on because the measured win is real
+    # (medium.com: 403 with the lop UA, 200 with the browser profile, 3/3) and
+    # the cost is one request on an already-failed fetch. Off is for an operator
+    # who wants the client to stay honest even in the face of a refusal.
+    blocked_retry: bool = True
 
 
 DEFAULT_WEB_FETCH_CONFIG: dict[str, object] = {
@@ -74,4 +106,6 @@ DEFAULT_WEB_FETCH_CONFIG: dict[str, object] = {
     "allow_private": False,
     "render_backend": "auto",
     "enrich": True,
+    "max_attempts": 3,
+    "blocked_retry": True,
 }

--- a/local_operator/web_fetch/service.py
+++ b/local_operator/web_fetch/service.py
@@ -27,7 +27,7 @@ import json
 import random
 import socket
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypedDict
@@ -131,19 +131,26 @@ _RETRY_MIN_MARGIN_S = 0.25
 #: back later, and the agent can act on the number.
 _RETRY_AFTER_MAX_SLEEP_S = 10.0
 
-#: Fraction of the whole-call budget the FIRST attempt of a hop may spend when a
-#: fallback attempt is still available. This is what turns the canadiantire case
-#: from "20 s then nothing" into "12 s then a browser-shaped probe that answers
-#: in ~0.25 s": a page that has sent no headers in 12 s is overwhelmingly more
-#: likely to be black-holed than slow.
+#: NOTE on attempt budgeting — deliberately absent, and the reasoning is a
+#: decision recorded in ``docs/design/web_fetch_robustness.md`` §3.3.
 #:
-#: A judgement call, not a measurement — the evidence that would tune it is the
-#: distribution of time-to-first-byte on genuinely slow-but-working origins,
-#: which we do not have. Deliberately NOT configurable (another knob nobody
-#: tunes). It applies only while a fallback attempt remains: the LAST attempt
-#: always gets the full remaining budget, so a genuinely slow origin is never
-#: penalised on its final try.
-_STALL_FIRST_ATTEMPT_FRACTION = 0.6
+#: An earlier revision of this change capped the first attempt of a hop at
+#: ``0.6 * timeout`` while a fallback remained, to leave the browser-shaped
+#: probe something to spend on a black-holing origin. That cap silently turned a
+#: slow-but-working origin into a failure: ``httpx``'s read timeout bounds the
+#: wait for response HEADERS too, so an origin whose time-to-first-byte exceeds
+#: 0.6·T (12 s of the default 20 s) was cut off on its first, honest attempt and
+#: then handed a browser-profile retry that had 0.4·T left — reported to the
+#: model as a "silent block" naming a vendor we never saw. Re-measured against
+#: the same fake-clock harness that found it: a 13 s-first-byte origin succeeds
+#: on the pre-change engine and failed as ``stall`` under the cap.
+#:
+#: So there is no first-attempt cap: **every attempt gets the full remaining
+#: budget**, and the escalation is opportunistic — funded only by whatever the
+#: hop's own outcome left behind. A fast refusal (403) still leaves ~all of T for
+#: the probe, which is where the measured win lives; a stall that consumes the
+#: budget simply reports a classified, readable terminal message instead of
+#: pretending to have diagnosed a vendor it never reached.
 
 #: Connect is capped independently of read: a handshake that has not completed
 #: in 5 s is not going to, and spending the whole budget on it would leave
@@ -187,11 +194,28 @@ class FetchError(Exception):
     throw), and is ``None`` for the policy refusals that never reach the network
     — an SSRF refusal is not a "failure class", it is the guard working. It is
     ADDITIVE: every existing ``str(error)`` call site keeps working unchanged.
+
+    ``attempts``/``profiles`` carry the same retry facts the message already
+    states in prose, so a caller that builds ``details`` from the exception does
+    not have to parse the sentence to find out how many requests were spent. The
+    pair is why the terminal path's ``details`` can finally agree with its own
+    preview text (design §5.3: ``attempts`` is a key, excluded only for a cache
+    hit) — before this the model read "2 attempts" while the structured payload
+    said nothing.
     """
 
-    def __init__(self, message: str, *, failure: FetchFailure | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure: FetchFailure | None = None,
+        attempts: int = 0,
+        profiles: Sequence[str] = (),
+    ) -> None:
         super().__init__(message)
         self.failure = failure
+        self.attempts = attempts
+        self.profiles = list(profiles)
 
 
 def coerce_fetch_settings(raw: object) -> WebFetchSettings:
@@ -597,23 +621,6 @@ class _Budget:
     def remaining(self) -> float:
         return self.deadline - _now()
 
-    def attempt_timeout(self, remaining: float, *, first: bool, has_fallback: bool) -> float:
-        """How long THIS attempt may take.
-
-        The first attempt of a hop is capped at a fraction of the budget while a
-        fallback attempt remains, because a page that has sent no headers in
-        12 s of a 20 s budget is overwhelmingly more likely to be black-holed by
-        an anti-bot layer than merely slow — and the browser-shaped probe that
-        follows answers in ~0.25 s on the hosts where that is true.
-
-        The LAST attempt always gets the full remaining budget: a genuinely slow
-        origin must never be penalised on its final try, which is what keeps
-        this from becoming a timeout reduction in disguise.
-        """
-        if first and has_fallback:
-            return min(remaining, self.total * _STALL_FIRST_ATTEMPT_FRACTION)
-        return remaining
-
 
 @dataclass
 class _Telemetry:
@@ -643,11 +650,20 @@ def _backoff_delay(attempt: int, retry_after_s: float | None) -> float | None:
     honouring it is both the polite and the effective behaviour — but only while
     it fits inside a live turn. A two-minute wait returns ``None`` so the caller
     reports the number instead of blocking the user on it.
+
+    The honoured interval carries the SAME ±25 % jitter as our own backoff curve
+    (design §3.4), and it matters most here: the tool description invites parallel
+    ``web_fetch`` calls, so several calls refused by one rate-limited origin would
+    otherwise sleep the identical interval and retry in lockstep — the exact burst
+    the jitter exists to spread out. The jitter is applied BEFORE the cap is
+    consulted so a value nudged over ``_RETRY_AFTER_MAX_SLEEP_S`` is reported
+    rather than slept.
     """
     if retry_after_s is not None:
-        if retry_after_s > _RETRY_AFTER_MAX_SLEEP_S:
+        delay = retry_after_s * (1 + random.uniform(-_RETRY_JITTER, _RETRY_JITTER))
+        if retry_after_s > _RETRY_AFTER_MAX_SLEEP_S or delay > _RETRY_AFTER_MAX_SLEEP_S:
             return None
-        return retry_after_s
+        return delay
     delay = min(_RETRY_BASE_S * (2 ** (attempt - 1)), _RETRY_CAP_S)
     return delay * (1 + random.uniform(-_RETRY_JITTER, _RETRY_JITTER))
 
@@ -874,6 +890,8 @@ class WebFetchService:
                 url=url,
             ),
             failure=failure,
+            attempts=telemetry.attempts,
+            profiles=telemetry.profiles,
         )
 
     async def _attempt_series(
@@ -909,17 +927,22 @@ class WebFetchService:
                     )
                 break
 
-            attempt_timeout = budget.attempt_timeout(
-                remaining,
-                first=attempt == 1,
-                has_fallback=attempt < max_attempts or budget.escalation_available,
-            )
+            # EVERY attempt gets the full remaining budget — including the first
+            # one. There used to be a `min(remaining, 0.6 * total)` cap here for
+            # the first attempt of a hop; it turned a slow-but-working origin into
+            # a failure, and the reasoning for its removal is at the top of this
+            # module. The escalation is opportunistic: it is funded by whatever
+            # the hop's own outcome left behind, so a refusal still leaves
+            # ~all of T for the browser-shaped probe while a stall that spends the
+            # budget simply reports the stall. The attempt's timeout is derived
+            # from the budget INSIDE ``_request_once``, after the resolver, which
+            # is what keeps the number honest (see that method).
             telemetry.attempts += 1
             telemetry.profiles.append(profile)
 
             try:
                 status, headers, body, complete = await self._request_once(
-                    owner, url, ceiling, attempt_timeout, budget.total, profile=profile
+                    owner, url, ceiling, budget, profile=profile
                 )
             except FetchError as error:
                 if error.failure is None:
@@ -948,8 +971,12 @@ class WebFetchService:
                     return response, None
 
             telemetry.failure = failure
-            if failure.retry_after_s is not None:
-                telemetry.retry_after_s = failure.retry_after_s
+            # Set UNCONDITIONALLY, including to ``None``: a 429's Retry-After
+            # must not ride into the details of a later, different failure. A
+            # caller reading ``retry_after_s`` is being told what the REPORTED
+            # outcome asked for, and a 503 that named no interval has nothing to
+            # say about the 2 s an earlier attempt was told to wait.
+            telemetry.retry_after_s = failure.retry_after_s
             if not failure.retryable or attempt >= max_attempts:
                 break
 
@@ -969,8 +996,7 @@ class WebFetchService:
         owner: WebReadIO,
         url: str,
         ceiling: int,
-        attempt_timeout: float,
-        pool_timeout: float,
+        budget: _Budget,
         *,
         profile: str,
     ) -> tuple[int, dict[str, str], bytes, bool]:
@@ -982,16 +1008,69 @@ class WebFetchService:
         attempt 2 must be refused on attempt 2, and a retry that reused attempt
         1's vetted address without re-checking would reopen exactly the rebinding
         window the pin exists to close.
+
+        The deadline is the ceiling for the VALIDATION too, not just the request:
+        ``getaddrinfo`` has no timeout of its own in the stdlib, so an unbounded
+        lookup would let a hung resolver push the call past its stated timeout and
+        make the per-attempt timeout computed before it stale. So the lookup runs
+        under ``asyncio.wait_for(remaining)`` and the request's own timeout is
+        recomputed from what is left AFTER it (see ``_attempt_series``).
         """
         # Validate returns the vetted IP to PIN this request's connection to, so
         # httpx cannot re-resolve to a different (internal) address between this
         # check and the socket open (M1). Re-run on EVERY request — every hop,
         # every retry, every enrichment probe, and the escalated attempt.
-        # DNS can block even before HTTP starts, which is why it runs in a
-        # thread.
-        pinned_ip = await asyncio.to_thread(
-            validate_public_url, url, allow_private=self.settings.allow_private
-        )
+        # DNS can block even before HTTP starts, which is why it runs in a thread.
+        #
+        # The abandoned-thread caveat: a timed-out ``to_thread`` cannot be
+        # cancelled, so the worker keeps running until getaddrinfo returns on its
+        # own. That thread cannot extend THIS call (the wait_for is what the call
+        # awaits) — it can only linger in the executor, where the resolver's own
+        # timeout ends it. The guarantee this buys is therefore about the fetch,
+        # not about the thread: no configuration of retries can make the CALL
+        # exceed its stated timeout.
+        resolver_budget = budget.remaining()
+        if resolver_budget <= 0:
+            raise FetchError(
+                f"ran out of time after {budget.total:.1f}s before resolving {url}",
+                failure=FetchFailure(
+                    kind="stall",
+                    retryable=False,
+                    detail=f"ran out of time after {budget.total:.1f}s",
+                ),
+            )
+        try:
+            pinned_ip = await asyncio.wait_for(
+                asyncio.to_thread(
+                    validate_public_url, url, allow_private=self.settings.allow_private
+                ),
+                timeout=resolver_budget,
+            )
+        except asyncio.TimeoutError:
+            # A policy refusal (private host, bad scheme) raises out of the
+            # thread as its own FetchError; only a lookup that never returns lands
+            # here. Classified as ``transport`` so the caller's retry decision is
+            # unchanged, and read as a stall by the model — which is what it is.
+            raise FetchError(
+                f"resolving {url} took longer than the {resolver_budget:.1f}s left "
+                "of this fetch's time budget",
+                failure=FetchFailure(
+                    kind="transport",
+                    retryable=True,
+                    detail=(
+                        "the host name could not be resolved in time — the lookup "
+                        f"did not finish within the {resolver_budget:.1f}s left of "
+                        "the fetch budget"
+                    ),
+                ),
+            ) from None
+        # Recompute against the TRUE remaining time: the lookup above just spent
+        # an unbounded amount of it, and the timeout the caller computed before
+        # that is now stale (it could exceed the deadline by the lookup's
+        # duration). A negative value is clamped to a hair above zero rather than
+        # passed through, so the attempt still costs one fast, classified failure
+        # instead of an httpx ``Timeout`` built from a negative number.
+        attempt_timeout = max(budget.remaining(), 0.001)
         origin = httpx.URL(url)
         async with owner.client(
             # The pool key keeps the CALL's timeout, not the attempt's: the
@@ -1003,12 +1082,12 @@ class WebFetchService:
                 origin.scheme,
                 origin.host,
                 origin.port,
-                pool_timeout,
+                budget.total,
                 id(self.transport),
             ),
             transport=self.transport,
             follow_redirects=False,
-            timeout=pool_timeout,
+            timeout=budget.total,
             headers={"User-Agent": USER_AGENT},
         ) as client:
             extra = BROWSER_PROFILE_HEADERS if profile == "browser" else None

--- a/local_operator/web_fetch/service.py
+++ b/local_operator/web_fetch/service.py
@@ -24,10 +24,13 @@ import asyncio
 import hashlib
 import ipaddress
 import json
+import random
 import socket
+import time
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TypedDict
 from urllib.parse import urljoin, urlparse, urlunparse
 
 import httpx
@@ -35,6 +38,13 @@ from pydantic import ValidationError
 
 from local_operator.config import ConfigManager
 from local_operator.paths import config_dir
+from local_operator.web_fetch.failure import (
+    MARKER_SCAN_BYTES,
+    FetchFailure,
+    classify_exception,
+    classify_response,
+    describe,
+)
 from local_operator.web_fetch.models import (
     DEFAULT_WEB_FETCH_CONFIG,
     FetchResult,
@@ -64,6 +74,97 @@ CACHE_MAX_ENTRIES = 500
 #: for), so it must not leak cookies or credentials to an agent-chosen host.
 USER_AGENT = "local-operator/web_fetch (+https://github.com/damianvtran/local-operator)"
 
+#: A COMPATIBILITY PROFILE, sent on exactly one retry after the origin has
+#: already refused the honest request above (design §4). It is NOT the default
+#: posture and must not be used anywhere else: the honest UA is truthful, seven
+#: major sites were measured to serve it fine, and a site owner who wants to
+#: allow or deny us should be able to identify us.
+#:
+#: This exact set was measured to flip ``https://medium.com/`` from 403 (5,507
+#: bytes, ``cf-mitigated: challenge``) to 200 (~53 KB of real page), 3/3
+#: reproductions, INCLUDING through the SSRF-pinned path with ``Host``/SNI
+#: preserved — so the escalation rides the existing guarded request and needs no
+#: second client.
+#:
+#: Deliberately absent: ``sec-ch-ua*`` client hints (Chrome-version-coupled and
+#: measured not to matter), cookies (``web_search/io.py`` refuses them on
+#: purpose — a fetch is not the user's session), and any ``Referer``, since
+#: inventing a referrer is a fabrication rather than a profile. It sends no
+#: credentials, so it impersonates a generic browser, never a user.
+BROWSER_PROFILE_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif," "image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-User": "?1",
+    "Sec-Fetch-Dest": "document",
+    "Upgrade-Insecure-Requests": "1",
+}
+
+#: Backoff shape: ``min(BASE * 2**(n-1), CAP)`` with ±JITTER. So retry 1 waits
+#: ~0.5 s and retry 2 ~1.0 s — ~1.9 s of added sleep in the worst
+#: non-rate-limited case, all of it inside the call's own deadline.
+#:
+#: The jitter is not decoration: a turn can issue several ``web_fetch`` calls in
+#: parallel (the tool description encourages it) and they frequently hit the same
+#: origin. Un-jittered backoff synchronises those retries into a burst, which is
+#: exactly what a struggling origin does not need. Same family as the TUI
+#: sidebar's backoff.
+_RETRY_BASE_S = 0.5
+_RETRY_CAP_S = 4.0
+_RETRY_JITTER = 0.25
+
+#: A backoff is only worth sleeping if the attempt after it can still run. This
+#: is the margin left for that attempt; below it we return the failure now
+#: rather than sleeping into the deadline and reporting a timeout we caused.
+_RETRY_MIN_MARGIN_S = 0.25
+
+#: ``Retry-After`` is honoured only when it fits inside the turn. Beyond this we
+#: report the number instead of sleeping on it: blocking a live turn for two
+#: minutes to obey a header is worse for the user than telling the agent to come
+#: back later, and the agent can act on the number.
+_RETRY_AFTER_MAX_SLEEP_S = 10.0
+
+#: Fraction of the whole-call budget the FIRST attempt of a hop may spend when a
+#: fallback attempt is still available. This is what turns the canadiantire case
+#: from "20 s then nothing" into "12 s then a browser-shaped probe that answers
+#: in ~0.25 s": a page that has sent no headers in 12 s is overwhelmingly more
+#: likely to be black-holed than slow.
+#:
+#: A judgement call, not a measurement — the evidence that would tune it is the
+#: distribution of time-to-first-byte on genuinely slow-but-working origins,
+#: which we do not have. Deliberately NOT configurable (another knob nobody
+#: tunes). It applies only while a fallback attempt remains: the LAST attempt
+#: always gets the full remaining budget, so a genuinely slow origin is never
+#: penalised on its final try.
+_STALL_FIRST_ATTEMPT_FRACTION = 0.6
+
+#: Connect is capped independently of read: a handshake that has not completed
+#: in 5 s is not going to, and spending the whole budget on it would leave
+#: nothing for the body.
+_CONNECT_CAP_S = 5.0
+
+#: Fraction of the whole-call budget that ALL enrichment probes together may
+#: spend. Necessary once probes share the call's deadline rather than each
+#: getting a fresh copy of the timeout: on a black-holing origin a stalling
+#: ``.md`` probe would otherwise consume the budget the real fetch — and its
+#: escalation — needs, so a speculative optimisation would decide the outcome of
+#: the request the user actually made. Measured: without this cap a 3 s fetch of
+#: a silent origin spent 1.8 s on the probe and had nothing left to escalate
+#: with.
+_ENRICHMENT_BUDGET_FRACTION = 0.25
+
+#: Attempts are bounded on both sides. 1 is "no retries" (the pre-change
+#: behaviour, and a legitimate choice); 5 is where a struggling origin is being
+#: hammered rather than helped.
+_MAX_ATTEMPTS_FLOOR, _MAX_ATTEMPTS_CEIL = 1, 5
+
 #: One read chunk. Small enough that the max_bytes cap trips within a chunk of
 #: the ceiling rather than after a large over-read.
 _CHUNK_BYTES = 64 * 1024
@@ -81,7 +182,16 @@ class FetchError(Exception):
     Raised for SSRF refusals, redirect-limit breaches, and transport errors so
     the tool layer can turn one exception into one clean error result rather
     than leaking a stack trace or an httpx internal into model context.
+
+    ``failure`` carries the classification when there is one (a transport-level
+    throw), and is ``None`` for the policy refusals that never reach the network
+    — an SSRF refusal is not a "failure class", it is the guard working. It is
+    ADDITIVE: every existing ``str(error)`` call site keeps working unchanged.
     """
+
+    def __init__(self, message: str, *, failure: FetchFailure | None = None) -> None:
+        super().__init__(message)
+        self.failure = failure
 
 
 def coerce_fetch_settings(raw: object) -> WebFetchSettings:
@@ -103,6 +213,7 @@ def coerce_fetch_settings(raw: object) -> WebFetchSettings:
     settings.max_bytes = max(settings.max_bytes, _MAX_BYTES_FLOOR)
     settings.max_redirects = min(max(settings.max_redirects, 0), _MAX_REDIRECTS_CEIL)
     settings.cache_ttl_seconds = max(settings.cache_ttl_seconds, 0)
+    settings.max_attempts = min(max(settings.max_attempts, _MAX_ATTEMPTS_FLOOR), _MAX_ATTEMPTS_CEIL)
     return settings
 
 
@@ -133,6 +244,22 @@ def set_allow_private(manager: ConfigManager, allow: bool) -> WebFetchSettings:
 def set_cache_ttl(manager: ConfigManager, ttl_seconds: int) -> WebFetchSettings:
     settings = load_fetch_settings(manager)
     settings.cache_ttl_seconds = max(ttl_seconds, 0)
+    save_fetch_settings(manager, settings)
+    return settings
+
+
+def set_max_attempts(manager: ConfigManager, attempts: int) -> WebFetchSettings:
+    """Set attempts per hop, clamped. 1 disables retries entirely."""
+    settings = load_fetch_settings(manager)
+    settings.max_attempts = min(max(attempts, _MAX_ATTEMPTS_FLOOR), _MAX_ATTEMPTS_CEIL)
+    save_fetch_settings(manager, settings)
+    return settings
+
+
+def set_blocked_retry(manager: ConfigManager, enabled: bool) -> WebFetchSettings:
+    """Toggle the one browser-shaped retry paid after a refusal (§4)."""
+    settings = load_fetch_settings(manager)
+    settings.blocked_retry = enabled
     save_fetch_settings(manager, settings)
     return settings
 
@@ -442,6 +569,100 @@ _JSON_TYPES = ("application/json", "text/json", "+json")
 _TEXT_TYPES = ("text/", "application/xml", "text/markdown")
 
 
+def _now() -> float:
+    """Monotonic clock for the deadline. Monotonic specifically: a wall-clock
+    jump (NTP step, laptop wake) must not extend or collapse a fetch budget."""
+    return time.monotonic()
+
+
+@dataclass
+class _Budget:
+    """The whole call's time budget, shared by every attempt.
+
+    Not a per-request timeout: the point of the deadline is that retries divide
+    one budget rather than each getting a fresh copy of it, so a
+    ``timeout_seconds=20`` fetch takes ~20 s whether it makes one attempt or
+    four.
+
+    ``escalation_available`` lives here rather than on the hop because the
+    escalation is one-per-FETCH: a redirect chain that fails at three hops must
+    spend one browser-shaped attempt in total, not three.
+    """
+
+    deadline: float
+    total: float
+    max_attempts: int
+    escalation_available: bool
+
+    def remaining(self) -> float:
+        return self.deadline - _now()
+
+    def attempt_timeout(self, remaining: float, *, first: bool, has_fallback: bool) -> float:
+        """How long THIS attempt may take.
+
+        The first attempt of a hop is capped at a fraction of the budget while a
+        fallback attempt remains, because a page that has sent no headers in
+        12 s of a 20 s budget is overwhelmingly more likely to be black-holed by
+        an anti-bot layer than merely slow — and the browser-shaped probe that
+        follows answers in ~0.25 s on the hosts where that is true.
+
+        The LAST attempt always gets the full remaining budget: a genuinely slow
+        origin must never be penalised on its final try, which is what keeps
+        this from becoming a timeout reduction in disguise.
+        """
+        if first and has_fallback:
+            return min(remaining, self.total * _STALL_FIRST_ATTEMPT_FRACTION)
+        return remaining
+
+
+@dataclass
+class _Telemetry:
+    """What the attempts actually did, carried out to the result.
+
+    Mutable and threaded through the hop loop because the reported outcome has
+    to name the attempt count and the identities used even when the final
+    response came from the escalated attempt — the reader needs to tell "asked
+    once" from "asked twice, the second time wearing a browser's headers".
+    """
+
+    attempts: int = 0
+    profiles: list[str] = field(default_factory=list)
+    failure: FetchFailure | None = None
+    retry_after_s: float | None = None
+
+    @property
+    def profile(self) -> str:
+        """The identity that produced the reported outcome."""
+        return self.profiles[-1] if self.profiles else "default"
+
+
+def _backoff_delay(attempt: int, retry_after_s: float | None) -> float | None:
+    """Seconds to wait before the next attempt, or ``None`` to stop retrying.
+
+    When the origin named its own interval (``Retry-After`` on a 429 or a 503),
+    honouring it is both the polite and the effective behaviour — but only while
+    it fits inside a live turn. A two-minute wait returns ``None`` so the caller
+    reports the number instead of blocking the user on it.
+    """
+    if retry_after_s is not None:
+        if retry_after_s > _RETRY_AFTER_MAX_SLEEP_S:
+            return None
+        return retry_after_s
+    delay = min(_RETRY_BASE_S * (2 ** (attempt - 1)), _RETRY_CAP_S)
+    return delay * (1 + random.uniform(-_RETRY_JITTER, _RETRY_JITTER))
+
+
+async def _backoff_sleep(delay: float) -> None:
+    """A plain ``asyncio.sleep`` — deliberately, and it is load-bearing.
+
+    ``tool.py::_fetch_or_abort`` races the whole fetch coroutine against the
+    abort signal, so a cancellation lands on this sleep immediately and the task
+    is reaped. Anything that blocked the loop here (``time.sleep``, a shielded
+    wait) would make an abort during a backoff wait out the full delay.
+    """
+    await asyncio.sleep(delay)
+
+
 class WebFetchService:
     """Resolve settings and run one SSRF-guarded, bounded, cached fetch.
 
@@ -492,6 +713,20 @@ class WebFetchService:
     async def _fetch_owned(
         self, owner: WebReadIO, normalized: str, ceiling: int, timeout: float, raw: bool
     ) -> FetchResult:
+        # The whole call gets ONE deadline, computed here and never extended.
+        # This is the hard invariant retries rest on: ``timeout`` used to be the
+        # per-REQUEST timeout, so N attempts could have taken N×T. It is now a
+        # budget the attempts share, which is why no configuration of retries
+        # can make a fetch exceed its stated timeout.
+        budget = _Budget(
+            deadline=_now() + timeout,
+            total=timeout,
+            max_attempts=self.settings.max_attempts,
+            # One escalation per FETCH, not per hop — a redirect chain must not
+            # be able to multiply it.
+            escalation_available=self.settings.blocked_retry,
+        )
+
         # Enrichment (design §6 step 3): before scraping HTML, try the cheap,
         # high-value candidates that many docs sites expose — a ``.md`` twin
         # and content negotiation. If one yields substantial non-HTML text we
@@ -499,16 +734,36 @@ class WebFetchService:
         # ``enrich`` switch and skipped for ``raw`` (the caller asked for the
         # source verbatim, not a cleaner rendition).
         if self.settings.enrich and not raw:
-            enriched = await self._try_enrichment(owner, normalized, ceiling, timeout)
+            enriched = await self._try_enrichment(owner, normalized, ceiling, budget)
             if enriched is not None:
                 return enriched
+            # Any budget the probes did not spend stays with the real fetch;
+            # what they DID spend is already gone from the shared deadline.
+
+        telemetry = _Telemetry()
         final_url, status, headers, body, complete = await self._follow(
-            owner, normalized, ceiling, timeout
+            owner,
+            normalized,
+            ceiling,
+            budget,
+            telemetry,
+            max_attempts=budget.max_attempts,
+            allow_escalation=True,
         )
-        return self._render(normalized, final_url, status, headers, body, complete, raw)
+        return self._render(
+            normalized, final_url, status, headers, body, complete, raw, telemetry=telemetry
+        )
 
     async def _follow(
-        self, owner: WebReadIO, start_url: str, ceiling: int, timeout: float
+        self,
+        owner: WebReadIO,
+        start_url: str,
+        ceiling: int,
+        budget: _Budget,
+        telemetry: _Telemetry,
+        *,
+        max_attempts: int,
+        allow_escalation: bool,
     ) -> tuple[str, int, dict[str, str], bytes, bool]:
         """Drive the manual, re-validating redirect loop and return the final hop.
 
@@ -517,30 +772,23 @@ class WebFetchService:
         URL that 302s to the metadata endpoint is refused at the hop, never
         followed. Shared by the primary fetch and every enrichment attempt so the
         policy cannot be bypassed through a side door.
+
+        Retries live INSIDE the hop (:meth:`_attempt_with_retries`), never around
+        this loop: a retry wrapped around the whole chain would re-issue every
+        earlier hop and — the part that matters — could not re-validate the hop
+        it is actually retrying.
         """
         current = start_url
         for _hop in range(self.settings.max_redirects + 1):
-            # Validate returns the vetted IP to PIN this hop's connection to, so
-            # httpx cannot re-resolve to a different (internal) address between
-            # this check and the socket open (M1). Re-run on EVERY hop: each
-            # redirect target is validated AND pinned independently, or a 302 to
-            # a rebinding host would reopen the window.
-            # DNS can block even before HTTP starts. Validation still runs for
-            # EVERY request/hop, including reused connections and enrichment.
-            pinned_ip = await asyncio.to_thread(
-                validate_public_url, current, allow_private=self.settings.allow_private
+            status, headers, body, complete = await self._attempt_with_retries(
+                owner,
+                current,
+                ceiling,
+                budget,
+                telemetry,
+                max_attempts=max_attempts,
+                allow_escalation=allow_escalation,
             )
-            origin = httpx.URL(current)
-            async with owner.client(
-                ("fetch", origin.scheme, origin.host, origin.port, timeout, id(self.transport)),
-                transport=self.transport,
-                follow_redirects=False,
-                timeout=timeout,
-                headers={"User-Agent": USER_AGENT},
-            ) as client:
-                status, headers, body, complete = await self._stream_once(
-                    client, current, ceiling, pinned_ip
-                )
             location = headers.get("location")
             if status in (301, 302, 303, 307, 308) and location:
                 current = urljoin(current, location)
@@ -550,8 +798,231 @@ class WebFetchService:
             f"too many redirects (> {self.settings.max_redirects}) starting from {start_url!r}"
         )
 
+    async def _attempt_with_retries(
+        self,
+        owner: WebReadIO,
+        url: str,
+        ceiling: int,
+        budget: _Budget,
+        telemetry: _Telemetry,
+        *,
+        max_attempts: int,
+        allow_escalation: bool,
+    ) -> tuple[int, dict[str, str], bytes, bool]:
+        """One hop, with retries and at most one browser-profile escalation.
+
+        Two orthogonal mechanisms, and keeping them distinct is what bounds the
+        request count at 4 per hop:
+
+        - **Retries** repeat the SAME request identity, for classes where the
+          origin's answer says another try could work (a reset, a 502 from a
+          rolling deploy, a 429 that named its own interval).
+        - **The escalation** changes the request identity ONCE, and only after a
+          refusal or a stall — the two classes a repeat cannot help, because the
+          origin has already decided about this client.
+
+        Only GET is ever issued here (``client.stream("GET", …)`` is the single
+        request site in this package), so retrying is safe by HTTP semantics.
+        **If a non-idempotent method is ever added, this predicate must gate on
+        the method** — an automatic retry of a POST is a duplicate side effect.
+        """
+        response, failure = await self._attempt_series(
+            owner, url, ceiling, budget, telemetry, profile="default", max_attempts=max_attempts
+        )
+        if failure is None:
+            assert response is not None  # a None failure means a response arrived
+            return response
+
+        escalate = (
+            allow_escalation
+            and failure.escalatable
+            and budget.escalation_available
+            and budget.remaining() > 0
+        )
+        if escalate:
+            # Spend the one-per-fetch escalation. Marked consumed BEFORE the
+            # attempt so a redirect chain or a second failing hop cannot spend
+            # it again even if this attempt itself fails.
+            budget.escalation_available = False
+            esc_response, esc_failure = await self._attempt_series(
+                owner, url, ceiling, budget, telemetry, profile="browser", max_attempts=1
+            )
+            if esc_failure is None:
+                assert esc_response is not None
+                return esc_response
+            # The escalated outcome is the more informative one and is what gets
+            # reported: canadiantire goes from "timed out with no message" to
+            # "403 from Akamai with a reference id". Fall back to the original
+            # response only when the escalation produced none at all (it threw),
+            # since a real 403 beats an exception either way.
+            failure = esc_failure
+            if esc_response is not None:
+                response = esc_response
+
+        telemetry.failure = failure
+        if response is not None:
+            # A classified NON-2xx response still flows to the render step: the
+            # status, the headers and (for every class but ``blocked``) the body
+            # are what the caller sees. Only a failure with no response at all
+            # is an exception.
+            return response
+        raise FetchError(
+            describe(
+                failure,
+                attempts=telemetry.attempts,
+                profiles=telemetry.profiles,
+                url=url,
+            ),
+            failure=failure,
+        )
+
+    async def _attempt_series(
+        self,
+        owner: WebReadIO,
+        url: str,
+        ceiling: int,
+        budget: _Budget,
+        telemetry: _Telemetry,
+        *,
+        profile: str,
+        max_attempts: int,
+    ) -> tuple[tuple[int, dict[str, str], bytes, bool] | None, FetchFailure | None]:
+        """Up to ``max_attempts`` requests with ONE identity, with backoff.
+
+        Returns ``(response, failure)``: a ``None`` failure means the response is
+        a success (2xx/3xx); a ``None`` response means every attempt threw before
+        a status arrived.
+        """
+        response: tuple[int, dict[str, str], bytes, bool] | None = None
+        failure: FetchFailure | None = None
+
+        for attempt in range(1, max_attempts + 1):
+            remaining = budget.remaining()
+            if remaining <= 0:
+                # The deadline is spent. Report what we already know rather than
+                # opening a connection that cannot finish.
+                if failure is None:
+                    failure = FetchFailure(
+                        kind="stall",
+                        retryable=False,
+                        detail=f"ran out of time after {budget.total:.1f}s",
+                    )
+                break
+
+            attempt_timeout = budget.attempt_timeout(
+                remaining,
+                first=attempt == 1,
+                has_fallback=attempt < max_attempts or budget.escalation_available,
+            )
+            telemetry.attempts += 1
+            telemetry.profiles.append(profile)
+
+            try:
+                status, headers, body, complete = await self._request_once(
+                    owner, url, ceiling, attempt_timeout, budget.total, profile=profile
+                )
+            except FetchError as error:
+                if error.failure is None:
+                    # A POLICY refusal — SSRF, an unresolvable host, a scheme we
+                    # do not speak. Never retried: it is the guard working, and
+                    # asking again cannot change the answer.
+                    raise
+                failure = error.failure
+                response = None
+            else:
+                # Markers are scanned over the first 8 KB only (see
+                # ``failure.MARKER_SCAN_BYTES``): a challenge page is always
+                # small, and a marker 3 MB into a real article is a false
+                # positive we do not want.
+                head = body[:MARKER_SCAN_BYTES].decode("utf-8", errors="replace")
+                failure = classify_response(status, headers, head)
+                response = (status, headers, body, complete)
+                if failure is None:
+                    # A retried SUCCESS is a success: clear the earlier attempt's
+                    # classification so a 500-then-200 does not report itself as
+                    # a server failure that happens to have content. The attempt
+                    # COUNT is kept, because that is the honest explanation for
+                    # the longer duration the user saw.
+                    telemetry.failure = None
+                    telemetry.retry_after_s = None
+                    return response, None
+
+            telemetry.failure = failure
+            if failure.retry_after_s is not None:
+                telemetry.retry_after_s = failure.retry_after_s
+            if not failure.retryable or attempt >= max_attempts:
+                break
+
+            delay = _backoff_delay(attempt, failure.retry_after_s)
+            if delay is None or delay > budget.remaining() - _RETRY_MIN_MARGIN_S:
+                # Either the origin asked for longer than this turn can honour,
+                # or the backoff would eat the budget the next attempt needs.
+                # Returning now with the number in the text lets the agent come
+                # back later; sleeping would just manufacture a timeout.
+                break
+            await _backoff_sleep(delay)
+
+        return response, failure
+
+    async def _request_once(
+        self,
+        owner: WebReadIO,
+        url: str,
+        ceiling: int,
+        attempt_timeout: float,
+        pool_timeout: float,
+        *,
+        profile: str,
+    ) -> tuple[int, dict[str, str], bytes, bool]:
+        """Validate, pin, and issue ONE request.
+
+        **Validation and pinning happen here, inside the attempt** — never
+        hoisted into the caller's loop. Hoisting them would be the one way to get
+        this badly wrong: a host that resolves public on attempt 1 and private on
+        attempt 2 must be refused on attempt 2, and a retry that reused attempt
+        1's vetted address without re-checking would reopen exactly the rebinding
+        window the pin exists to close.
+        """
+        # Validate returns the vetted IP to PIN this request's connection to, so
+        # httpx cannot re-resolve to a different (internal) address between this
+        # check and the socket open (M1). Re-run on EVERY request — every hop,
+        # every retry, every enrichment probe, and the escalated attempt.
+        # DNS can block even before HTTP starts, which is why it runs in a
+        # thread.
+        pinned_ip = await asyncio.to_thread(
+            validate_public_url, url, allow_private=self.settings.allow_private
+        )
+        origin = httpx.URL(url)
+        async with owner.client(
+            # The pool key keeps the CALL's timeout, not the attempt's: the
+            # per-attempt budget rides on the request (see ``_stream_once``), so
+            # every attempt of one call shares one pooled connection instead of
+            # opening a fresh pool entry each time and defeating keep-alive.
+            (
+                "fetch",
+                origin.scheme,
+                origin.host,
+                origin.port,
+                pool_timeout,
+                id(self.transport),
+            ),
+            transport=self.transport,
+            follow_redirects=False,
+            timeout=pool_timeout,
+            headers={"User-Agent": USER_AGENT},
+        ) as client:
+            extra = BROWSER_PROFILE_HEADERS if profile == "browser" else None
+            return await self._stream_once(
+                client,
+                url,
+                ceiling,
+                pinned_ip,
+                extra_headers=extra,
+                attempt_timeout=attempt_timeout,
+            )
+
     async def _try_enrichment(
-        self, owner: WebReadIO, url: str, ceiling: int, timeout: float
+        self, owner: WebReadIO, url: str, ceiling: int, budget: _Budget
     ) -> FetchResult | None:
         """Attempt the cheap enrichment candidates; return a result or ``None``.
 
@@ -571,10 +1042,38 @@ class WebFetchService:
         beyond the global ``enrich`` switch was judged not worth the param surface
         for a bounded two-probe cost.
         """
+        # Probes get a bounded SLICE of the call's budget, never the whole
+        # thing: enrichment is speculative, and a probe that stalls must not be
+        # able to starve the request the user actually made (or the escalation
+        # that would have diagnosed it).
+        probe_budget = _Budget(
+            deadline=min(
+                budget.deadline,
+                _now() + budget.total * _ENRICHMENT_BUDGET_FRACTION,
+            ),
+            total=budget.total * _ENRICHMENT_BUDGET_FRACTION,
+            max_attempts=1,
+            escalation_available=False,
+        )
         for candidate in _enrichment_candidates(url):
+            if probe_budget.remaining() <= 0:
+                # The slice is spent. Stop probing rather than queue a request
+                # that has no time to complete.
+                return None
             try:
+                # A probe gets ONE attempt and never the escalation: enrichment
+                # is an optimisation, and spending retries or a browser-shaped
+                # request on a speculative ``.md`` twin multiplies request volume
+                # for no user-visible gain. It still shares the call's deadline,
+                # so a stalling probe cannot eat the real fetch's budget.
                 final_url, status, headers, body, complete = await self._follow(
-                    owner, candidate, ceiling, timeout
+                    owner,
+                    candidate,
+                    ceiling,
+                    probe_budget,
+                    _Telemetry(),
+                    max_attempts=1,
+                    allow_escalation=False,
                 )
             except FetchError:
                 # A blocked/failed probe must not sink the primary fetch; a
@@ -595,7 +1094,14 @@ class WebFetchService:
         return None
 
     async def _stream_once(
-        self, client: httpx.AsyncClient, url: str, ceiling: int, pinned_ip: str | None = None
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        ceiling: int,
+        pinned_ip: str | None = None,
+        *,
+        extra_headers: Mapping[str, str] | None = None,
+        attempt_timeout: float | None = None,
     ) -> tuple[int, dict[str, str], bytes, bool]:
         """One request, reading at most ``ceiling`` bytes off the wire.
 
@@ -612,11 +1118,40 @@ class WebFetchService:
         or the host was already an IP literal, and httpx connects normally.
         """
         request_url, request_headers, extensions = _pin_request(url, pinned_ip)
+        if extra_headers:
+            # The pin's ``Host`` header (and the SNI extension) are merged LAST,
+            # so an escalated attempt carrying its own headers cannot accidentally
+            # unpin itself by overwriting the hostname the certificate is verified
+            # against.
+            merged = dict(extra_headers)
+            merged.update(request_headers)
+            request_headers = merged
         buffer = bytearray()
         complete = True
+        # The per-attempt budget rides on the REQUEST, not the client, so attempts
+        # share one pooled connection while each gets its own slice of the
+        # deadline. Connect is capped independently: a handshake that has not
+        # completed in 5 s is not going to, and spending the whole budget on it
+        # would leave nothing for the body. ``None`` (a direct caller that named
+        # no budget) leaves the client's own timeout in force, which is the
+        # pre-deadline behaviour.
+        request_timeout = (
+            httpx.Timeout(
+                connect=min(_CONNECT_CAP_S, attempt_timeout),
+                read=attempt_timeout,
+                write=attempt_timeout,
+                pool=min(_CONNECT_CAP_S, attempt_timeout),
+            )
+            if attempt_timeout is not None
+            else httpx.USE_CLIENT_DEFAULT
+        )
         try:
             async with client.stream(
-                "GET", request_url, headers=request_headers, extensions=extensions
+                "GET",
+                request_url,
+                headers=request_headers,
+                extensions=extensions,
+                timeout=request_timeout,
             ) as response:
                 headers = {k.lower(): v for k, v in response.headers.items()}
                 status = response.status_code
@@ -630,10 +1165,18 @@ class WebFetchService:
                         del buffer[ceiling:]
                         complete = False
                         break
-        except httpx.TimeoutException as exc:
-            raise FetchError(f"timed out fetching {url!r}: {exc}") from exc
-        except httpx.HTTPError as exc:
-            raise FetchError(f"could not fetch {url!r}: {exc}") from exc
+        except (httpx.TimeoutException, httpx.HTTPError) as exc:
+            # The message is built from the CLASSIFIER, never from ``str(exc)``:
+            # ``httpx.ReadTimeout.__str__()`` is the empty string, which is how
+            # the shipped error came to read ``timed out fetching '<url>': ``
+            # with nothing after the colon. ``str(exc)`` is appended only when it
+            # actually says something.
+            failure = classify_exception(exc, timeout_s=attempt_timeout)
+            detail = str(exc).strip()
+            message = f"{failure.detail or 'the request failed'}: {url}"
+            if detail:
+                message += f" ({detail})"
+            raise FetchError(message, failure=failure) from exc
         return status, headers, bytes(buffer), complete
 
     def _render(
@@ -645,10 +1188,39 @@ class WebFetchService:
         body: bytes,
         complete: bool,
         raw: bool,
+        telemetry: _Telemetry | None = None,
     ) -> FetchResult:
         """Classify the body and render it, producing the full FetchResult."""
         content_type = headers.get("content-type", "").lower()
         byte_count = len(body)
+        telemetry = telemetry or _Telemetry(attempts=1, profiles=["default"])
+        diagnostics = _diagnostics(telemetry)
+
+        failure = telemetry.failure
+        if failure is not None and failure.kind == "blocked":
+            # The challenge body is REPLACED, not inlined — and only for this
+            # class. It is markup whose entire purpose is to be executed by a
+            # browser: 5.5 KB of Cloudflare interstitial (measured on
+            # medium.com) that costs context to tell the agent nothing, under a
+            # lead that invites the misread that it is page content.
+            #
+            # Every other non-2xx class still renders its body verbatim below.
+            # A 404's body, a 451's and a 500's often genuinely explain
+            # themselves, so the narrowing stops here.
+            explanation = describe(
+                failure, attempts=telemetry.attempts, profiles=telemetry.profiles
+            )
+            return FetchResult(
+                url=request_url,
+                final_url=final_url,
+                status=status,
+                content_type=content_type or "text/html",
+                render_method="text",
+                content=explanation,
+                bytes=byte_count,
+                complete=complete,
+                **diagnostics,
+            )
 
         if _is_binary(content_type, body):
             text, method = binary_notice(content_type, byte_count, final_url)
@@ -661,6 +1233,7 @@ class WebFetchService:
                 content=text,
                 bytes=byte_count,
                 complete=complete,
+                **diagnostics,
             )
 
         decoded = body.decode("utf-8", errors="replace")
@@ -690,7 +1263,40 @@ class WebFetchService:
             bytes=byte_count,
             complete=complete,
             low_quality=low_quality,
+            **diagnostics,
         )
+
+
+class _Diagnostics(TypedDict):
+    """The retry/block fields, typed so ``**`` into :class:`FetchResult` keeps
+    its types instead of widening every field to ``object``."""
+
+    attempts: int
+    profile: str
+    profiles: list[str]
+    failure_kind: str | None
+    block_vendor: str | None
+    block_reference: str | None
+    retry_after_s: float | None
+
+
+def _diagnostics(telemetry: _Telemetry) -> _Diagnostics:
+    """The retry/block fields every :class:`FetchResult` carries.
+
+    One builder so a new construction site cannot forget half of them, and so a
+    SUCCESS reports the honest ``attempts``/``profile`` (a 500-then-200 that took
+    two tries says two) without inventing a ``failure_kind`` it does not have.
+    """
+    failure = telemetry.failure
+    return {
+        "attempts": max(telemetry.attempts, 1),
+        "profile": telemetry.profile,
+        "profiles": list(telemetry.profiles) or ["default"],
+        "failure_kind": failure.kind if failure is not None else None,
+        "block_vendor": failure.vendor if failure is not None else None,
+        "block_reference": failure.reference if failure is not None else None,
+        "retry_after_s": telemetry.retry_after_s,
+    }
 
 
 def _enrichment_candidates(url: str) -> list[str]:

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -37,7 +37,11 @@ from local_operator.harness.types import (
 from local_operator.paths import config_dir
 from local_operator.tools.builtin import spill_truncate, validation_error_result
 from local_operator.tools.spill import get_store
-from local_operator.web_fetch.failure import attempt_summary, vendor_label
+from local_operator.web_fetch.failure import (
+    attempt_summary,
+    block_lead,
+    retry_after_note,
+)
 from local_operator.web_fetch.models import FetchResult
 from local_operator.web_fetch.service import (
     CacheEntry,
@@ -198,16 +202,11 @@ def _header_line(result_like: dict[str, Any]) -> str:
         quality = " · sparse/JS-gated (try `browser`)" if result_like.get("low_quality") else ""
         return f"[{status}] {final}\n{tail}{quality}"
     if result_like.get("failure_kind") == "blocked":
-        label = vendor_label(
-            str(result_like["block_vendor"]) if result_like.get("block_vendor") else None
-        )
-        reason = (
-            f"blocked by {label} bot protection, not page content"
-            if label
-            else "the origin refused this request, which may be bot protection or an "
-            "access restriction"
-        )
-        warn = f"⚠ HTTP {status} {_status_reason(status)} — {reason}. {final}"
+        # The reason clause is IMPORTED, not re-typed: this line, the TUI card's
+        # danger row and the tests that pin both must not be able to drift into
+        # three opinions about the same refusal (review round 1, R5).
+        vendor = str(result_like["block_vendor"]) if result_like.get("block_vendor") else None
+        warn = f"⚠ HTTP {status} {_status_reason(status)} — {block_lead(vendor)}. {final}"
         # NO "the body below is the error response" note for this class: the
         # body below is no longer the origin's response at all, it is our own
         # statement of what happened plus the next step (the challenge markup is
@@ -217,6 +216,20 @@ def _header_line(result_like: dict[str, Any]) -> str:
         f"⚠ HTTP {status} {_status_reason(status)} — this is an error/block page, "
         f"not page content. {final}"
     )
+    # §3.4: a Retry-After too long to sleep on is REPORTED, not obeyed — and
+    # reporting it only in ``details`` reaches nothing, because the agent reads
+    # this text. ``describe`` would say the same thing, but it is only reached
+    # for a class with no response at all; a 429 HAS a response, so its lead is
+    # built here and this is where the number has to land.
+    retry_after = result_like.get("retry_after_s")
+    if result_like.get("failure_kind") == "ratelimit" and isinstance(retry_after, (int, float)):
+        # AFTER the parenthetical, so the card's header strip still recognises the
+        # header block it removes (lead + meta + note) and leaves this sentence
+        # where a reader looks for it: in the body, as the reason the call stopped.
+        return (
+            f"{warn}\n{tail}\n(The body below is the error response, not the requested page.)\n"
+            f"{retry_after_note(float(retry_after))}"
+        )
     return f"{warn}\n{tail}\n(The body below is the error response, not the requested page.)"
 
 
@@ -321,6 +334,11 @@ def _cache_hit_result(
         # diagnostic keys are absent rather than zero/None because a cached entry
         # records no failure to describe.
         "attempts": 0,
+        # …and for the same reason NO profiles: ``profiles`` names the identities
+        # that made the requests, and a hit made none. Leaving the model's default
+        # (``["default"]``) in place would report a request identity for a call
+        # that never opened a socket (review round 1, N3).
+        "profiles": [],
     }
     # Same declared supersede key as a fresh fetch: a cached re-read describes
     # the same resource, so it must group with the fresh ones rather than
@@ -489,6 +507,16 @@ async def run_fetch(
         # transcript show a bare sentence for exactly the failures that most
         # need explaining.
         details: dict[str, Any] = {"url": normalized, "cache": "miss"}
+        # The retry facts ride the exception (``FetchError.attempts/profiles``)
+        # precisely so this branch can carry them too: the preview states "2
+        # attempts" in prose, and a structured payload that omits what its own
+        # text says is the contract gap §5.3 exists to close (review round 1,
+        # Q1). ``profiles`` is reported only when there was more than one
+        # identity to report, matching the fresh-fetch path exactly.
+        if error.attempts:
+            details["attempts"] = error.attempts
+            if error.attempts > 1 and error.profiles:
+                details["profiles"] = list(error.profiles)
         if error.failure is not None:
             details["failure_kind"] = error.failure.kind
             if error.failure.vendor:

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -64,11 +64,14 @@ _DESCRIPTION = (
     "cache TTL reuses stored content with no network call. Use this (or "
     "`read <url>`) instead of `browser` for headless, subagent, and server "
     "contexts; use `browser` only when a page needs a real logged-in session or "
-    "JavaScript rendering. Transient failures are retried automatically; when a "
-    "result says the origin's bot protection refused the request, `browser` is "
-    "the named next step and re-fetching the same URL will not help. Need "
-    "several pages? Issue multiple web_fetch calls in one turn — they run in "
-    "parallel instead of one-at-a-time."
+    # The retry/block sentence is deliberately terse: this string is billed on
+    # EVERY turn of every session, and `scripts/bench_context_budget.py` had
+    # ~41 tokens of headroom before this change. It has to say only what the
+    # agent cannot work out from the result itself — that retries already
+    # happened, so a blocked result is final and the named step is the move.
+    "JavaScript rendering. Transient failures retry themselves; a blocked result "
+    "is final, so take the step it names. Need several pages? Issue multiple "
+    "web_fetch calls in one turn — they run in parallel instead of one-at-a-time."
 )
 
 

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -37,6 +37,7 @@ from local_operator.harness.types import (
 from local_operator.paths import config_dir
 from local_operator.tools.builtin import spill_truncate, validation_error_result
 from local_operator.tools.spill import get_store
+from local_operator.web_fetch.failure import attempt_summary, vendor_label
 from local_operator.web_fetch.models import FetchResult
 from local_operator.web_fetch.service import (
     CacheEntry,
@@ -63,8 +64,11 @@ _DESCRIPTION = (
     "cache TTL reuses stored content with no network call. Use this (or "
     "`read <url>`) instead of `browser` for headless, subagent, and server "
     "contexts; use `browser` only when a page needs a real logged-in session or "
-    "JavaScript rendering. Need several pages? Issue multiple web_fetch calls in "
-    "one turn — they run in parallel instead of one-at-a-time."
+    "JavaScript rendering. Transient failures are retried automatically; when a "
+    "result says the origin's bot protection refused the request, `browser` is "
+    "the named next step and re-fetching the same URL will not help. Need "
+    "several pages? Issue multiple web_fetch calls in one turn — they run in "
+    "parallel instead of one-at-a-time."
 )
 
 
@@ -164,6 +168,13 @@ def _header_line(result_like: dict[str, Any]) -> str:
     the page content, so the agent's own judgement has a reliable signal. The
     rendered body still follows (it can carry a useful message) but the lead makes
     clear it is the error RESPONSE body, never the requested content.
+
+    A CONFIRMED block refines that lead with the reason (``blocked by Akamai bot
+    protection``) instead of the generic error/block wording, because "this is a
+    bot wall, and another fetch will not clear it" and "this page is missing" are
+    different facts with different next steps. An UNSIGNED refusal keeps the
+    generic wording: claiming bot protection we did not detect would send the
+    agent to `browser` when it should be asking the user for access.
     """
     status = int(result_like["status"])
     final = result_like["final_url"]
@@ -171,9 +182,34 @@ def _header_line(result_like: dict[str, Any]) -> str:
     method = result_like["render_method"]
     cache = result_like["cache"]
     tail = f"{method} · {ctype} · cache {cache}"
+    # The attempt count rides in the meta line so a 2.4 s fetch that used to look
+    # like a slow network now reads as what it was. Only when it is not 1: a
+    # single attempt is the norm and says nothing.
+    attempts = result_like.get("attempts")
+    if isinstance(attempts, int) and attempts > 1:
+        profiles = result_like.get("profiles")
+        summary = attempt_summary(attempts, profiles if isinstance(profiles, list) else ())
+        if summary:
+            tail += f" · {summary}"
     if 200 <= status < 300:
         quality = " · sparse/JS-gated (try `browser`)" if result_like.get("low_quality") else ""
         return f"[{status}] {final}\n{tail}{quality}"
+    if result_like.get("failure_kind") == "blocked":
+        label = vendor_label(
+            str(result_like["block_vendor"]) if result_like.get("block_vendor") else None
+        )
+        reason = (
+            f"blocked by {label} bot protection, not page content"
+            if label
+            else "the origin refused this request, which may be bot protection or an "
+            "access restriction"
+        )
+        warn = f"⚠ HTTP {status} {_status_reason(status)} — {reason}. {final}"
+        # NO "the body below is the error response" note for this class: the
+        # body below is no longer the origin's response at all, it is our own
+        # statement of what happened plus the next step (the challenge markup is
+        # dropped). Keeping the note would describe the wrong thing.
+        return f"{warn}\n{tail}"
     warn = (
         f"⚠ HTTP {status} {_status_reason(status)} — this is an error/block page, "
         f"not page content. {final}"
@@ -278,6 +314,10 @@ def _cache_hit_result(
         "cache": "hit",
         "ok": http_ok,
         "http_error": not http_ok,
+        # Truthfully zero: a cache hit made no network attempt at all. The other
+        # diagnostic keys are absent rather than zero/None because a cached entry
+        # records no failure to describe.
+        "attempts": 0,
     }
     # Same declared supersede key as a fresh fetch: a cached re-read describes
     # the same resource, so it must group with the fresh ones rather than
@@ -440,7 +480,23 @@ async def run_fetch(
     except asyncio.CancelledError:
         return "web_fetch aborted.", {"url": normalized, "cache": "miss"}, True
     except FetchError as error:
-        return str(error), {"url": normalized, "cache": "miss"}, True
+        # A TERMINAL failure (no response ever arrived) still carries what it
+        # knows: the class says whether another try could help, and a blocked
+        # stall names `browser` as the next step. Without this the card and the
+        # transcript show a bare sentence for exactly the failures that most
+        # need explaining.
+        details: dict[str, Any] = {"url": normalized, "cache": "miss"}
+        if error.failure is not None:
+            details["failure_kind"] = error.failure.kind
+            if error.failure.vendor:
+                details["block_vendor"] = error.failure.vendor
+            if error.failure.reference:
+                details["block_reference"] = error.failure.reference
+            if error.failure.retry_after_s is not None:
+                details["retry_after_s"] = error.failure.retry_after_s
+            if error.failure.kind in ("blocked", "stall"):
+                details["suggested_tool"] = "browser"
+        return str(error), details, True
     except Exception as error:  # pragma: no cover - defensive; unexpected transport bug
         return f"web_fetch failed for {normalized!r}: {error}", {"url": normalized}, True
 
@@ -462,6 +518,29 @@ async def run_fetch(
         "ok": http_ok,
         "http_error": not http_ok,
     }
+    # Retry/block diagnostics: ADDITIVE keys only. Nothing above changes name,
+    # type or meaning, so the TUI card, the UI row model and any stored
+    # transcript keep working untouched — and a key is omitted rather than set
+    # to None when it has nothing to say, so a reader can test presence.
+    result_like["attempts"] = result.attempts
+    if result.attempts > 1:
+        result_like["profiles"] = list(result.profiles)
+    if result.failure_kind:
+        result_like["failure_kind"] = result.failure_kind
+    if result.block_vendor:
+        result_like["block_vendor"] = result.block_vendor
+    if result.block_reference:
+        result_like["block_reference"] = result.block_reference
+    if result.profile != "default":
+        result_like["profile"] = result.profile
+    if result.retry_after_s is not None:
+        result_like["retry_after_s"] = result.retry_after_s
+    if result.failure_kind == "blocked":
+        # The escalation the agent should take next, as DATA as well as prose —
+        # `browser` is write-tier and approval-gated, so this names the step
+        # rather than taking it (design §8.1).
+        result_like["suggested_tool"] = "browser"
+
     preview, details, handle = _shape_from_content(
         result_like, result.content, tool_name, context, variant=base_variant
     )

--- a/scripts/fetch_block_shot.py
+++ b/scripts/fetch_block_shot.py
@@ -11,11 +11,15 @@ the blocked body text has to be judged against the shapes it must NOT alter:
     blocked   (default)  a confirmed Akamai refusal — the case whose body text
                          changes (challenge markup replaced by the origin
                          statement, the reference id and the `browser` next
-                         step)
+                         step). Carries the two-attempt/escalated shape, so the
+                         ``Rendered:`` row's attempt summary is in the frame.
     missing              a 404, which keeps inlining its body verbatim: the
                          §5.2 narrowing applies to the ``blocked`` class only,
                          and a frame is what proves the other classes are
                          untouched
+    stall                a TERMINAL failure (no response ever arrived), which
+                         carries no render_method/final_url — the shape that
+                         used to fall through to the generic output body
     ok                   a plain 200, the regression baseline
 
 Why a script rather than an assertion: the card's structured rows are unchanged
@@ -60,6 +64,11 @@ from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
 
 BLOCKED_URL = "https://www.shoppersdrugmart.ca/?lang=en&query=power+bar"
+
+#: The terminal-failure fixture's URL. A host that accepts the connection and
+#: then never answers — the case whose card used to be indistinguishable from a
+#: bash error (design review round 1, D5).
+STALL_URL = "https://www.canadiantire.ca/en/pdp/some-product.html"
 
 #: What the card painted BEFORE this change: the Akamai interstitial rendered as
 #: if it were content, under the warning lead. Captured verbatim from the live
@@ -126,19 +135,59 @@ def _blocked_details() -> dict[str, object]:
         "final_url": BLOCKED_URL,
         "status": 403,
         "content_type": "text/html",
-        "render_method": "markdownify",
+        # NOT "markdownify": the body below the error row is OUR statement, not
+        # a rendering of the origin's markup (``service.py`` sets this to the
+        # rendered-content method, and the replacement body is plain text). The
+        # card prints this field, so a wrong value here is a frame that lies.
+        "render_method": "text",
         "cache": "miss",
         "bytes": 382,
         "lines": 9,
         "ok": False,
         "http_error": True,
         "attempts": 2,
+        # The escalation took a refusal to a 200 on medium.com; on this origin it
+        # was refused too. Either way the count and the identity happen to be the
+        # facts a reader cannot get from the row without them (review round 1,
+        # D1).
+        "profiles": ["default", "browser"],
         "failure_kind": "blocked",
         "block_vendor": "akamai",
         "block_reference": "18.4b182117.1789250183.345ea6ea",
         "profile": "browser",
         "suggested_tool": "browser",
     }
+
+
+def _stall_details() -> dict[str, object]:
+    """``details`` for a TERMINAL stall: no response, so no render/final_url.
+
+    This is the shape ``tool.py``'s ``except FetchError`` branch builds, and the
+    one the card used to mistake for a bash row (design review round 1, D5).
+    """
+    return {
+        "url": STALL_URL,
+        "cache": "miss",
+        "failure_kind": "stall",
+        "attempts": 2,
+        "profiles": ["default", "browser"],
+        "suggested_tool": "browser",
+    }
+
+
+def _stall_text() -> str:
+    """The terminal stall preview, composed by the engine's own ``describe``."""
+    from local_operator.web_fetch.failure import FetchFailure, describe
+
+    failure = FetchFailure(
+        kind="stall",
+        retryable=False,
+        detail=(
+            "read timed out after 20.0s — the origin accepted the connection but "
+            "never sent a response"
+        ),
+    )
+    return describe(failure, attempts=2, profiles=("default", "browser"), url=STALL_URL)
 
 
 def _seed(app: OperatorApp, case: str) -> ToolCard:
@@ -184,6 +233,10 @@ def _seed(app: OperatorApp, case: str) -> ToolCard:
             "http_error": False,
             "attempts": 1,
         }
+    elif case == "stall":
+        url = STALL_URL
+        text = _stall_text()
+        details = _stall_details()
     else:
         url = BLOCKED_URL
         text = _blocked_after_text()
@@ -191,7 +244,21 @@ def _seed(app: OperatorApp, case: str) -> ToolCard:
 
     card = ToolCard("t1", "web_fetch", {"url": url})
     app._append_block(card)
-    card.mark_done(text, details)
+    # Settle the way the APP settles it, which is the whole point of this
+    # script: a non-2xx fetch returns ``is_error=True`` and the session settles
+    # the card as an ERROR (``session_presentation.py`` → ``restore(state=
+    # "error", error=_first_line(result_text))``). Capturing a 403 with
+    # ``mark_done`` painted ``✓ <0.1s`` over a refusal — a frame that showed the
+    # opposite of what the app does.
+    if details.get("http_error") or details.get("failure_kind"):
+        card.mark_failed(
+            text.splitlines()[0] if text else "error",
+            result_text=text,
+            details=details,
+            measured_s=0.4,
+        )
+    else:
+        card.mark_done(text, details, measured_s=0.4)
 
     app._append_block(_answer("The origin refused the request; here is what it said."))
     return card
@@ -200,14 +267,19 @@ def _seed(app: OperatorApp, case: str) -> ToolCard:
 def _blocked_after_text() -> str:
     """The blocked preview as this tree builds it, or the pre-change capture.
 
-    Imported from the engine when the module exposes it, so the frame is the
-    text the code actually produces rather than a copy that can drift. A
-    checkout predating the change has no such module, and falls back to the
-    verbatim BEFORE capture — which is exactly what makes one script able to
+    Composed from the engine's OWN ``_header_line`` and ``describe``, not
+    re-typed here: the previous revision hand-wrote the lead and got it wrong in
+    two ways a reader could see — it printed the ``(The body below is the error
+    response…)`` note that the blocked class deliberately no longer emits, and it
+    kept ``markdownify`` as the render method. A capture script whose fixture
+    disagrees with the shipped code produces a frame that argues for a shape the
+    app does not have. A checkout predating the change has no such module, and
+    falls back to the verbatim BEFORE capture — which is what lets one script
     take both frames.
     """
     try:
         from local_operator.web_fetch.failure import FetchFailure, describe
+        from local_operator.web_fetch.tool import _header_line
     except ImportError:
         return BEFORE_BLOCKED_TEXT
     failure = FetchFailure(
@@ -217,13 +289,13 @@ def _blocked_after_text() -> str:
         reference="18.4b182117.1789250183.345ea6ea",
         status=403,
     )
-    lead = (
-        "⚠ HTTP 403 Forbidden — blocked by Akamai bot protection, not page content. "
-        f"{BLOCKED_URL}\n"
-        "markdownify · text/html · cache miss · 2 attempts (default, browser-profile)\n"
-        "(The body below is the error response, not the requested page.)\n\n"
+    details = _blocked_details()
+    lead = _header_line(dict(details))
+    return (
+        lead
+        + "\n\n"
+        + describe(failure, attempts=2, profiles=("default", "browser"), url=BLOCKED_URL)
     )
-    return lead + describe(failure, attempts=2, profiles=("default", "browser"))
 
 
 async def main() -> None:

--- a/scripts/fetch_block_shot.py
+++ b/scripts/fetch_block_shot.py
@@ -1,0 +1,264 @@
+"""Capture the web_fetch tool card for a BLOCKED fetch (bot-protection refusal).
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/fetch_block_shot.py OUT.svg [COLSxROWS] [CASE]
+
+``CASE`` selects which result the card is painted from, because the change to
+the blocked body text has to be judged against the shapes it must NOT alter:
+
+    blocked   (default)  a confirmed Akamai refusal — the case whose body text
+                         changes (challenge markup replaced by the origin
+                         statement, the reference id and the `browser` next
+                         step)
+    missing              a 404, which keeps inlining its body verbatim: the
+                         §5.2 narrowing applies to the ``blocked`` class only,
+                         and a frame is what proves the other classes are
+                         untouched
+    ok                   a plain 200, the regression baseline
+
+Why a script rather than an assertion: the card's structured rows are unchanged
+by this work, but its painted BODY is not, and a passing test cannot show that
+the replacement text wraps, aligns under the ledger spine, and stays inside the
+danger treatment the error row establishes. The two frames (this tree vs. a
+checkout predating the change, same script, same fixture) differ in the body
+text and in nothing else.
+
+The fixtures are REAL captures taken through the live path on 2026-09-12 —
+the shoppersdrugmart.ca Akamai body with its ``Reference #`` id, and the
+medium.com Cloudflare interstitial — not invented markup, so the frame shows
+the number of rows an actual block costs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot must not rename the operator's real workspace through inherited CMUX IDs.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.visual_capture import (  # noqa: E402
+    isolate_capture,
+    save_capture,
+    settle_status_line,
+)
+
+isolate_capture()
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+BLOCKED_URL = "https://www.shoppersdrugmart.ca/?lang=en&query=power+bar"
+
+#: What the card painted BEFORE this change: the Akamai interstitial rendered as
+#: if it were content, under the warning lead. Captured verbatim from the live
+#: CLI on 2026-09-12 (`fetch test` against the URL above).
+BEFORE_BLOCKED_TEXT = (
+    "⚠ HTTP 403 Forbidden — this is an error/block page, not page content. "
+    f"{BLOCKED_URL}\n"
+    "markdownify · text/html · cache miss\n"
+    "(The body below is the error response, not the requested page.)\n"
+    "\n"
+    "Access Denied\n"
+    "\n"
+    "# Access Denied\n"
+    "\n"
+    'You don\'t have permission to access "http://www.shoppersdrugmart.ca/?" on this server.\n'
+    "\n"
+    "Reference #18.4b182117.1789250183.345ea6ea\n"
+    "\n"
+    "https://errors.edgesuite.net/18.4b182117.1789250183.345ea6ea"
+)
+
+#: The 404 fixture. Its body is inlined before AND after, which is the property
+#: the `missing` frame exists to hold: a page that explains itself still does.
+MISSING_TEXT = (
+    "⚠ HTTP 404 Not Found — this is an error/block page, not page content. "
+    "https://docs.example.com/guide/old-page\n"
+    "markdownify · text/html · cache miss\n"
+    "(The body below is the error response, not the requested page.)\n"
+    "\n"
+    "# Page moved\n"
+    "\n"
+    "This guide moved to /guide/new-page in the 3.0 release. Update your bookmarks."
+)
+
+OK_TEXT = (
+    "[200] https://example.com/\n"
+    "text · text/html · cache miss\n"
+    "\n"
+    "# Example Domain\n"
+    "\n"
+    "This domain is for use in illustrative examples in documents."
+)
+
+
+def _answer(text: str) -> AssistantBlock:
+    """A SETTLED answer — an unsettled block keeps its live-turn ink, which is
+    not the state the operator reads a finished fetch in."""
+    block = AssistantBlock()
+    block.update_text(text)
+    block.finalize_text()
+    return block
+
+
+def _blocked_details() -> dict[str, object]:
+    """``details`` for the blocked card.
+
+    Built by hand rather than imported so the SAME script runs against a
+    checkout that predates the new keys — the additive keys are simply ignored
+    by an older ``_fetch_result_output``, which is itself the §5.3 claim under
+    test.
+    """
+    return {
+        "url": BLOCKED_URL,
+        "final_url": BLOCKED_URL,
+        "status": 403,
+        "content_type": "text/html",
+        "render_method": "markdownify",
+        "cache": "miss",
+        "bytes": 382,
+        "lines": 9,
+        "ok": False,
+        "http_error": True,
+        "attempts": 2,
+        "failure_kind": "blocked",
+        "block_vendor": "akamai",
+        "block_reference": "18.4b182117.1789250183.345ea6ea",
+        "profile": "browser",
+        "suggested_tool": "browser",
+    }
+
+
+def _seed(app: OperatorApp, case: str) -> ToolCard:
+    """Put the fetch card in a realistic turn: a question, an answer, and tool
+    rows on both sides, so the body's indentation can be judged against the
+    ledger spine rather than floating alone on an empty screen."""
+    if case == "missing":
+        app._append_block(UserBlock("read the old setup guide and tell me what changed"))
+    else:
+        app._append_block(UserBlock("what does a power bar cost at shoppers?"))
+    app._append_block(_answer("Checking the product page directly."))
+
+    if case == "missing":
+        url = "https://docs.example.com/guide/old-page"
+        text = MISSING_TEXT
+        details: dict[str, object] = {
+            "url": url,
+            "final_url": url,
+            "status": 404,
+            "content_type": "text/html",
+            "render_method": "markdownify",
+            "cache": "miss",
+            "bytes": 512,
+            "lines": 3,
+            "ok": False,
+            "http_error": True,
+            "attempts": 1,
+            "failure_kind": "client",
+        }
+    elif case == "ok":
+        url = "https://example.com/"
+        text = OK_TEXT
+        details = {
+            "url": url,
+            "final_url": url,
+            "status": 200,
+            "content_type": "text/html",
+            "render_method": "text",
+            "cache": "miss",
+            "bytes": 1256,
+            "lines": 4,
+            "ok": True,
+            "http_error": False,
+            "attempts": 1,
+        }
+    else:
+        url = BLOCKED_URL
+        text = _blocked_after_text()
+        details = _blocked_details()
+
+    card = ToolCard("t1", "web_fetch", {"url": url})
+    app._append_block(card)
+    card.mark_done(text, details)
+
+    app._append_block(_answer("The origin refused the request; here is what it said."))
+    return card
+
+
+def _blocked_after_text() -> str:
+    """The blocked preview as this tree builds it, or the pre-change capture.
+
+    Imported from the engine when the module exposes it, so the frame is the
+    text the code actually produces rather than a copy that can drift. A
+    checkout predating the change has no such module, and falls back to the
+    verbatim BEFORE capture — which is exactly what makes one script able to
+    take both frames.
+    """
+    try:
+        from local_operator.web_fetch.failure import FetchFailure, describe
+    except ImportError:
+        return BEFORE_BLOCKED_TEXT
+    failure = FetchFailure(
+        kind="blocked",
+        retryable=False,
+        vendor="akamai",
+        reference="18.4b182117.1789250183.345ea6ea",
+        status=403,
+    )
+    lead = (
+        "⚠ HTTP 403 Forbidden — blocked by Akamai bot protection, not page content. "
+        f"{BLOCKED_URL}\n"
+        "markdownify · text/html · cache miss · 2 attempts (default, browser-profile)\n"
+        "(The body below is the error response, not the requested page.)\n\n"
+    )
+    return lead + describe(failure, attempts=2, profiles=("default", "browser"))
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+    case = sys.argv[3] if len(sys.argv) > 3 else "blocked"
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        card = _seed(app, case)
+        await pilot.pause()
+        # The body is what changed, and it is only painted when the card is
+        # open — a collapsed row shows the one-line summary either way.
+        card.toggle_expanded()
+        await pilot.pause()
+
+        # A second settled frame: a first paint that differs from this one is a
+        # reflow the user sees as motion (AGENTS.md, "Animation and multi-frame
+        # changes"). The status band is waited on so two captures of the same
+        # tree differ in the card and in nothing else.
+        await pilot.pause()
+        await settle_status_line(pilot, app)
+        screen = app.screen
+        print(
+            f"size={screen.size} virtual={screen.virtual_size} "
+            f"vscroll={screen.show_vertical_scrollbar} "
+            f"card_size={card.size} "
+            f"card_lines={len(card._build_content(size[0]).plain.splitlines())}",
+            file=sys.stderr,
+        )
+        save_capture(app, out)
+
+
+asyncio.run(main())

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -448,6 +448,11 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     "web_fetch.allow_private": (True, lambda s, w: _fetch_settings(w).allow_private),
     "web_fetch.render_backend": ("stdlib", lambda s, w: _fetch_settings(w).render_backend),
     "web_fetch.enrich": (False, lambda s, w: _fetch_settings(w).enrich),
+    # Both retry knobs are read per fetch (the service resolves settings on every
+    # call), so a change takes effect on the NEXT fetch with no reload — which is
+    # what LIVE means here.
+    "web_fetch.max_attempts": (1, lambda s, w: _fetch_settings(w).max_attempts),
+    "web_fetch.blocked_retry": (False, lambda s, w: _fetch_settings(w).blocked_retry),
     "bash.shell": ("/opt/probe/bash", lambda s, w: _bash_shell(w)),
     # -- web_tools: the inventory after the next turn boundary -----------------
     # Observed through the SAME reconcile the turn start runs, on a session

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -573,6 +573,136 @@ def test_web_fetch_non_2xx_renders_error_treatment() -> None:
     assert _style_at(card._build_content(120), "⚠ HTTP 403").color == Color.parse(danger)
 
 
+def test_a_blocked_card_names_the_vendor_and_the_attempt_count() -> None:
+    """Design review round 1, D1 + D2 + D4 + DN2, on the operator's own case.
+
+    Before this round the card printed the vendor-less generic copy in its danger
+    row while the row above it said "blocked by Akamai" — two wordings of one
+    fact, with the *name* only on the line the card throws away — and the
+    successfully-escalated fetch was character-for-character a one-attempt
+    success. It also reported the discarded challenge page's byte count on a row
+    whose line count described the replacement.
+    """
+    url = "https://www.shoppersdrugmart.ca/?lang=en&query=power+bar"
+    preview = (
+        f"⚠ HTTP 403 Forbidden — blocked by Akamai bot protection, not page content. {url}\n"
+        "text · text/html · cache miss · 2 attempts (default, browser-profile)\n\n"
+        "The origin's bot protection refused this request. A browser-shaped retry was "
+        "also refused, so no headless fetch of this URL will succeed.\n"
+        "Origin reference: 18.4b182117.1789250183.345ea6ea\n"
+        "Next step: use the `browser` tool on this URL.\n"
+        f"{url}"
+    )
+    card = ToolCard("t", "web_fetch", {"url": url})
+    card.mark_done(
+        preview,
+        {
+            "url": url,
+            "final_url": url,
+            "status": 403,
+            "content_type": "text/html",
+            "render_method": "text",
+            "cache": "miss",
+            "bytes": 382,
+            "lines": 4,
+            "ok": False,
+            "http_error": True,
+            "attempts": 2,
+            "profiles": ["default", "browser"],
+            "failure_kind": "blocked",
+            "block_vendor": "akamai",
+            "suggested_tool": "browser",
+        },
+    )
+    card.toggle_expanded()
+    content = card._build_content(120).plain
+
+    # D2: ONE danger row, and it is the one that names the vendor.
+    assert content.count("⚠ HTTP 403 Forbidden") == 1
+    assert "blocked by Akamai bot protection" in content
+    assert "error/block page, not page content" not in content
+    # D1: the count and the identity change §3.6 promises are on the card.
+    assert "2 attempts (default, browser-profile)" in content
+    # DN2: no byte count for a replaced body — it describes the discarded page.
+    assert "382 B" not in content
+    assert "text · 4 lines" in content
+
+    # D4: the actionable sentence is the anchor, the opaque reference recedes,
+    # and the prose itself is NOT dim (3.32:1 on the light error-tinted panel).
+    built = card._build_content(120)
+    assert _triplet(_style_at(built, "Next step:").color) == _triplet(
+        Style(color=theme_mod.semantic_color("signal")).color
+    )
+    assert _triplet(_style_at(built, "Origin reference:").color) == _triplet(
+        Style(color=theme_mod.semantic_color("dim")).color
+    )
+    assert _triplet(_style_at(built, "The origin's bot protection").color) == _triplet(
+        Style(color=theme_mod.semantic_color("muted")).color
+    )
+
+
+def test_a_terminal_failure_card_is_the_same_visual_family() -> None:
+    """Design review round 1, D5 + D3: a stall is a FETCH card, not a bash row.
+
+    A terminal failure carries no ``render_method``/``final_url``, so this card
+    used to fall through to the generic output body: no ⚠ lead, transcript ink,
+    and a ``Fetched:`` row with no status — two failure shapes of one tool reading
+    as two different tools. ``failure_kind`` is the key both carry.
+
+    D3 rides along here: the statement is fitted to the card's own width at paint
+    time, so it is one row where there is room and never clipped mid-word where
+    there is not.
+    """
+    url = "https://stalls.example/x"
+    explanation = (
+        "A browser-shaped retry was tried as well, since a stalled request is "
+        "frequently a silent block."
+    )
+    text = (
+        "Read timed out after 20.0s — the origin accepted the connection but never "
+        "sent a response (2 attempts: default, browser-profile)\n"
+        f"{explanation}\n"
+        "Next step: use the `browser` tool on this URL. It drives the real browser "
+        "(a write-tier, approval-gated action), which is the only path that clears "
+        "an interactive challenge.\n"
+        f"{url}"
+    )
+    card = ToolCard("t", "web_fetch", {"url": url})
+    card.restore(
+        state="error",
+        result_text=text,
+        error=text.splitlines()[0],
+        details={
+            "url": url,
+            "cache": "miss",
+            "failure_kind": "stall",
+            "attempts": 2,
+            "profiles": ["default", "browser"],
+            "suggested_tool": "browser",
+        },
+    )
+    card.toggle_expanded()
+    content = card._build_content(100).plain
+
+    # The fetch family: a structured Fetched row and a ⚠ lead…
+    assert "Fetched: " + url in content
+    assert "⚠ Read timed out after 20.0s" in content
+    # …and the lead is not repeated in the body (it was promoted, like the
+    # response family's lead is stripped).
+    assert content.count("Read timed out after 20.0s") == 1
+
+    # D3 at 80 columns: every row of the sentence is painted in full — no
+    # mid-word ellipsis, which is what the 76-cell hard wrap produced.
+    narrow = card._build_content(80).plain.splitlines()
+    explained = [row for row in narrow if "bot " in row or "silent block" in row]
+    assert explained
+    assert all("…" not in row for row in explained)
+    # D3 at 150: the sentence fits ONE row, because the wrap follows the card's
+    # width instead of stopping at a constant 76 cells.
+    wide = card._build_content(150).plain.splitlines()
+    assert any(explanation in row for row in wide)
+
+
 def test_web_fetch_low_quality_note_surfaced_once() -> None:
     """The low-quality advisory appears, and (D4) only ONCE: the model-facing
     header carried a second `· sparse/JS-gated` copy that D1's header strip

--- a/tests/unit/web_fetch/test_efficiency.py
+++ b/tests/unit/web_fetch/test_efficiency.py
@@ -104,3 +104,40 @@ async def test_fetch_cache_cannot_survive_changed_private_policy(tmp_path, monke
     )
     assert second[2]
     assert "private/loopback/reserved" in second[0]
+
+
+@pytest.mark.asyncio
+async def test_blocked_preview_does_not_spend_context_on_challenge_markup(tmp_path, monkeypatch):
+    """The context-cost guard for §5.2.
+
+    Measured before this change: medium.com's Cloudflare interstitial put ~5,507
+    bytes of challenge markup into the model-facing preview to say nothing. The
+    replacement is a statement, a reference id and a next step, so the ceiling
+    here is deliberately tight — a regression that re-inlines the body cannot
+    fit under it.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    settings = WebFetchSettings(enrich=False)
+    monkeypatch.setattr(tool, "load_fetch_settings", lambda manager: settings)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+
+    challenge = (
+        "<!DOCTYPE html><html><head><title>Just a moment...</title>"
+        + ("<script>/* challenge platform payload */</script>" * 120)
+        + "</head><body></body></html>"
+    )
+    assert len(challenge) > 5000, "the fixture must be the size the guard is about"
+
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            403, text=challenge, headers={"content-type": "text/html", "cf-mitigated": "challenge"}
+        )
+    )
+    preview, _details, is_error = await tool.run_fetch(
+        "https://walled.example/x", tool_name="web_fetch", transport=transport
+    )
+    assert is_error is True
+    assert len(preview) < 700
+    assert "Just a moment" not in preview
+    assert "<script" not in preview
+    assert "browser" in preview

--- a/tests/unit/web_fetch/test_failure.py
+++ b/tests/unit/web_fetch/test_failure.py
@@ -13,6 +13,8 @@ import httpx
 import pytest
 
 from local_operator.web_fetch.failure import (
+    _is_stock_block_page,
+    attempt_summary,
     classify_exception,
     classify_response,
     describe,
@@ -199,7 +201,10 @@ def test_empty_exception_string_still_produces_a_legible_message() -> None:
 
     failure = classify_exception(exc, timeout_s=20.0)
     text = " ".join(describe(failure, attempts=2, profiles=("default", "browser")).split())
-    assert "read timed out after 20.0s" in text
+    # Sentence case (design review round 1, DN3): this text is the card body's
+    # FIRST line in the terminal case, where a lowercase opening read as a
+    # fragment with nothing in front of it.
+    assert "Read timed out after 20.0s" in text
     assert "never sent a response" in text
     assert not text.rstrip().endswith(":")
 
@@ -226,6 +231,43 @@ def test_stock_waf_page_needs_both_title_and_heading_and_a_small_body() -> None:
     failure = classify_response(403, {"content-type": "text/html"}, article)
     assert failure is not None
     assert failure.vendor is None  # no vendor claimed for a long, unsigned body
+
+
+def test_the_stock_page_bound_is_bytes_not_characters() -> None:
+    """Review round 1, N2: ``_STOCK_PAGE_MAX_BYTES`` claimed 2 KB and compared
+    CHARACTERS.
+
+    ``body_head`` is decoded text, so the old ``len(body_head)`` was a character
+    count: 700 euro signs are 700 characters and 2 100 bytes of UTF-8, i.e. a
+    body a third larger than the bound could still be read as a "tiny stock
+    page". The unit in the name has to be the unit the comparison uses, or the
+    next person tunes this against the wrong quantity. Exercised on the predicate
+    itself: both branches of ``classify_response`` for a 403 yield
+    ``vendor=None``, so a test at that level cannot tell the two apart.
+    """
+    small_stock = "<title>Access Denied</title><h1>Access Denied</h1>"
+    assert _is_stock_block_page(small_stock) is True
+
+    big_but_few_chars = small_stock + ("\u20ac" * 700)
+    assert len(big_but_few_chars) < 2048  # what a character count sees
+    assert len(big_but_few_chars.encode("utf-8")) > 2048  # what the wire carries
+    assert _is_stock_block_page(big_but_few_chars) is False
+
+
+def test_attempt_summary_collapses_a_repeated_identity() -> None:
+    """Review round 1, Q3: ``3 attempts (default, default, default)`` is accurate
+    and reads like a bug.
+
+    The sequence exists to show a CHANGE of identity — that is the fact a reader
+    cannot get from the count — so consecutive repeats collapse while the mixed
+    case (the one that matters) is untouched.
+    """
+    assert attempt_summary(3, ("default", "default", "default")) == "3 attempts (default)"
+    assert attempt_summary(2, ("default", "browser")) == "2 attempts (default, browser-profile)"
+    assert attempt_summary(2, ("default", "default")) == "2 attempts (default)"
+    # One attempt says nothing, and an absent identity list is not a lie.
+    assert attempt_summary(1, ("default",)) == ""
+    assert attempt_summary(2, ()) == "2 attempts"
 
 
 def test_2xx_and_3xx_are_not_failures() -> None:

--- a/tests/unit/web_fetch/test_failure.py
+++ b/tests/unit/web_fetch/test_failure.py
@@ -1,0 +1,233 @@
+"""Classifier tests: what each failure class is detected from, and what it says.
+
+The marker bodies here are REAL captures taken through the live path on
+2026-09-12, not invented markup — a test written against a plausible-looking
+Cloudflare page proves nothing about the page Cloudflare actually serves. The
+Akamai body in particular is kept with its HTML entities intact, because that
+encoding is exactly what defeats a naive reference-id regex.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from local_operator.web_fetch.failure import (
+    classify_exception,
+    classify_response,
+    describe,
+    extract_reference,
+    parse_retry_after,
+)
+
+#: Captured verbatim from ``https://medium.com/`` (403, 5,507 bytes). Trimmed to
+#: the markers; the real page is mostly challenge JavaScript.
+CLOUDFLARE_BODY = (
+    '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>'
+    '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'
+    '<meta http-equiv="content-security-policy" content="default-src \'none\'; '
+    "script-src 'nonce-sxCBDQGvcCXBCxZ9Xdwr5S' https://challenges.cloudflare.com\">"
+    '</head><body><div class="main-wrapper" role="main"><noscript>'
+    '<span id="challenge-error-text">Enable JavaScript and cookies to continue</span>'
+    "</noscript></div></body></html>"
+)
+
+#: Captured verbatim from ``https://www.shoppersdrugmart.ca/?lang=en&query=power+bar``
+#: (403, 382 bytes). The entities are NOT decorative: Akamai emits the reference
+#: id as ``Reference&#32;&#35;18&#46;…`` and a regex over the raw bytes misses it.
+AKAMAI_BODY = (
+    "<HTML><HEAD>\n<TITLE>Access Denied</TITLE>\n</HEAD><BODY>\n"
+    "<H1>Access Denied</H1>\n \n"
+    "You don't have permission to access &#34;http&#58;&#47;&#47;www&#46;"
+    "shoppersdrugmart&#46;ca&#47;&#63;&#34; on this server.<P>\n"
+    "Reference&#32;&#35;18&#46;44182117&#46;1789250166&#46;2be4ae76\n"
+    "<P>https&#58;&#47;&#47;errors&#46;edgesuite&#46;net&#47;18&#46;44182117&#46;"
+    "1789250166&#46;2be4ae76</P>\n</BODY>\n</HTML>"
+)
+
+
+def test_cloudflare_header_marker_is_authoritative() -> None:
+    """``cf-mitigated: challenge`` alone classifies, with no body at all.
+
+    Cloudflare sets it specifically so a non-browser client can distinguish a
+    challenge from a real 403, which is why it is checked before any body text.
+    """
+    failure = classify_response(403, {"cf-mitigated": "challenge", "server": "cloudflare"}, "")
+    assert failure is not None
+    assert failure.kind == "blocked"
+    assert failure.vendor == "cloudflare"
+    assert failure.retryable is False
+
+
+def test_cloudflare_body_marker_without_branded_header() -> None:
+    """The body fallback catches a challenge whose headers say nothing."""
+    failure = classify_response(403, {"content-type": "text/html"}, CLOUDFLARE_BODY)
+    assert failure is not None
+    assert failure.vendor == "cloudflare"
+
+
+def test_akamai_header_and_reference_extraction() -> None:
+    """``server: AkamaiGHost`` names the vendor, and the entity-encoded
+    ``Reference #`` id survives — that id is what a human quotes to support."""
+    headers = {"server": "AkamaiGHost", "content-type": "text/html"}
+    failure = classify_response(403, headers, AKAMAI_BODY)
+    assert failure is not None
+    assert failure.kind == "blocked"
+    assert failure.vendor == "akamai"
+    assert failure.reference == "18.44182117.1789250166.2be4ae76"
+    assert extract_reference(AKAMAI_BODY, headers) == "18.44182117.1789250166.2be4ae76"
+
+
+def test_datadome_header_marker() -> None:
+    failure = classify_response(403, {"x-datadome": "protected"}, "")
+    assert failure is not None
+    assert failure.vendor == "datadome"
+
+
+def test_unmatched_403_is_blocked_but_never_labelled_a_bot_wall() -> None:
+    """The honesty rule (§2.2): an unsigned 403 earns the escalation but must
+    NOT be described as bot protection.
+
+    Claiming "bot protection" on a 403 that really means "you are not a
+    subscriber" sends the agent to `browser` when it should be asking the user
+    for credentials. The word "bot" is the assertion under test.
+    """
+    failure = classify_response(403, {"content-type": "text/html"}, "<html>nope</html>")
+    assert failure is not None
+    assert failure.kind == "blocked"
+    assert failure.vendor is None
+    assert failure.escalatable is True
+
+    text = describe(failure)
+    # The assertion is that no bot wall is CLAIMED — not that the token "bot"
+    # is absent. §2.2's own prescribed wording ("No anti-bot vendor signature
+    # was found … rather than bot protection") contains the word while denying
+    # the claim, and that denial is the more useful sentence: it tells the agent
+    # the refusal might be an access restriction. §6.6's literal "must not
+    # contain 'bot'" would have forbidden the design's own text.
+    # Flattened: `describe` pre-wraps its prose to the TUI card's row width (a
+    # card paints one row per line and clips the overflow), so the assertion is
+    # about the sentence, not about where it happens to break.
+    lowered = " ".join(text.lower().split())
+    assert "blocked by" not in lowered
+    assert "no anti-bot vendor signature was found" in lowered
+    assert "access restriction" in lowered
+    # It still names the escalation — an unsigned refusal is exactly the case
+    # where the agent has to decide between `browser` and asking the user.
+    assert "browser" in text
+
+
+def test_signed_block_says_bot_protection_and_names_the_vendor() -> None:
+    failure = classify_response(403, {"server": "AkamaiGHost"}, AKAMAI_BODY)
+    assert failure is not None
+    text = " ".join(describe(failure, attempts=2, profiles=("default", "browser")).split())
+    assert "bot protection" in text
+    assert "18.44182117.1789250166.2be4ae76" in text
+    assert "browser" in text
+    # It says the escalation was already spent, so the agent does not read
+    # "try a different client" into it.
+    assert "browser-shaped retry was also refused" in text
+
+
+def test_404_is_client_and_not_retryable() -> None:
+    failure = classify_response(404, {}, "<html>gone</html>")
+    assert failure is not None
+    assert failure.kind == "client"
+    assert failure.retryable is False
+    assert failure.escalatable is False
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+def test_server_statuses_retry(status: int) -> None:
+    failure = classify_response(status, {}, "")
+    assert failure is not None
+    assert failure.kind == "server"
+    assert failure.retryable is True
+
+
+def test_503_with_challenge_marker_is_blocked_not_server() -> None:
+    """Cloudflare's "under attack" interstitial is a 503 — and repeating the
+    request is not what clears it, so it must classify as a block."""
+    failure = classify_response(503, {"cf-mitigated": "challenge"}, CLOUDFLARE_BODY)
+    assert failure is not None
+    assert failure.kind == "blocked"
+
+
+def test_429_carries_retry_after() -> None:
+    failure = classify_response(429, {"retry-after": "7"}, "")
+    assert failure is not None
+    assert failure.kind == "ratelimit"
+    assert failure.retry_after_s == 7.0
+
+
+def test_retry_after_http_date_form_is_parsed() -> None:
+    """CDNs do emit the date form; a client that only understands seconds
+    silently falls back to its own backoff and ignores the origin."""
+    import datetime
+
+    when = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=30)
+    stamp = when.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    parsed = parse_retry_after(stamp)
+    assert parsed is not None
+    assert 20 <= parsed <= 40
+
+
+@pytest.mark.parametrize("value", ["", "soon", "-5", "0"])
+def test_retry_after_garbage_falls_back_to_none(value: str) -> None:
+    assert parse_retry_after(value) is None
+
+
+def test_read_timeout_is_a_stall_and_connect_error_is_transport() -> None:
+    request = httpx.Request("GET", "https://example.com/")
+    stall = classify_exception(httpx.ReadTimeout("", request=request), timeout_s=12.0)
+    assert stall.kind == "stall"
+    assert stall.escalatable is True
+
+    transport = classify_exception(httpx.ConnectError("boom", request=request))
+    assert transport.kind == "transport"
+    assert transport.retryable is True
+
+
+def test_empty_exception_string_still_produces_a_legible_message() -> None:
+    """The §1.3 regression: ``httpx.ReadTimeout.__str__()`` is the EMPTY STRING,
+    which is how the shipped error read ``timed out fetching '<url>': `` with
+    nothing after the colon. The text is built from the classification, so it
+    names the class and how long it waited whatever the exception says."""
+    request = httpx.Request("GET", "https://example.com/")
+    exc = httpx.ReadTimeout("", request=request)
+    assert str(exc) == ""  # the defect's root cause, asserted so it cannot drift
+
+    failure = classify_exception(exc, timeout_s=20.0)
+    text = " ".join(describe(failure, attempts=2, profiles=("default", "browser")).split())
+    assert "read timed out after 20.0s" in text
+    assert "never sent a response" in text
+    assert not text.rstrip().endswith(":")
+
+
+def test_marker_scan_window_ignores_a_late_false_positive() -> None:
+    """A 5 MB page containing "access denied" 3 MB in is NOT a block.
+
+    Guards §8 risk 6: the phrase is ordinary prose on a real page, and the 8 KB
+    window plus the stock-page size bound are what keep it from being read as a
+    refusal.
+    """
+    body = ("x" * (3 * 1024 * 1024)) + "<h1>Access Denied</h1><title>Access Denied</title>"
+    # The engine only ever passes the head, which is the behaviour under test.
+    from local_operator.web_fetch.failure import MARKER_SCAN_BYTES
+
+    failure = classify_response(403, {"content-type": "text/html"}, body[:MARKER_SCAN_BYTES])
+    assert failure is not None
+    assert failure.vendor is None  # unsigned: no marker was in the window
+
+
+def test_stock_waf_page_needs_both_title_and_heading_and_a_small_body() -> None:
+    """An article ABOUT access denials must not classify as a block."""
+    article = "<html><title>Access Denied</title>" + ("<p>a real article. " * 400) + "</html>"
+    failure = classify_response(403, {"content-type": "text/html"}, article)
+    assert failure is not None
+    assert failure.vendor is None  # no vendor claimed for a long, unsigned body
+
+
+def test_2xx_and_3xx_are_not_failures() -> None:
+    assert classify_response(200, {}, "") is None
+    assert classify_response(302, {"location": "/x"}, "") is None

--- a/tests/unit/web_fetch/test_service.py
+++ b/tests/unit/web_fetch/test_service.py
@@ -330,3 +330,451 @@ def test_cache_prune_keeps_newest(monkeypatch: pytest.MonkeyPatch) -> None:
         )
     remaining = list(service.cache_dir().iterdir())
     assert len(remaining) <= 3
+
+
+# --- retries, deadline, and the blocked-profile escalation ------------------
+#
+# These cover §3-§4 of docs/design/web_fetch_robustness.md. The recurring shape
+# is a MockTransport that counts its calls, because "how many requests did we
+# actually issue" is the property every one of these rests on and a mock's
+# return value cannot show it.
+
+
+class _Recorder:
+    """Counts requests and records the identity each one carried.
+
+    The profile is read off the User-Agent rather than asserted through an
+    internal hook: what an origin sees is the only thing that matters here, and
+    a test that inspected our own call arguments would keep passing if the
+    headers stopped reaching the wire.
+    """
+
+    def __init__(self, responder) -> None:
+        self.requests: list[httpx.Request] = []
+        self._responder = responder
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self._responder(len(self.requests), request)
+
+    @property
+    def calls(self) -> int:
+        return len(self.requests)
+
+    @property
+    def profiles(self) -> list[str]:
+        return [
+            "browser" if "Chrome/" in r.headers.get("user-agent", "") else "default"
+            for r in self.requests
+        ]
+
+
+CHALLENGE_HEADERS = {"content-type": "text/html", "cf-mitigated": "challenge"}
+CHALLENGE_BODY = "<html><head><title>Just a moment...</title></head><body></body></html>"
+
+
+@pytest.fixture
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record backoff sleeps instead of serving them.
+
+    Per AGENTS.md ("wait on the event, never on the clock"), the assertions
+    below are on WHAT was slept, never on elapsed wall time — so these tests
+    cannot flake under load and do not spend a second of suite time proving a
+    backoff happened.
+    """
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(service, "_backoff_sleep", fake_sleep)
+    return slept
+
+
+@pytest.mark.asyncio
+async def test_transient_500_then_200_recovers(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """The headline case: a 500 from a rolling deploy no longer fails the call."""
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        if n == 1:
+            return httpx.Response(500, text="broke")
+        return httpx.Response(200, text="recovered", headers={"content-type": "text/plain"})
+
+    recorder = _Recorder(responder)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    result = await svc.fetch("https://example.com/x")
+
+    assert result.status == 200
+    assert "recovered" in result.content
+    assert result.attempts == 2
+    assert recorder.calls == 2
+    assert len(_no_sleep) == 1  # exactly one backoff, between the two attempts
+    # A retried SUCCESS is a success: the earlier 500 must not be reported as
+    # the outcome's failure class.
+    assert result.failure_kind is None
+
+
+@pytest.mark.asyncio
+async def test_persistent_500_stops_at_max_attempts(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """The attempt count is bounded and asserted on the TRANSPORT, not inferred."""
+    recorder = _Recorder(lambda n, req: httpx.Response(500, text="still broke"))
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder), max_attempts=3)
+    result = await svc.fetch("https://example.com/x")
+
+    assert result.status == 500
+    assert recorder.calls == 3
+    assert result.attempts == 3
+    assert result.failure_kind == "server"
+
+
+@pytest.mark.asyncio
+async def test_404_is_never_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 404 will not become a 200; retrying spends the user's turn for nothing."""
+    recorder = _Recorder(lambda n, req: httpx.Response(404, text="gone"))
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    result = await svc.fetch("https://example.com/missing")
+
+    assert recorder.calls == 1
+    assert result.attempts == 1
+    assert result.failure_kind == "client"
+
+
+@pytest.mark.asyncio
+async def test_retry_after_small_value_is_honoured(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """The origin named its own interval and it fits inside the turn: sleep it."""
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        if n == 1:
+            return httpx.Response(429, text="slow down", headers={"retry-after": "2"})
+        return httpx.Response(200, text="ok", headers={"content-type": "text/plain"})
+
+    recorder = _Recorder(responder)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    result = await svc.fetch("https://example.com/x")
+
+    assert result.status == 200
+    # Slept EXACTLY the origin's number, not our backoff curve.
+    assert _no_sleep == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_retry_after_large_value_is_reported_not_slept(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """Blocking a live turn for 15 minutes to obey a header is worse for the user
+    than handing the agent the number and letting it come back later."""
+    recorder = _Recorder(
+        lambda n, req: httpx.Response(429, text="later", headers={"retry-after": "900"})
+    )
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    result = await svc.fetch("https://example.com/x")
+
+    assert recorder.calls == 1
+    assert _no_sleep == []  # nothing was slept
+    assert result.retry_after_s == 900.0
+
+
+@pytest.mark.asyncio
+async def test_validate_public_url_runs_once_per_attempt(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """THE rebinding guard across retries (§8 risk 1).
+
+    Hoisting ``validate_public_url`` out of the attempt loop "for efficiency"
+    would let a host that turns private between attempts be re-contacted without
+    a check. The count is asserted directly: one validation per network attempt,
+    never one per hop.
+    """
+    validations: list[str] = []
+    real_validate = service.validate_public_url
+
+    def counting_validate(url: str, *, allow_private: bool = False) -> str | None:
+        validations.append(url)
+        return real_validate(url, allow_private=allow_private)
+
+    monkeypatch.setattr(service, "validate_public_url", counting_validate)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+
+    recorder = _Recorder(lambda n, req: httpx.Response(503, text="down"))
+    svc = _service(httpx.MockTransport(recorder), max_attempts=3)
+    await svc.fetch("https://example.com/x")
+
+    assert recorder.calls == 3
+    assert len(validations) == 3
+    assert validations == ["https://example.com/x"] * 3
+
+
+@pytest.mark.asyncio
+async def test_retry_refuses_a_host_that_turns_private(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """The consequence of the above, end to end: attempt 1 resolves public and
+    fails; attempt 2 resolves to loopback and must be REFUSED, not followed."""
+    resolutions = iter([["93.184.216.34"], ["127.0.0.1"], ["127.0.0.1"]])
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: next(resolutions))
+
+    recorder = _Recorder(lambda n, req: httpx.Response(500, text="broke"))
+    svc = _service(httpx.MockTransport(recorder))
+    with pytest.raises(FetchError, match="private/loopback/reserved"):
+        await svc.fetch("https://rebind.example/x")
+
+    # The second attempt never reached the transport.
+    assert recorder.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_every_attempt_including_the_escalation_stays_pinned(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """The pin must survive the browser profile: the escalated request carries
+    its own headers, and merging them over the pin's ``Host`` would unpin it."""
+    recorder = _Recorder(
+        lambda n, req: httpx.Response(403, text=CHALLENGE_BODY, headers=CHALLENGE_HEADERS)
+    )
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    await svc.fetch("https://pinned.example/x")
+
+    assert recorder.calls == 2
+    assert recorder.profiles == ["default", "browser"]
+    for request in recorder.requests:
+        assert request.url.host == "93.184.216.34"  # the vetted IP, never the name
+        assert request.headers["host"] == "pinned.example"
+        assert request.extensions.get("sni_hostname") == "pinned.example"
+
+
+@pytest.mark.asyncio
+async def test_blocked_retry_flips_a_challenge_to_success(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """The measured medium.com win, reproduced deterministically: the honest
+    profile is refused and the browser-shaped one is served."""
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        if "Chrome/" in request.headers.get("user-agent", ""):
+            return httpx.Response(200, text="the real page", headers={"content-type": "text/html"})
+        return httpx.Response(403, text=CHALLENGE_BODY, headers=CHALLENGE_HEADERS)
+
+    recorder = _Recorder(responder)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    result = await svc.fetch("https://walled.example/x")
+
+    assert result.status == 200
+    assert "the real page" in result.content
+    assert result.attempts == 2
+    assert result.profile == "browser"
+    assert recorder.profiles == ["default", "browser"]
+
+
+@pytest.mark.asyncio
+async def test_blocked_retry_fires_exactly_once(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """A refusal costs exactly 2 requests: the honest one and the escalation.
+    There is no third, and the block class is never retried with the same
+    identity (the origin already decided about this client)."""
+    recorder = _Recorder(
+        lambda n, req: httpx.Response(403, text=CHALLENGE_BODY, headers=CHALLENGE_HEADERS)
+    )
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder), max_attempts=3)
+    result = await svc.fetch("https://walled.example/x")
+
+    assert recorder.calls == 2
+    assert result.failure_kind == "blocked"
+    assert result.block_vendor == "cloudflare"
+
+
+@pytest.mark.asyncio
+async def test_blocked_retry_disabled_costs_one_request(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """The switch exists for an operator who wants the client to stay honest
+    even in the face of a refusal."""
+    recorder = _Recorder(
+        lambda n, req: httpx.Response(403, text=CHALLENGE_BODY, headers=CHALLENGE_HEADERS)
+    )
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder), blocked_retry=False)
+    result = await svc.fetch("https://walled.example/x")
+
+    assert recorder.calls == 1
+    assert recorder.profiles == ["default"]
+    assert result.failure_kind == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_escalation_is_once_per_fetch_not_once_per_hop(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """A redirect chain must not be able to multiply the escalation budget."""
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/a":
+            return httpx.Response(302, headers={"location": "https://example.com/b"})
+        return httpx.Response(403, text=CHALLENGE_BODY, headers=CHALLENGE_HEADERS)
+
+    recorder = _Recorder(responder)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    await svc.fetch("https://example.com/a")
+
+    # hop 1 (the 302) + hop 2 default + hop 2 escalation == 3, never 4.
+    assert recorder.calls == 3
+    assert recorder.profiles.count("browser") == 1
+
+
+@pytest.mark.asyncio
+async def test_deadline_bounds_the_whole_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hard invariant (§3.3): retries divide ONE budget rather than each
+    getting a fresh copy of the timeout.
+
+    Asserted structurally on a fake clock rather than on wall time, per AGENTS.md
+    "prefer a structural invariant to a numeric one": the timeout each attempt is
+    granted must never exceed what is left of the call's budget.
+    """
+    granted: list[float] = []
+    clock = {"t": 0.0}
+    monkeypatch.setattr(service, "_now", lambda: clock["t"])
+
+    async def fake_sleep(delay: float) -> None:
+        clock["t"] += delay
+
+    monkeypatch.setattr(service, "_backoff_sleep", fake_sleep)
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        timeout = request.extensions.get("timeout") or {}
+        granted.append(float(timeout.get("read", 0.0)))
+        # Each attempt "spends" most of what it was granted before failing.
+        clock["t"] += granted[-1] * 0.9
+        return httpx.Response(503, text="down")
+
+    recorder = _Recorder(responder)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder), max_attempts=5)
+    await svc.fetch("https://example.com/x", timeout_seconds=10.0)
+
+    assert granted, "no attempt recorded its timeout"
+    # Every attempt's budget fits inside what remained, and the total never
+    # exceeds the call's timeout.
+    assert all(t > 0 for t in granted)
+    assert clock["t"] <= 10.0
+    # The deadline, not max_attempts, is what stopped it.
+    assert recorder.calls < 5
+
+
+@pytest.mark.asyncio
+async def test_first_attempt_is_shortened_while_a_fallback_remains(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """§3.3's stall shortening: attempt 1 gets at most 0.6·T so a black-holing
+    origin leaves time for the browser-shaped probe that actually answers.
+
+    The LAST attempt still gets the full remaining budget — a genuinely slow
+    origin must not be penalised on its final try — which is the second half of
+    the assertion.
+    """
+    granted: list[float] = []
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        timeout = request.extensions.get("timeout") or {}
+        granted.append(float(timeout.get("read", 0.0)))
+        raise httpx.ReadTimeout("", request=request)
+
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(_Recorder(responder)))
+    with pytest.raises(FetchError):
+        await svc.fetch("https://stalls.example/x", timeout_seconds=20.0)
+
+    assert len(granted) == 2  # the stall earns the escalation, not a blind repeat
+    assert granted[0] <= 20.0 * service._STALL_FIRST_ATTEMPT_FRACTION + 0.01
+    # The escalated attempt is the last one and is not artificially shortened.
+    assert granted[1] > granted[0] * 0.5
+
+
+@pytest.mark.asyncio
+async def test_stall_message_names_the_class_and_is_never_empty(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """The §1.3 regression, end to end: ``httpx.ReadTimeout`` stringifies to ""
+    and the old message ended in ``': '`` with nothing after it."""
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("", request=request)
+
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(_Recorder(responder)))
+    with pytest.raises(FetchError) as excinfo:
+        await svc.fetch("https://stalls.example/x", timeout_seconds=5.0)
+
+    message = str(excinfo.value)
+    assert "timed out" in message
+    assert "never sent a response" in message
+    assert "https://stalls.example/x" in message
+    assert not message.rstrip().endswith(":")
+    assert not message.rstrip().endswith("': '")
+
+
+@pytest.mark.asyncio
+async def test_enrichment_probe_never_spends_the_escalation(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """A speculative ``.md`` twin is an optimisation, and must not pay a second
+    request to diagnose itself — nor consume the escalation the real fetch may
+    need."""
+    recorder = _Recorder(
+        lambda n, req: (
+            httpx.Response(403, text=CHALLENGE_BODY, headers=CHALLENGE_HEADERS)
+            if req.url.path.endswith(".md")
+            else httpx.Response(200, text="the page", headers={"content-type": "text/html"})
+        )
+    )
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    settings = WebFetchSettings(enrich=True)
+    svc = WebFetchService(settings, transport=httpx.MockTransport(recorder))
+    result = await svc.fetch("https://docs.example.com/guide/page")
+
+    assert result.status == 200
+    # The blocked probe cost exactly one request, and the escalation was still
+    # available (unspent) for the real fetch.
+    md_calls = [r for r in recorder.requests if r.url.path.endswith(".md")]
+    assert len(md_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_max_attempts_one_reproduces_the_pre_retry_behaviour(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``max_attempts: 1`` with the escalation off is byte-for-byte today's
+    engine: one request, one result, no diagnostics invented."""
+    recorder = _Recorder(
+        lambda n, req: httpx.Response(200, text="hello", headers={"content-type": "text/plain"})
+    )
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder), max_attempts=1, blocked_retry=False)
+    result = await svc.fetch("https://example.com/x")
+
+    assert recorder.calls == 1
+    assert result.attempts == 1
+    assert result.profile == "default"
+    assert result.failure_kind is None
+    assert "hello" in result.content
+
+
+def test_coerce_clamps_attempts() -> None:
+    assert coerce_fetch_settings({"max_attempts": 99}).max_attempts == 5
+    assert coerce_fetch_settings({"max_attempts": 0}).max_attempts == 1
+    assert coerce_fetch_settings({}).max_attempts == 3
+    assert coerce_fetch_settings({}).blocked_retry is True

--- a/tests/unit/web_fetch/test_service.py
+++ b/tests/unit/web_fetch/test_service.py
@@ -7,6 +7,8 @@ rather than depending on live DNS.
 
 from __future__ import annotations
 
+import asyncio
+
 import httpx
 import pytest
 
@@ -463,8 +465,12 @@ async def test_retry_after_small_value_is_honoured(
     result = await svc.fetch("https://example.com/x")
 
     assert result.status == 200
-    # Slept EXACTLY the origin's number, not our backoff curve.
-    assert _no_sleep == [2.0]
+    # Honoured, PLUS the same ±25 % jitter our own backoff curve carries
+    # (design §3.4). The burst it prevents is real: the tool description invites
+    # parallel fetches, and several calls refused by one rate-limited origin
+    # would otherwise sleep the identical interval and retry in lockstep.
+    assert len(_no_sleep) == 1
+    assert 2.0 * (1 - service._RETRY_JITTER) <= _no_sleep[0] <= 2.0 * (1 + service._RETRY_JITTER)
 
 
 @pytest.mark.asyncio
@@ -676,32 +682,88 @@ async def test_deadline_bounds_the_whole_call(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.asyncio
-async def test_first_attempt_is_shortened_while_a_fallback_remains(
+async def test_first_attempt_gets_the_full_remaining_budget(
     monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
 ) -> None:
-    """§3.3's stall shortening: attempt 1 gets at most 0.6·T so a black-holing
-    origin leaves time for the browser-shaped probe that actually answers.
+    """Review round 1, R1: there is NO first-attempt cap, and this pins it.
 
-    The LAST attempt still gets the full remaining budget — a genuinely slow
-    origin must not be penalised on its final try — which is the second half of
-    the assertion.
+    A cap of ``min(remaining, 0.6 * T)`` used to apply to the first attempt of a
+    hop whenever a fallback remained — which, with the defaults, is always. It
+    read as "reserve time for the escalation", but ``httpx``'s read timeout
+    bounds the wait for response HEADERS as well as inter-chunk gaps, so it was
+    really a 12 s timeout on a 20 s fetch: any origin whose time-to-first-byte
+    fell between 12 s and 20 s was cut off on its first, honest attempt and then
+    handed a browser-profile retry with the remaining 8 s, reported to the model
+    as a silent block naming a vendor we never saw. See
+    ``test_slow_but_working_origin_still_succeeds`` for that end to end.
+
+    The stall case here also pins the CONSEQUENCE the manager accepted: a stall
+    that spends the budget leaves the escalation nothing to spend, so it does not
+    run at all — one honest request, and an honest stall.
     """
     granted: list[float] = []
+    clock = {"t": 0.0}
+    monkeypatch.setattr(service, "_now", lambda: clock["t"])
 
     def responder(n: int, request: httpx.Request) -> httpx.Response:
         timeout = request.extensions.get("timeout") or {}
         granted.append(float(timeout.get("read", 0.0)))
+        # The origin accepts the connection and never answers: it burns exactly
+        # what it was granted, which is what a black-holing host does.
+        clock["t"] += granted[-1]
         raise httpx.ReadTimeout("", request=request)
 
     monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
     svc = _service(httpx.MockTransport(_Recorder(responder)))
-    with pytest.raises(FetchError):
+    with pytest.raises(FetchError) as excinfo:
         await svc.fetch("https://stalls.example/x", timeout_seconds=20.0)
 
-    assert len(granted) == 2  # the stall earns the escalation, not a blind repeat
-    assert granted[0] <= 20.0 * service._STALL_FIRST_ATTEMPT_FRACTION + 0.01
-    # The escalated attempt is the last one and is not artificially shortened.
-    assert granted[1] > granted[0] * 0.5
+    assert granted == [pytest.approx(20.0)]  # the WHOLE budget, not 0.6 * 20
+    assert len(granted) == 1  # the spent budget funds no escalation
+    assert "Read timed out" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_slow_but_working_origin_still_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """THE regression guard for review round 1, R1.
+
+    A 13 s-first-byte origin is inside the default 20 s budget and succeeded on
+    the pre-change engine. Under the 0.6 first-attempt cap it FAILED: attempt 1
+    was granted 12 s, timed out, and the escalation was granted 8 s — also short
+    — so a working URL became a terminal "stall" whose text claimed the origin
+    "never sent a response". This test is the guard, and it did not exist before
+    the cap was removed.
+
+    Fake clock, structural assertion (AGENTS.md: "prefer a structural invariant to
+    a numeric one"): the transport answers 200 only when the read budget it was
+    granted covers what the origin needs, and otherwise burns the budget and
+    raises, exactly like a real slow origin. No wall-clock waiting.
+    """
+    needed = 13.0  # > 0.6 * 20 = 12, < 20
+    granted: list[float] = []
+    clock = {"t": 0.0}
+    monkeypatch.setattr(service, "_now", lambda: clock["t"])
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        timeout = request.extensions.get("timeout") or {}
+        budget = float(timeout.get("read", 0.0))
+        granted.append(budget)
+        if budget < needed:
+            clock["t"] += budget
+            raise httpx.ReadTimeout("", request=request)
+        clock["t"] += needed
+        return httpx.Response(200, text="slow but real", headers={"content-type": "text/plain"})
+
+    recorder = _Recorder(responder)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    result = await svc.fetch("https://slow.example.com/x", timeout_seconds=20.0)
+
+    assert result.status == 200
+    assert "slow but real" in result.content
+    assert result.attempts == 1
+    assert recorder.calls == 1
+    assert granted == [pytest.approx(20.0)]
 
 
 @pytest.mark.asyncio
@@ -771,6 +833,91 @@ async def test_max_attempts_one_reproduces_the_pre_retry_behaviour(
     assert result.profile == "default"
     assert result.failure_kind is None
     assert "hello" in result.content
+
+
+@pytest.mark.asyncio
+async def test_retry_after_does_not_ride_into_a_later_failure(
+    monkeypatch: pytest.MonkeyPatch, _no_sleep: list[float]
+) -> None:
+    """Review round 1, R3: the reported ``Retry-After`` belongs to the outcome.
+
+    Reproduced before the fix: a 429 carrying ``Retry-After: 2`` followed by a
+    persistent 503 reported ``failure_kind=server`` **with** ``retry_after_s=2.0``
+    — a number the reported failure never sent, which is worse than no number,
+    because a caller acting on it waits out an interval nothing asked for.
+    """
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        if n == 1:
+            return httpx.Response(429, headers={"retry-after": "2"}, text="slow down")
+        return httpx.Response(503, text="down")
+
+    recorder = _Recorder(responder)
+    monkeypatch.setattr(service, "_resolve_host_ips", lambda host: ["93.184.216.34"])
+    svc = _service(httpx.MockTransport(recorder))
+    result = await svc.fetch("https://flaky.example/x", timeout_seconds=20.0)
+
+    assert result.status == 503
+    assert result.failure_kind == "server"
+    assert result.retry_after_s is None
+
+
+@pytest.mark.asyncio
+async def test_the_attempt_timeout_is_recomputed_after_the_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Review round 1, R4: the attempt timeout used to be computed BEFORE the
+    (unbounded) DNS validation, so a slow resolver pushed the request's own
+    timeout past the deadline and the "hard ceiling T" claim had a hole.
+
+    Structural, with a fake clock: the resolver spends 5 s of a 20 s budget, so
+    the request that follows must be granted 15 s, not 20.
+    """
+    clock = {"t": 0.0}
+    monkeypatch.setattr(service, "_now", lambda: clock["t"])
+    granted: list[float] = []
+
+    def slow_validate(url: str, *, allow_private: bool = False) -> str | None:
+        clock["t"] += 5.0
+        return "93.184.216.34"
+
+    def responder(n: int, request: httpx.Request) -> httpx.Response:
+        granted.append(float((request.extensions.get("timeout") or {}).get("read", 0.0)))
+        return httpx.Response(200, text="ok", headers={"content-type": "text/plain"})
+
+    monkeypatch.setattr(service, "validate_public_url", slow_validate)
+    svc = _service(httpx.MockTransport(_Recorder(responder)))
+    result = await svc.fetch("https://slow-dns.example/x", timeout_seconds=20.0)
+
+    assert result.status == 200
+    assert granted == [pytest.approx(15.0)]
+
+
+@pytest.mark.asyncio
+async def test_a_hung_resolver_cannot_outlast_the_call_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half of R4: ``getaddrinfo`` has no timeout of its own, so the
+    lookup is bounded by the same remaining budget the request is.
+
+    Asserted on the EVENT, not the clock (AGENTS.md): the resolver here sleeps far
+    longer than the budget, and the call must return a classified failure — the
+    outer ``wait_for`` is a guard so a regression FAILS rather than hangs.
+    """
+    import time as _time
+
+    def hung_validate(url: str, *, allow_private: bool = False) -> str | None:
+        _time.sleep(3.0)
+        return "93.184.216.34"
+
+    monkeypatch.setattr(service, "validate_public_url", hung_validate)
+    svc = _service(httpx.MockTransport(_Recorder(lambda n, req: httpx.Response(200))))
+
+    with pytest.raises(FetchError) as excinfo:
+        await asyncio.wait_for(
+            svc.fetch("https://hung.example/x", timeout_seconds=1.0), timeout=2.5
+        )
+    assert "could not be resolved in time" in str(excinfo.value)
 
 
 def test_coerce_clamps_attempts() -> None:

--- a/tests/unit/web_fetch/test_tool.py
+++ b/tests/unit/web_fetch/test_tool.py
@@ -614,6 +614,66 @@ def _cache_files() -> list[str]:
 
 
 @pytest.mark.asyncio
+async def test_terminal_failure_details_agree_with_its_own_preview(
+    context: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Review round 1, Q1: the terminal path dropped ``attempts``/``profiles``.
+
+    The preview said "3 attempts" while ``details`` carried only ``failure_kind``,
+    so the structured contract §5.3 defines (``attempts`` is a key, excluded only
+    for a cache hit) was broken on exactly the failures that need it most. The
+    facts now ride the exception from the engine, so the two cannot disagree.
+    """
+    monkeypatch.setattr(service, "_backoff_sleep", lambda delay: asyncio.sleep(0))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("no route", request=request)
+
+    transport = _CountingTransport(handler)
+    preview, details, is_error = await run_fetch(
+        "https://dead.example/x", tool_name="web_fetch", context=context, transport=transport
+    )
+
+    assert is_error is True
+    assert details["failure_kind"] == "transport"
+    assert details["attempts"] == 3
+    assert details["profiles"] == ["default", "default", "default"]
+    assert "3 attempts" in preview
+
+
+@pytest.mark.asyncio
+async def test_a_large_retry_after_reaches_the_model_text(context: ToolContext) -> None:
+    """Review round 1, Q2: §3.4 requires the interval in the TEXT and in details.
+
+    A 429 bears a response, so its preview is built by ``_header_line`` and never
+    by ``describe`` — which meant the number reached ``details`` and stopped
+    there, leaving the agent to be silently refused after one attempt with no
+    reason given. Reproduced before the fix: ``error: ⚠ HTTP 429 Too Many
+    Requests — this is an error/block page …`` with no mention of 600.
+    """
+    transport = _CountingTransport(
+        lambda req: httpx.Response(
+            429,
+            text="slow down",
+            headers={"content-type": "text/plain", "retry-after": "600"},
+        )
+    )
+    preview, details, is_error = await run_fetch(
+        "https://busy.example/x", tool_name="web_fetch", context=context, transport=transport
+    )
+
+    assert is_error is True
+    assert details["retry_after_s"] == 600.0
+    assert "600" in preview
+    assert "asked us to wait" in preview
+    # Not slept on, and not retried either: one attempt, reported. ``attempts`` is
+    # the structured form of that claim (a second try would read 2), and it is the
+    # one that cannot be confused by an enrichment probe also reaching the
+    # transport.
+    assert details["attempts"] == 1
+
+
+@pytest.mark.asyncio
 async def test_repeated_5xx_is_never_cached_and_a_retried_200_is(
     context: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -697,6 +757,11 @@ async def test_cache_hit_reports_zero_attempts(context: ToolContext) -> None:
     )
     assert details["cache"] == "hit"
     assert details["attempts"] == 0
+    # …and no identity either. ``profiles`` names the clients that made the
+    # requests, and a hit made none: ``attempts: 0`` beside
+    # ``profiles: ["default"]`` reported a request identity for a call that never
+    # opened a socket (review round 1, N3).
+    assert details["profiles"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/web_fetch/test_tool.py
+++ b/tests/unit/web_fetch/test_tool.py
@@ -7,6 +7,7 @@ real against an isolated config dir.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Callable
 
 import httpx
@@ -290,8 +291,21 @@ async def test_non_2xx_surfaced_as_error_not_content(
     assert details["status"] == status
     # (b) leads with the prominent, unmissable status line
     assert preview.startswith(f"⚠ HTTP {status} {reason}")
-    assert "error/block page, not page content" in preview
-    assert "The body below is the error response" in preview
+    if status == 403:
+        # A 403 is now classified: this body carries no vendor signature, so the
+        # lead says the origin refused the request and names the ambiguity
+        # instead of the generic "error/block page" wording. The F1 property
+        # under test — an unmissable lead that cannot be mistaken for content —
+        # is unchanged and asserted above; only the reason phrase is sharper.
+        # The class also replaces the challenge body with an explanation, so the
+        # "body below is the error response" note is deliberately absent (it
+        # would describe the wrong thing).
+        assert "the origin refused this request" in preview
+        assert details["failure_kind"] == "blocked"
+        assert details["suggested_tool"] == "browser"
+    else:
+        assert "error/block page, not page content" in preview
+        assert "The body below is the error response" in preview
     # (c) not cached: a second fetch hits the network again
     calls = transport.calls
     _p2, d2, _e2 = await run_fetch(
@@ -577,3 +591,231 @@ async def test_a_disabled_fetch_refuses_per_call_without_touching_the_network(
     )
     assert is_error is False
     assert transport.calls >= 1
+
+
+# --- retries, cacheability, and the blocked result shape --------------------
+
+
+CHALLENGE_HEADERS = {"content-type": "text/html", "server": "AkamaiGHost"}
+#: The real shoppersdrugmart.ca body, entities intact (see test_failure.py).
+AKAMAI_BODY = (
+    "<HTML><HEAD>\n<TITLE>Access Denied</TITLE>\n</HEAD><BODY>\n"
+    "<H1>Access Denied</H1>\n \n"
+    "You don't have permission to access this server.<P>\n"
+    "Reference&#32;&#35;18&#46;44182117&#46;1789250166&#46;2be4ae76\n</BODY>\n</HTML>"
+)
+
+
+def _cache_files() -> list[str]:
+    try:
+        return [p.name for p in service.cache_dir().iterdir() if p.suffix == ".json"]
+    except OSError:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_repeated_5xx_is_never_cached_and_a_retried_200_is(
+    context: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """M4 still holds AFTER retries: a transient outage must never be replayed
+    for the TTL, while a success that took two tries is an ordinary success.
+
+    Asserted on the cache DIRECTORY rather than a mock, because "nothing was
+    written" is a statement about the disk.
+    """
+    monkeypatch.setattr(service, "_backoff_sleep", lambda delay: asyncio.sleep(0))
+    state = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Count only the TARGET path: an enrichment probe (``/x.md``) is a real
+        # request but not the one under test, and letting it consume a scripted
+        # response would make the attempt numbers describe the optimisation
+        # instead of the fetch.
+        if not request.url.path.endswith("/x"):
+            return httpx.Response(404, text="no probe here")
+        state["n"] += 1
+        if state["n"] <= 3:
+            return httpx.Response(500, text="down")
+        return httpx.Response(200, text="back up", headers={"content-type": "text/plain"})
+
+    transport = _CountingTransport(handler)
+    _p, details, is_error = await run_fetch(
+        "https://flaky.example/x", tool_name="web_fetch", context=context, transport=transport
+    )
+    assert is_error is True
+    assert details["attempts"] == 3
+    assert _cache_files() == []  # three failures wrote nothing
+
+    _p2, d2, e2 = await run_fetch(
+        "https://flaky.example/x", tool_name="web_fetch", context=context, transport=transport
+    )
+    assert e2 is False
+    assert d2["attempts"] == 1
+    assert len(_cache_files()) == 1  # the success IS cached
+
+
+@pytest.mark.asyncio
+async def test_retried_success_is_cached_with_its_attempt_count(
+    context: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 500-then-200 is a success that happened to cost two requests."""
+    monkeypatch.setattr(service, "_backoff_sleep", lambda delay: asyncio.sleep(0))
+    state = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Only the target path is scripted; see the note in the test above.
+        if not request.url.path.endswith("/x"):
+            return httpx.Response(404, text="no probe here")
+        state["n"] += 1
+        if state["n"] == 1:
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(200, text="content here", headers={"content-type": "text/plain"})
+
+    transport = _CountingTransport(handler)
+    preview, details, is_error = await run_fetch(
+        "https://slow.example/x", tool_name="web_fetch", context=context, transport=transport
+    )
+    assert is_error is False
+    assert details["attempts"] == 2
+    # The count rides in the header meta line, so a longer duration is legible
+    # rather than looking like a slow network.
+    assert "2 attempts" in preview
+    assert len(_cache_files()) == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_reports_zero_attempts(context: ToolContext) -> None:
+    """Truthful: a cache hit made no network attempt at all."""
+    transport = _CountingTransport(
+        lambda req: httpx.Response(200, text="page", headers={"content-type": "text/plain"})
+    )
+    await run_fetch(
+        "https://example.com/cached", tool_name="web_fetch", context=context, transport=transport
+    )
+    _p, details, _e = await run_fetch(
+        "https://example.com/cached", tool_name="web_fetch", context=context, transport=transport
+    )
+    assert details["cache"] == "hit"
+    assert details["attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_blocked_result_drops_the_challenge_body_and_names_the_escalation(
+    context: ToolContext,
+) -> None:
+    """§5.2: the challenge markup is REPLACED, not inlined.
+
+    The body is unusable by construction — markup whose purpose is to be executed
+    by a browser — and inlining it cost ~5.5 KB of context (measured on
+    medium.com) to tell the agent nothing, under a lead that invited the misread
+    that it was page content. What survives is the one durable fact (the origin's
+    reference id) plus the named next step.
+    """
+    transport = _CountingTransport(
+        lambda req: httpx.Response(403, text=AKAMAI_BODY, headers=CHALLENGE_HEADERS)
+    )
+    preview, details, is_error = await run_fetch(
+        "https://walled.example/x", tool_name="web_fetch", context=context, transport=transport
+    )
+
+    assert is_error is True
+    # The markup is gone.
+    assert "Access Denied" not in preview
+    assert "<html" not in preview.lower()
+    # The useful parts are not.
+    assert "18.44182117.1789250166.2be4ae76" in preview
+    assert "browser" in preview
+    assert "Akamai" in preview
+    # And the escalation is data as well as prose, so a UI or a future caller
+    # does not have to parse the sentence.
+    assert details["failure_kind"] == "blocked"
+    assert details["block_vendor"] == "akamai"
+    assert details["block_reference"] == "18.44182117.1789250166.2be4ae76"
+    assert details["suggested_tool"] == "browser"
+
+
+@pytest.mark.asyncio
+async def test_404_body_is_still_inlined(context: ToolContext) -> None:
+    """The §5.2 narrowing applies to the ``blocked`` class ONLY: a 404's body,
+    like a 451's and a 500's, often genuinely explains itself."""
+    body = "<html><body><h1>Page moved</h1><p>See /guide/new-page instead.</p></body></html>"
+    transport = _CountingTransport(
+        lambda req: httpx.Response(404, text=body, headers={"content-type": "text/html"})
+    )
+    preview, details, is_error = await run_fetch(
+        "https://docs.example.com/old", tool_name="web_fetch", context=context, transport=transport
+    )
+    assert is_error is True
+    assert "Page moved" in preview
+    assert "/guide/new-page" in preview
+    assert details["failure_kind"] == "client"
+    assert "suggested_tool" not in details
+
+
+@pytest.mark.asyncio
+async def test_existing_details_keys_keep_their_names_and_types(
+    context: ToolContext,
+) -> None:
+    """§5.3 is ADDITIVE: the card, the UI row model and any stored transcript
+    read these, so a rename or a retype here breaks a second repo silently."""
+    transport = _CountingTransport(
+        lambda req: httpx.Response(200, text="hello", headers={"content-type": "text/plain"})
+    )
+    _p, details, _e = await run_fetch(
+        "https://example.com/x", tool_name="web_fetch", context=context, transport=transport
+    )
+    expected: dict[str, type] = {
+        "url": str,
+        "final_url": str,
+        "status": int,
+        "content_type": str,
+        "render_method": str,
+        "bytes": int,
+        "complete": bool,
+        "low_quality": bool,
+        "cache": str,
+        "ok": bool,
+        "http_error": bool,
+    }
+    for key, kind in expected.items():
+        assert key in details, f"{key} disappeared from details"
+        assert isinstance(details[key], kind), f"{key} changed type"
+
+
+@pytest.mark.asyncio
+async def test_abort_during_a_backoff_returns_promptly(context: ToolContext) -> None:
+    """§3.5: the backoff is a plain ``asyncio.sleep`` inside the raced coroutine,
+    so an abort lands on it immediately rather than waiting the delay out.
+
+    Structural, not timed: the signal is set while the sleep is in flight and the
+    assertion is on the RESULT, so the test cannot flake under load.
+    """
+    from local_operator.harness.types import AbortSignal
+
+    signal = AbortSignal()
+    started = asyncio.Event()
+
+    async def slow_backoff(delay: float) -> None:
+        started.set()
+        await asyncio.sleep(30)  # never completes; the abort must cut it short
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(service, "_backoff_sleep", slow_backoff)
+        transport = _CountingTransport(lambda req: httpx.Response(503, text="down"))
+
+        async def abort_when_sleeping() -> None:
+            await started.wait()
+            signal.abort()
+
+        waiter = asyncio.create_task(abort_when_sleeping())
+        preview, _details, is_error = await run_fetch(
+            "https://example.com/x",
+            tool_name="web_fetch",
+            context=context,
+            transport=transport,
+            signal=signal,
+        )
+        await waiter
+
+    assert is_error is True
+    assert "aborted" in preview.lower()


### PR DESCRIPTION
# PR Description

## Summary of Changes

Every `web_fetch` in a live shopping turn came back `is_error=True`, the model-facing body was
the origin's Akamai block page presented under a warning lead, and nothing in the result named a
next step — so the agent spent ~40 tool calls probing URL shapes with no working escalation.

That is three defects in the harness tool, not one. All three are measured against `origin/main`
in this worktree, not estimated:

- **No retries anywhere.** `_follow` made exactly one `_stream_once` call per hop, so a read
  timeout, a connection reset, a mid-body EOF, a 500, a 502, a 503 or a 429 failed the whole call
  on the first try.
- **Exactly one request identity, and a maximally blockable one.** `USER_AGENT` was the only
  header set — no `Accept`, no `Accept-Language`, no `Sec-Fetch-*`. `https://medium.com/` answers
  it with **403, 5,507 bytes, `cf-mitigated: challenge`**; a browser-shaped profile gets
  **200 and ~53 KB of real page**, 3/3 reproductions, including through the SSRF-pinned path.
- **Failure text that could not be read.** `httpx.ReadTimeout.__str__()` is the **empty string**,
  so `canadiantire.ca` returned ``timed out fetching '<url>': `` — nothing after the colon —
  after burning the full 20.6 s budget.

Implements §2–§6 of `docs/design/web_fetch_robustness.md` (merged in the parent commit).

Release: minor — `web_fetch` now recovers from transient failures on its own, and a blocked fetch
returns an actionable diagnosis instead of challenge markup

## Round 1 remediation (`813ac907a`)

All three round-1 reports on this PR are answered in one commit, `813ac907a`, and the
dispositions are posted as three comments below (`Agent review remediation`, `QA
remediation`, `Design review remediation`). Two claims this description made are
**withdrawn and corrected in place**: the 0.6·T first-attempt cap (removed) and the
canadiantire `~12.7 s / 403 from Akamai` measurement that depended on it. Both texts
below say what shipped now.

## Round 2 remediation (`f135e343f`)

The three round-2 reports are answered in one commit, `f135e343f`, on top of `813ac907a` with no
rebase. `### Agent review — round 2` closed as clean/terminal and offered a delta-only convergence
pass once R2-1/R2-2 became a commit; `### QA report — round 2` closed **PASS, 0 FAIL**;
`### Design review — round 2` was **NOT TERMINAL** on one MAJOR, D6, which is fixed here.

The one that mattered is **D6**: the card's reflow permission was keyed on
`isinstance(failure_kind, str)`, which is true for every classified non-2xx, so a 404/500's **origin
body** — the bytes `service.py` keeps verbatim on purpose — was being re-wrapped, on a surface round
1 had proved byte-identical. The predicate is now the no-response test the promotion branch beside it
already used:

```python
terminal_no_response = terminal and "render_method" not in fetch_details
self._fetch_statement = fetch_details.get("failure_kind") == "blocked" or terminal_no_response
```

**The 404/500 bodies are byte-identical to the round-1 head `e6a7b6c01` again**, by `cmp` on the
painted frames rather than by inference: the five 404 shapes are identical in the **whole frame**
(13 rows in both), and the 500's **origin body** is identical, its only frame delta being the
round-2 delta's own approved `· 3 attempts` clause on the header row. Forcing the permission on
reproduces the designer's symptom exactly (the rich 404 goes 13 → 17 rows at 60 columns; the table
row breaks into three, the indented route line loses its indent). Evidence:
<https://gist.github.com/damianvtran/b24639ec9befc90afbd93860d663c4f5> (`D6-PROOF.txt`).

Also in this commit: the attempt summary is placed before the line/byte counts so the identity
survives 80 columns where it used to be clipped first (D7); the classified `⚠ HTTP …` headline
reflows like a promoted lead instead of clipping mid-sentence at 70 (D8); the summary rides `signal`
rather than the row's 3.32:1 `dim` (D9, one rule with D4); a same-identity retry prints `2 attempts`
without the empty parenthetical (D10); the capture script stops painting a trailing URL row the app
never shows (D11, `card_lines=11`); and the `Retry-After` note is gated on the value rather than on
`ratelimit`, so a 503 reaches the text (R2-2). R2-1's three stale copies of the withdrawn stall
latency are corrected in `docs/design/web_fetch_robustness.md`, together with the terminal sample's
now-unreachable `20.0s / 2 attempts` figure.


### Gates and CI on `f135e343f`

All four local gates clean over the whole tree, exactly as CI runs them (`python -m` / `uvx`, never the
venv console scripts): `flake8 .` 0, `black --check .` 1268 files unchanged, `isort --check .` clean,
`pyright --pythonpath .venv/bin/python .` 0 errors. `tests/e2e -m e2e -n0` →
**119 passed, 7 skipped in 370.98s** (the same counts as the round-1 head, on this host's load).
Targeted suites on the changed surfaces: `tests/unit/tui/test_tool_card.py tests/unit/web_fetch` →
**304 passed**. Frames for the round-2 surfaces, and the D6 byte-identity proof, are in
<https://gist.github.com/damianvtran/b24639ec9befc90afbd93860d663c4f5>.

The whole-tree local `tests/unit` run **did complete this time**, at 40 minutes against the
documented ~3.5 (this host is carrying sibling worktrees; the §5 load note still applies):

```
1 failed, 19314 passed, 18 skipped in 2415.30s
```

The single failure is
`tests/unit/tui/test_paste_clipboard.py::test_the_reading_card_is_on_screen_while_the_read_is_still_running`,
a wall-clock assertion (`at 0.44s of a 0.6s read the card was ''`) in a module this diff does not
touch — `git diff 813ac907a f135e343f -- local_operator/tui/` is `tool_card.py` alone. It **passes
3/3 in isolation** on this head (71 passed, ~67 s each), so it is load-induced, not this change.

CI's five shards are the whole-suite evidence for this head, and they are **all green** —
`test (3.12, 0..4)`, `tui-e2e` (both legs), `lint`, `type-check`, `version-bump-guard`,
`coverage-report`, `cli-sanity`, `server-sanity`, `context-budget`, `pip-audit`,
`filesystem-boundaries-windows`, 16/16.

`### Agent review — round 2` closed this PR's review as terminal for `813ac907a` and offered a
delta-only convergence pass once R2-1/R2-2 became a commit; that pass is requested here, scoped to
`813ac907a..f135e343f`.

## Not addressed

- **The 25 % enrichment slice.** With `enrich=True` and a black-holing `.md` twin, a page whose first
  byte lands near `T` fails here as `stall`, where base "succeeded" only by overrunning its stated
  budget by 16 s (36.3 s against a 20 s budget). Both round-2 reviewers classified it as
  pre-existing and outside this slice, and QA reproduced the mechanism independently (round 2, A2).
  `deferred — pre-existing enrichment slice, unchanged by this PR; needs a first byte near T plus a
  black-holing .md twin; giving enrichment a budget outside the page deadline is a design change, not
  this PR's slice.`

## Related Issue(s)

- Related: none (found from a live desktop-app turn)

## The mechanism

`web_fetch/failure.py` is new and owns the whole taxonomy — the failure classes, the anti-bot
marker tables, reference-id extraction, and the model-facing prose — so the engine's retry
decision, the tool's text and the tests cannot drift into three opinions about the same response.
It is pure: no I/O, no settings, no client.

| class | detected from | what happens |
|---|---|---|
| `transport` | `ConnectError`, `ConnectTimeout`, `ReadError`, `WriteError`, `RemoteProtocolError`, `PoolTimeout` | retried |
| `stall` | `ReadTimeout` / `WriteTimeout` | **not** repeated — escalated once |
| `server` | 5xx | retried |
| `ratelimit` | 429 | retried, honouring `Retry-After` when it fits in a turn |
| `blocked` | 401/403/503 **plus** a vendor marker, or a 403 stock page | **not** retried — escalated once |
| `client` | any other 4xx | never retried |

**Markers are header-first, body second.** Headers are the stable signal (a vendor renames body
copy far more often than a header), and every marker was captured live through this package's own
pinned path on 2026-09-12 — `cf-mitigated: challenge` on medium.com, `server: AkamaiGHost` on
shoppersdrugmart.ca and canadiantire.ca — not copied from memory.

**An unsigned refusal is never called a bot wall.** A 403 with no vendor signature still earns the
escalation (an unbranded WAF is common and one request is cheap) but is described as "the origin
refused this request … this may be an access restriction (login, region, or policy) rather than bot
protection". Claiming bot protection on a 403 that really means "you are not a subscriber" would
send the agent to `browser` when it should be asking the user for credentials.

**Retries and the escalation are orthogonal, which is what bounds the request count at 4/hop.** A
retry repeats the *same* identity for classes where the origin's answer says another try could
work. The escalation changes the identity **once per fetch** (not per hop), and only after a
refusal or a stall — the two classes a repeat cannot help, because the origin has already decided
about this client.

**One deadline, shared.** `timeout_seconds` used to be the per-*request* timeout, so N attempts
could have taken N×T. It is now a budget every attempt divides, so no configuration of retries can
make a fetch exceed its stated timeout — **including the resolver**: the DNS validation runs under
the same remaining budget and the request's own timeout is recomputed after it, so a hung
`getaddrinfo` cannot push the call past T (it used to be able to, because the timeout was computed
before an unbounded lookup).

**Every attempt gets the full remaining budget; the escalation is opportunistic.** *This paragraph
replaces one that described a 0.6·T cap on the first attempt of a hop. That cap was withdrawn during
remediation, because it was a timeout reduction in disguise:* `httpx`'s read timeout bounds the wait
for response **headers**, so capping the first attempt meant any origin whose first byte took
12-20 s of a 20 s budget was cut off on its honest attempt, handed a browser-profile retry with the
leftovers, and reported to the model as a "silent block" naming a vendor we never reached. The
escalation is now funded by whatever the hop's own outcome leaves behind — ~all of T after a fast
refusal, nothing after a stall. Reasoning and the measurement are in the design doc's §3.3; the
regression guard is `test_slow_but_working_origin_still_succeeds`.

**The challenge body is replaced, for the `blocked` class only.** It is markup whose entire purpose
is to be executed by a browser — 5.5 KB of interstitial that costs context to say nothing, under a
lead that invites the misread that it is page content. What replaces it is what happened, the
origin's own reference id (the one durable fact, and what a human quotes to the site's support
desk), and `browser` named as the next step. Every other non-2xx still renders its body verbatim: a
404's body, a 451's and a 500's often genuinely explain themselves.

### Invariants this change does not weaken

- **SSRF.** `validate_public_url` runs **once per attempt**, inside `_request_once` — never hoisted
  into the loop. A host that resolves public on attempt 1 and private on attempt 2 is refused on
  attempt 2. The connection stays pinned to the vetted IP through the escalation, with `Host` and
  SNI intact (the browser profile's headers are merged *under* the pin's, so an escalated attempt
  cannot unpin itself). TLS verification is never disabled. Both properties have direct tests, and
  both are proven below by mutation.
- **Cache.** Only 2xx is cached. A retried success may be cached; a final failure never is.
- **One engine.** `read <url>` and `web_fetch` still share `run_fetch`. No forked pipeline.
- **Default identity unchanged.** No Chrome-by-default; the profile is paid only on a refusal, and
  `blocked_retry: off` restores the strictly honest client.
- **`browser` is named, never driven.** `web_fetch` is read-tier and `browser` is write-tier, so an
  automatic fallback would launder an approval-gated action through an auto-approved call.
- **No third-party reader backend** (Jina/Parallel), which `docs/design/web_fetch.md` rejects on
  privacy grounds.

## What changed

- **`local_operator/web_fetch/failure.py`** (new) — `FetchFailure`, `classify_exception`,
  `classify_response`, the marker tables, `extract_reference` (HTML-unescapes first: Akamai emits
  the id as `Reference&#32;&#35;18&#46;…`, which a naive regex over the raw bytes misses),
  `parse_retry_after` (both wire forms), and `describe`.
- **`local_operator/web_fetch/service.py`** — `_Budget` (the shared deadline and the one-per-fetch
  escalation), `_Telemetry`, jittered backoff, `_attempt_with_retries` / `_attempt_series` /
  `_request_once`, `BROWSER_PROFILE_HEADERS`, the per-attempt request timeout, the blocked-body
  substitution in `_render`, and `FetchError.failure`. Enrichment probes now get one attempt, no
  escalation, and a bounded 25 % slice of the budget.
- **`local_operator/web_fetch/tool.py`** — the classified lead line, the attempt count in the meta
  line, additive `details` keys, and diagnostics on the terminal-failure path.
- **`local_operator/web_fetch/models.py`** — `max_attempts`, `blocked_retry`, and the defaulted
  result fields (`attempts`, `failure_kind`, `block_vendor`, `block_reference`, `profile`,
  `profiles`, `retry_after_s`).
- **`local_operator/settings_io.py`**, **`web_fetch/cli.py`** — the two new keys registered in
  `/settings` and settable from `lop fetch set`, per AGENTS.md "Adding a configuration key".
- **`scripts/fetch_block_shot.py`** (new) — the reusable card capture used for the frames below.
- **Tests** — `tests/unit/web_fetch/test_failure.py` (new, 24 cases), plus 20 in `test_service.py`,
  7 in `test_tool.py` and a context-cost guard in `test_efficiency.py`.

### The one existing test that changed, and why

`test_non_2xx_surfaced_as_error_not_content[403-Forbidden]` asserted the generic
`"error/block page, not page content"` lead for a 403. This change deliberately specialises that
lead by class, and for the `blocked` class drops the "(The body below is the error response…)"
note — because the body below is no longer the origin's response at all. The **F1 property under
test** (an unmissable lead that cannot be mistaken for content) is unchanged and still asserted;
only the reason phrase is sharper, and the test now also pins the new `failure_kind` /
`suggested_tool` keys. The 404 arm is untouched. No other existing test needed changes.

## Testing Details

### 1. The real path, before and after

All through the real CLI (`python -m local_operator.cli fetch test`), isolated `HOME` and config
dir, `/usr/bin/time -p` for the wall clock.

**medium.com** — the proven flip, preserved:

```
BEFORE  error: ⚠ HTTP 403 Forbidden — this is an error/block page, not page content. https://medium.com/
        markdownify · text/html; charset=utf-8 · cache miss
        (The body below is the error response, not the requested page.)

        Just a moment...

AFTER   [200] https://medium.com/
        markdownify · text/html; charset=utf-8 · cache miss · 2 attempts (default, browser-profile)

        MediumMedium: Read and write stories.
        [Sitemap](/sitemap/sitemap.xml) [Our story](/about?autoplay=1) [Membership](/membership) …
```

**canadiantire.ca** — the stall, revised: the ~12.7 s `403 from Akamai` this section used to show
was bought with the 0.6·T first-attempt cap, and is withdrawn with it. Re-measured after the cap was
removed (defaults, `timeout_seconds=20`):

```
BEFORE  error: timed out fetching 'https://www.canadiantire.ca/en/pdp/…-0527211p.html':
        real 20.63

AFTER   error: Read timed out after 19.8s — the origin accepted the connection but never
        sent a response
        https://www.canadiantire.ca/en/pdp/…-0527211p.html
        real 20.38   (attempts=1, profiles=[default], failure_kind=stall)

        A browser-shaped retry was not attempted: a stall spends the whole budget on
        the honest attempt, so there was nothing left to fund the probe.
```

That is still the §1.3 fix — the pre-change error was `timed out fetching '<url>': ` with *nothing
after the colon*, because `httpx.ReadTimeout.__str__()` is the empty string. What it is not is a
faster fetch: with the cap gone, an origin that black-holes for the full 20 s gets the full 20 s, and
the escalation that found the Akamai 403 is only reachable while a stall leaves budget behind. The
trade is stated in the design doc's §3.3 as a decision, not left as a stale promise. (Where the
escalation *does* pay — a fast refusal — the measured win is unchanged: medium.com, `0.41 s`,
`attempts=2`, `profiles=[default, browser]`, 53,072 bytes.)

**The shopper's URL** that started this:

```
BEFORE  error: ⚠ HTTP 403 Forbidden — this is an error/block page, not page content. https://www.shoppersdrugmart.ca/?lang=en&query=power+bar
        markdownify · text/html · cache miss
        (The body below is the error response, not the requested page.)

        Access Denied
        # Access Denied
        You don't have permission to access "http://www.shoppersdrugmart.ca/?" on this server.
        Reference #18.4b182117.1789250183.345ea6ea
        https://errors.edgesuite.net/18.4b182117.1789250183.345ea6ea

AFTER   error: ⚠ HTTP 403 Forbidden — blocked by Akamai bot protection, not page content. https://www.shoppersdrugmart.ca/?lang=en&query=power+bar
        text · text/html · cache miss · 2 attempts (default, browser-profile)

        The origin's bot protection refused this request. A browser-shaped retry was
        also refused, so no headless fetch of this URL will succeed.
        Origin reference: 18.4d182117.1789252044.1b85b46b
        Next step: use the `browser` tool on this URL. It drives the real
        browser (a write-tier, approval-gated action), which is the only
        path that clears an interactive challenge.
```

**To be plain about the limit of this change: the shopper's URLs are not fixed by it.** That origin
refuses every non-browser client for that URL shape. Verified independently of our code — `curl`
carrying a full Chrome header set gets the same 403, while a different path on the same host is
served normally:

```
$ curl -s -o /dev/null -w "%{http_code}\n" -H 'User-Agent: Mozilla/5.0 … Chrome/140.0.0.0 Safari/537.36' \
    -H 'Accept: text/html,…' -H 'Accept-Language: en-US,en;q=0.9' \
    "https://www.shoppersdrugmart.ca/?lang=en&query=power+bar"
403
$ curl -s -o /dev/null -w "%{http_code}\n" -H 'User-Agent: Mozilla/5.0 … Chrome/140.0.0.0 Safari/537.36' \
    "https://www.shoppersdrugmart.ca/en"
200
```

So the win on those URLs is **diagnosis plus a named escalation**, not access. The agent now learns
in one call that this is Akamai, that no headless client will clear it, and that `browser` is the
step to take — instead of spending forty calls discovering the same thing.

**A plain 200 is byte-identical to today.** Three shapes (HTML, JSON, markdown) fetched with
`--refresh` through the pre-change tool and this one, output diffed:

```
$ diff before/plain200.txt after-plain200.txt && echo IDENTICAL
IDENTICAL
```

(`example.com` → `status=200 method=markdownify`, `httpbin.org/json` → `method=json`,
`raw.githubusercontent.com/…/README.md` → `status=200 method=text bytes=2906 lines=76 cache=miss`,
all unchanged.)

### 2. A local origin, so the retry is proven rather than inferred

A `ThreadingHTTPServer` with a per-request access log, driven through the real CLI/`run_fetch`.
The log is the evidence: it shows how many requests actually reached an origin.

**500, 500, then 200 — the retry recovers:**

```
[200] http://127.0.0.1:8801/x
text · text/plain · cache miss · 2 attempts (default, default)
# Recovered — The retry worked.
real 1.00
server log:  REQ 1 /x t=…002.756   REQ 2 /x t=…003.215
```

**Always 503 — the attempt count and the latency are bounded:**

```
⚠ HTTP 503 Service Unavailable — … · 3 attempts (default, default, default)
real 1.87
server log:  REQ 1 /x …004.565   REQ 2 /x …005.117   REQ 3 /x …005.941
```

Exactly 3 requests, ~1.9 s of jittered backoff, no fourth.

**The deadline holds on a silent origin** (server sleeps 30 s; fetch budget 3 s):

```
elapsed=3.21s is_error=True   attempts=1   profiles=[default]   server requests=1
Read timed out after 3.0s — the origin accepted the connection but never sent a response
http://127.0.0.1:<port>/stall
```

3.21 s against a 3 s budget, exactly one request to the origin, and a message that says something,
which is the §1.3 regression. (Re-measured after the first-attempt cap was removed: the honest
attempt now spends the whole budget, so the count is 1 and the server sees one request. The earlier
capture showed 2 attempts inside the same budget — that second attempt existed only because the
first was truncated at 0.6·T.)

**`Retry-After: 1` is slept and recovers; `Retry-After: 600` is reported, not slept:**

```
Retry-After: 1     elapsed=1.19s is_error=False  attempts=2   (log: REQ 1 …101.052, REQ 2 …102.086)
Retry-After: 600   elapsed=0.11s is_error=True   attempts=1  retry_after_s=600.0  (log: REQ 1 only)
```

### 3. The new tests can fail

Per AGENTS.md "Prove the test can still fail" — two mutations, each applied and reverted:

| mutation | result |
|---|---|
| retries disabled (`max_attempts=1` forced in `_fetch_owned`) | **5 failed**, incl. `test_persistent_500_stops_at_max_attempts` (`assert 1 == 3`), `test_retry_after_small_value_is_honoured` (`assert 429 == 200`) |
| `validate_public_url` hoisted out of the attempt loop (cached per service) | **3 failed**: `test_validate_public_url_runs_once_per_attempt` (`assert 1 == 3`), `test_retry_refuses_a_host_that_turns_private` (*DID NOT RAISE*), `test_ssrf_via_redirect_is_refused_at_the_hop` (*DID NOT RAISE*) |

The second is the one that matters: the SSRF guard tests actively catch the "optimisation" a future
reader is most likely to attempt. Restored tree: `45 passed`.

### 4. Rendered frames — the card body is user-visible

Captured with the new `scripts/fetch_block_shot.py` through the **real `OperatorApp`** (so
`local_operator.tcss` is applied), isolated HOME/config, two settled frames, geometry printed. The
before-frame comes from the same script against the pre-change tree — it falls back to the verbatim
pre-change capture when `web_fetch.failure` is absent, which is what lets one script take both.

| | before | after |
|---|---|---|
| screen / virtual | `98×28` / `98×28`, no scrollbar | `98×28` / `98×28`, no scrollbar |
| card rows | 15 | 12 |
| body | Akamai interstitial rendered as content (`Access Denied`, `# Access Denied`, the edgesuite URL) | what happened, the reference id, the `browser` next step |

The frames also drove a real fix, and then a second one. The card paints one body row per line and
clips the overflow with an ellipsis (pre-existing — still visible on the `Fetched:` row in both
frames), so the first capture lost the name of the escalation tool off the right edge. The first
answer was a hard wrap to 76 cells inside `describe()`; the design round showed that a constant is
wrong at both ends — clipped mid-word at 80 columns, stopping half-way across a 150-column card — so
the statement is now fitted to the card's own width at paint time (`_append_fetch_body`), the
`Next step:` sentence rides `signal` while the opaque reference recedes to `dim`, the vendor name
reaches the card's own danger row, and the attempt count rides the `Rendered:` row. Frames for
those surfaces (blocked at 100/80/150 columns, stall, 404, 200) are on the remediation comment.

| state | frame |
|---|---|
| blocked card, round-1 frame (the "before" for the remediation) | [rendered frame](https://gist.githubusercontent.com/damianvtran/5d3eaf10c579cabbbfa6eccbe98ac01c/raw/669a4eb40a4bf636f4706ed60bb2c56f841bbe47/gist-card-blocked-after.svg) |
| blocked card, after the remediation (`813ac907a`, 100x30) | [rendered frame](https://gist.githubusercontent.com/damianvtran/5b179618caeeda975afbc832e7075924/raw/db1845265b12440b6a95d0269b82823555bba105/after-blocked-100x30.svg) |
| the same card at 80 and 150 columns | [80 cols](https://gist.githubusercontent.com/damianvtran/5b179618caeeda975afbc832e7075924/raw/56473a6d967b7d98fce83bc800b7ef5a4d7f770d/after-blocked-80x30.svg) · [150 cols](https://gist.githubusercontent.com/damianvtran/5b179618caeeda975afbc832e7075924/raw/21c11b4c3f88165871bfd5c4f9c06e4a37829952/after-blocked-150x40.svg) |
| terminal stall card (a fetch card since D5) | [rendered frame](https://gist.githubusercontent.com/damianvtran/5b179618caeeda975afbc832e7075924/raw/303065839e3d9ec4da66001240964ea7158c55ce/after-stall-100x30.svg) |
| 404 card, unchanged | [rendered frame](https://gist.githubusercontent.com/damianvtran/5b179618caeeda975afbc832e7075924/raw/8f2e15e6ceac410aa30b87fd40375226bb2d57b8/after-missing-100x30.svg) |

<img src="https://gist.githubusercontent.com/damianvtran/5b179618caeeda975afbc832e7075924/raw/db1845265b12440b6a95d0269b82823555bba105/after-blocked-100x30.svg" width="512">
<img src="https://gist.githubusercontent.com/damianvtran/5b179618caeeda975afbc832e7075924/raw/303065839e3d9ec4da66001240964ea7158c55ce/after-stall-100x30.svg" width="512">

Gist (SVGs, geometry JSON and the capture commands):
<https://gist.github.com/damianvtran/5b179618caeeda975afbc832e7075924>

The **404 card is byte-identical before and after** — asserted by extracting every painted text row
from both SVGs and diffing them (no differences). That is the §5.2 narrowing holding: only the
`blocked` class changed.

Gist: https://gist.github.com/damianvtran/5d3eaf10c579cabbbfa6eccbe98ac01c

### 5. Gates

Run from this worktree with its own venv (`.venv/bin/python -c "import local_operator"` resolves to
this worktree), exactly as CI does, via `python -m` / `uvx` rather than the venv's console scripts:

```
$FILES = the 13 changed files
flake8 $FILES                                   # clean
black --check $FILES                            # 13 files unchanged
isort --check-only $FILES                       # clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   # 0 errors, 0 warnings, 0 informations
.venv/bin/python -m pytest tests/unit/web_fetch tests/unit/tui/test_tool_card.py -q -n0
                                                # 296 passed in 58.41s
.venv/bin/python -m pytest tests/unit/session/test_config_live.py -q -n0   # 103 passed
.venv/bin/python -m pytest tests/unit/test_settings_io.py -q -n0           # 277 passed
```

**CI is green on `813ac907a`**, including the whole `tests/unit` suite in its five shards
(9m11s-17m0s), `lint`, `type-check`, `context-budget`, `filesystem-boundaries-windows`,
`pip-audit`, `version-bump-guard`, `server-sanity`, and **`tui-e2e` on both macOS and ubuntu**
(`tests/e2e -m e2e`).

One flake, stated rather than hidden: `cli-sanity` failed on attempt 1 with `test.txt was not
created` — the live-LLM sanity task, two `chat/completions` calls returning 200 and no file
written, no 429/5xx in the log. It passed on the re-run (31 s). Its own workflow comments document
this exact mode ("`and test.txt is never written` … all of which passed on retry — which is the
signature of upstream capacity, not of a defect in the PR under test"), and nothing in this diff
reaches the `lop exec` write path; recorded here so the red attempt in the checks UI is not
re-diagnosed.

Local gates, run from this worktree's own venv:

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
        # 119 passed, 7 skipped in 421.06s
.venv/bin/python -m pytest tests/unit/web_fetch tests/unit/tui/test_tool_card.py -q -n0
        # 296 passed in 58.41s
# every test file that references web_fetch / the fetch card / the fetch service, plus its
# settings, prompts, analytics and compaction consumers, in one run:
        # 882 passed in 54.20s
```

**On the round-1 head (`813ac907a`), the whole-tree local `tests/unit` run did not complete, and that is stated rather than implied.**
Two attempts on this host — which is currently carrying several sibling worktrees' whole-unit
suites (load average 190-460, four peers running `pytest tests/unit` at once) — were killed at 49 %
and 81 % by the runner's own time limits, at 20-50x the documented ~3.5 min. Run 2 reported **one**
failure in the shape run 1 did: `tests/unit/browser_bridge`, which passes in isolation on this head
(`220 passed in 13.18s`). The whole-suite evidence for this head is therefore **CI's five shards**
(same suite, same commit, all green) plus the 882-test targeted run above covering every file this
diff can reach.

### 6. Two things CI caught that the local run had not reached

Both are fixed in this PR, as their own commits, and both are worth stating rather than hiding:

- **`context-budget` (`c4a5b0ed4`).** The sentence I added to the tool description pushed
  start-of-session context 28 tokens over the ratchet. That string is billed on **every turn of
  every session**, so the budget was not raised — the sentence was cut to the part the agent cannot
  work out from the result itself. Measured with an isolated `HOME` (the ambient one leaks extra
  tools into the surface and reports a false failure for `origin/main` too):
  `origin/main` 27,279 (41 tokens of headroom) → this branch initially 27,348 (28 over) → now
  27,312 (**8 tokens of headroom**).
- **`test_every_live_section_is_exercised_and_every_probe_is_live` (`e6a7b6c01`).** A real gap, and
  exactly what that guard exists for: the two new keys are LIVE-scoped (the service resolves
  settings per fetch) and had no live probe. Added, asserted through the real settings loader.

### 7. One CI failure that is NOT this change

`test (3.12, 3)` failed once on the first push with
`tests/unit/server/test_desktop_notifications.py::test_an_unknown_or_foreign_token_claims_nothing —
DID NOT RAISE KeyError`, and **passed on the next run of the same code**. It is a pre-existing flake
unrelated to this diff: the test feeds `mine.upper()` as a "bogus session id", which is only bogus
when the random 12-hex-char session id contains at least one letter. Measured rate: **0.36 %** of
ids are all-digits (`717 / 200,000`), and the test uses two such ids. Left alone deliberately —
it is outside this slice — and reported here so it is not re-diagnosed from scratch.


## Deviations from the design doc

Three, each folded into `docs/design/web_fetch_robustness.md` in this PR and called out at the top
of it:

1. **Enrichment probes get a bounded 25 % slice of the deadline.** §6.2 correctly made probes share
   the call's deadline but did not say what stops a stalling `.md` probe from eating the budget the
   real fetch — and its escalation — needs. Found by measurement, not by reading: a 3 s fetch of a
   silent origin spent 1.8 s on the probe and had nothing left to escalate with.
2. **The `blocked` lead drops the "(The body below is the error response…)" note**, because for
   that class the body below is our own statement rather than the origin's response.
3. **§6.6 case 5's literal wording is self-contradictory and was implemented as its intent.** It
   asks that an unmatched 403's text "does not contain the word 'bot'", but §2.2's own prescribed
   wording for that case — "No anti-bot vendor signature was found … rather than bot protection" —
   contains the word precisely in order to deny the claim. The test asserts the *claim* is absent.

A fourth, withdrawn during remediation: `describe()` used to pre-wrap its prose to card width,
for the clipping reason in §4 above. The design round showed a constant is wrong at both ends, so
the wrap moved into the card and follows the card's own width at paint time — see §3.6 of the
design doc and the design remediation comment.

A fifth, decided during remediation: **the 0.6·T first-attempt cap is removed** (the one deviation
that reverses a ratified decision, and the reason is a measurement rather than a preference — see
`docs/design/web_fetch_robustness.md` §3.3 and R1 in the agent remediation comment).




