### PR TITLE
fix(tui): re-fit a ledger row when the shared name column moved, not only its width

### DIFF
--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -273,6 +273,28 @@ def row_indent(width: int) -> int:
     return ROW_INDENT if width >= ROW_INDENT_MIN_WIDTH else 0
 
 
+def row_body_width(width: int) -> int:
+    """Cells a ledger row's CONTENT is built in, given the width it is given.
+
+    The card's own 1-cell inner padding each side and the ledger inset come off
+    the budget before anything is measured, which is why this is a named
+    derivation rather than a subtraction repeated in a builder and again in the
+    question "would a rebuild change this row's name column?". Those two must
+    answer with the SAME number: the name column is gated on width
+    (``NAME_GROWTH_MIN_ROW``), and the gate is applied to the width the row
+    builds at — the reduced one — while the row's own width is what a resize
+    reports. Recording the column of the outer width and then asking the
+    question of the outer width measures a row that does not exist: at a 72-cell
+    row the outer width clears the gate (14) while the painted content is built
+    in 69 cells and floors at 8, so the record and the paint disagree and the
+    guard cannot see it.
+
+    ``max(..., 10)`` is the builder's own floor, kept here so the two callers
+    cannot drift apart on the degenerate widths either.
+    """
+    return max(width - 2 - row_indent(width), 10)
+
+
 NAME_COL = TOOL_NAME_COL
 #: The ceiling that widening respects. Past roughly this width the eye stops
 #: scanning a column of names and starts reading a list of them.
@@ -2119,7 +2141,7 @@ class ToolCard(ExpandableActionBlock):
         # the one a parentless build cannot read, so it bakes the floor. Recorded
         # beside the width because `ExpandableActionBlock._layout_moved` reads the
         # pair to decide whether this row still fits the ledger it landed in.
-        self._built_name_col = self._name_col(width)
+        self._built_name_col = self._name_col(row_body_width(width))
         moved = self._row_count != self._applied_rows
         self._applied_rows = self._row_count
         was_finalized = self._finalized
@@ -2493,7 +2515,10 @@ class ToolCard(ExpandableActionBlock):
         # (`_row_indent`), against the width being BUILT rather than the last
         # one built, because this runs before `_built_width` is updated.
         indent = row_indent(width)
-        width = max(width - 2 - indent, 10)  # 1-cell inner padding each side (kit rule)
+        # The content box this row is built in — the SAME derivation
+        # `_refresh_row` records the name column against, so the guard's question
+        # and the builder's answer cannot be asked of two different widths (R2).
+        width = row_body_width(width)
 
         # Status segment (right-aligned), capped at width // 3 (D8) and then
         # hard-clamped so no state can ever push the row past its card.

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1981,7 +1981,7 @@ class ToolCard(ExpandableActionBlock):
 
     # -- resize (TUI-017: rebuild the row when the width changes) -----------
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
-        """Re-fit the row at the new width.
+        """Re-fit the row at the new width — or at a new shared column.
 
         Guarded on the WIDTH, because the card's content is a pure function of
         its state and the width it is folded to — a resize that only changed
@@ -1990,9 +1990,16 @@ class ToolCard(ExpandableActionBlock):
         raises a Resize that landed straight back here. Measured on a session
         replay, this handler was a third of the ``_refresh_row`` calls: 645
         builds for 215 cards, ~366 ms.
+
+        The other term is the ledger's shared name column, which the same claim
+        needs and which the width cannot stand in for: a card authored before it
+        was appended builds parentless, so it bakes the floor, and a fold hint
+        promising the width it will be given made the width term report
+        "unchanged" when it landed. See
+        :meth:`ExpandableActionBlock._layout_moved`.
         """
         size = getattr(event, "size", None)
-        if size is not None and size.width == self._built_width:
+        if size is not None and not self._layout_moved(size.width):
             return
         self._refresh_row()
 
@@ -2108,6 +2115,11 @@ class ToolCard(ExpandableActionBlock):
         if detached:
             return
         self._built_width = width
+        # The shared column is the OTHER input this content was built from, and
+        # the one a parentless build cannot read, so it bakes the floor. Recorded
+        # beside the width because `ExpandableActionBlock._layout_moved` reads the
+        # pair to decide whether this row still fits the ledger it landed in.
+        self._built_name_col = self._name_col(width)
         moved = self._row_count != self._applied_rows
         self._applied_rows = self._row_count
         was_finalized = self._finalized

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -774,6 +774,21 @@ class ExpandableActionBlock(TranscriptBlock):
     #: which is the honest answer for a row that has not been drawn yet.
     _built_width: int = -1
 
+    #: The shared name column the APPLIED content was built with, written beside
+    #: :attr:`_built_width` and for the same reason — it is the second input to
+    #: the geometry that was painted, and the only one a width guard cannot stand
+    #: in for.
+    #:
+    #: The two are written together because they are read together by
+    #: :meth:`_layout_moved`; ``None`` is "nothing applied yet", and it never
+    #: equals a real column, so a row that has never painted always re-fits on its
+    #: first layout pass. That is the ground this attribute exists to restore: a
+    #: row authored while it was parentless cannot read the shared column at all
+    #: (there is no ledger to ask), so it bakes the floor and records the width it
+    #: authored at — and when a fold hint has promised exactly that width, the
+    #: width term alone reported "unchanged" and the row kept the floor for good.
+    _built_name_col: int | None = None
+
     @classmethod
     def _bound_keys(cls) -> frozenset[str]:
         """Every key this row class answers itself, MERGED across the hierarchy.
@@ -815,6 +830,57 @@ class ExpandableActionBlock(TranscriptBlock):
     def _refresh_row(self) -> None:
         """Rebuild and apply this subclass's current summary/expansion."""
         raise NotImplementedError
+
+    def _name_col(self, width: int) -> int:
+        """The ledger's shared name column, in cells, as THIS row reads it.
+
+        Declared on the base because :meth:`_layout_moved` asks the question of
+        every ledger row, and each row type already answers it: the column is the
+        transcript's shared value above the width gate and the floor below it, or
+        the floor for a row with no ledger to ask. Implementing the ladder once
+        here instead would give the base an import of `tool_card` at class-body
+        time (the modules import each other) and, worse, a second copy of the
+        gate — which is the kind of duplicate that drifts and tears the column.
+        """
+        raise NotImplementedError
+
+    def _layout_moved(self, width: int) -> bool:
+        """Whether the APPLIED content is stale for a row laid out at ``width``.
+
+        Every ledger row's ``on_resize`` used to guard on the width alone, and the
+        width is only ONE of the two inputs its geometry is built from. The other
+        is the shared name column, which a row cannot read until it is mounted.
+
+        That is not a rare window. The replay and paging paths author a row before
+        they append it — deliberately, so the row folds once at its destination
+        width instead of flashing at the terminal's — and they say where it is
+        going through :meth:`set_fold_hint`. So the row builds parentless, bakes
+        the floor (`NAME_COL`, because there is no ledger to ask), records the
+        hinted width, and is then laid out at EXACTLY that width. The width term
+        says "unchanged", the rebuild is skipped, and the row keeps the floor
+        while its mounted neighbours paint the shared column: two `bash` rows on
+        one screen at different summary offsets, which is the tear the operator
+        reported. A pointer crossing such a row re-fitted THAT row and no other,
+        which is why it read as tearing under a moving cursor and why it healed
+        one row at a time.
+
+        Asked of the subclass's own :meth:`_name_col`, so the builder's ladder and
+        this question cannot disagree, and against :attr:`_built_name_col` — the
+        column the applied content was really built with — never against the
+        current column alone, which would rebuild every row on every resize that
+        happened to leave the width alone.
+        """
+        if width != self._built_width:
+            return True
+        if self._built_name_col is None:
+            # Nothing is applied to be stale: `_built_name_col` is written only
+            # where content is really applied, so `None` covers both a row that
+            # has never built (the `-1` placeholder) and one whose content was
+            # measured but could not be applied — the detached rung. Reading that
+            # as "the column moved" would rebuild rows no reader can see, on
+            # every height-only resize.
+            return False
+        return self._name_col(width) != self._built_name_col
 
     def _row_indent(self) -> int:
         """Cells of left inset on this row's summary line AS BUILT.
@@ -1719,9 +1785,16 @@ class WakeBlock(ExpandableActionBlock):
         return True
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
-        """Re-fit the row at the new width (same guard as the tool card)."""
+        """Re-fit the row at the new width — or at a new shared column.
+
+        Same guard as the tool card, and the same two terms: the width this row is
+        laid out at and the ledger's shared column. A resize that moved neither
+        reproduces the row byte for byte; see
+        :meth:`ExpandableActionBlock._layout_moved` for why the column has to be
+        one of them.
+        """
         size = getattr(event, "size", None)
-        if size is not None and size.width == self._built_width:
+        if size is not None and not self._layout_moved(size.width):
             return
         self._refresh_row()
 
@@ -1770,6 +1843,11 @@ class WakeBlock(ExpandableActionBlock):
         if detached:
             return
         self._built_width = width
+        # The shared column is the OTHER input this content was built from — and
+        # the one a parentless build cannot read, so it bakes the floor. Recorded
+        # beside the width because :meth:`_layout_moved` reads the pair to decide
+        # whether this row still fits the ledger it just landed in.
+        self._built_name_col = self._name_col(width)
         moved = self._row_count != self._applied_rows
         self._applied_rows = self._row_count
         was_finalized = self._finalized
@@ -2386,6 +2464,11 @@ class PeerMessageBlock(ExpandableActionBlock):
         if detached:
             return
         self._built_width = width
+        # The shared column is the OTHER input this content was built from — and
+        # the one a parentless build cannot read, so it bakes the floor. Recorded
+        # beside the width because :meth:`_layout_moved` reads the pair to decide
+        # whether this row still fits the ledger it just landed in.
+        self._built_name_col = self._name_col(width)
         moved = self._row_count != self._applied_rows
         self._applied_rows = self._row_count
         was_finalized = self._finalized
@@ -4063,7 +4146,12 @@ class TranscriptView(ScrollableContainer):
                 # to ask for the shared column, would fit it to the console rung
                 # and paint one frame at the old width before its own layout
                 # pass corrected it. It derives the column on that pass, like
-                # any other newcomer.
+                # any other newcomer — which is a promise `_layout_moved` is
+                # what keeps: a row authored parentless bakes the floor, and
+                # without that second term in the resize guard the layout pass
+                # could see a width it had already built at and skip the rebuild
+                # that re-reads the column. Then this skip would be a tear, not
+                # a saving.
                 continue
             repaint = getattr(block, "refresh_row", None)
             if callable(repaint):

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -870,6 +870,8 @@ class ExpandableActionBlock(TranscriptBlock):
         current column alone, which would rebuild every row on every resize that
         happened to leave the width alone.
         """
+        from local_operator.tui.widgets.tool_card import row_body_width
+
         if width != self._built_width:
             return True
         if self._built_name_col is None:
@@ -880,7 +882,7 @@ class ExpandableActionBlock(TranscriptBlock):
             # as "the column moved" would rebuild rows no reader can see, on
             # every height-only resize.
             return False
-        return self._name_col(width) != self._built_name_col
+        return self._name_col(row_body_width(width)) != self._built_name_col
 
     def _row_indent(self) -> int:
         """Cells of left inset on this row's summary line AS BUILT.
@@ -1825,7 +1827,7 @@ class WakeBlock(ExpandableActionBlock):
         must be able to re-fit a settled card, and the content it produces is
         a pure function of the card's state, never new history.
         """
-        from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH
+        from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH, row_body_width
 
         # Same ladder as `ToolCard._refresh_row`, for the same reason: a row
         # built before its first layout pass must fold at the width it is
@@ -1847,7 +1849,7 @@ class WakeBlock(ExpandableActionBlock):
         # the one a parentless build cannot read, so it bakes the floor. Recorded
         # beside the width because :meth:`_layout_moved` reads the pair to decide
         # whether this row still fits the ledger it just landed in.
-        self._built_name_col = self._name_col(width)
+        self._built_name_col = self._name_col(row_body_width(width))
         moved = self._row_count != self._applied_rows
         self._applied_rows = self._row_count
         was_finalized = self._finalized
@@ -1878,6 +1880,7 @@ class WakeBlock(ExpandableActionBlock):
             _SUMMARY_FLOOR,
             COLLAPSE_HINT,
             EXPAND_HINT,
+            row_body_width,
             row_indent,
             truncate_cells,
         )
@@ -1891,7 +1894,10 @@ class WakeBlock(ExpandableActionBlock):
         # `_built_width`, which this runs before updating, and through the
         # ledger's one derivation so the copy gutter reads the same rule.
         indent = row_indent(width)
-        width = max(width - 2 - indent, 10)  # 1-cell inner padding each side (kit rule)
+        # The content box this row is built in — the SAME derivation
+        # `_refresh_row` records the name column against, so the guard's question
+        # and the builder's answer cannot be asked of two different widths (R2).
+        width = row_body_width(width)
 
         icon = tool_icon(self.tool_name)
         label = display_name(self.tool_name)
@@ -2403,9 +2409,16 @@ class PeerMessageBlock(ExpandableActionBlock):
         return identity, self._snippet
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
-        """Re-fit the card at the new width (same guard as the tool card)."""
+        """Re-fit the card at the new width — or at a new shared column.
+
+        Same guard as the tool card, and the same two terms: the width this row is
+        laid out at and the ledger's shared column. Every ledger row class shares
+        it, which is the whole point of the guard living on the base — a peer row
+        sits between tool rows, so a peer left on the width-only form keeps the
+        floor column until a pointer crosses it (review round 1, R1).
+        """
         size = getattr(event, "size", None)
-        if size is not None and size.width == self._built_width:
+        if size is not None and not self._layout_moved(size.width):
             return
         self._refresh_row()
 
@@ -2446,7 +2459,7 @@ class PeerMessageBlock(ExpandableActionBlock):
         must be able to re-fit a settled card, and the content it produces is a
         pure function of the card's state, never new history.
         """
-        from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH
+        from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH, row_body_width
 
         # Same ladder as `WakeBlock._refresh_row`, for the same reason: a row
         # built before its first layout pass must fold at the width it is about
@@ -2468,7 +2481,7 @@ class PeerMessageBlock(ExpandableActionBlock):
         # the one a parentless build cannot read, so it bakes the floor. Recorded
         # beside the width because :meth:`_layout_moved` reads the pair to decide
         # whether this row still fits the ledger it just landed in.
-        self._built_name_col = self._name_col(width)
+        self._built_name_col = self._name_col(row_body_width(width))
         moved = self._row_count != self._applied_rows
         self._applied_rows = self._row_count
         was_finalized = self._finalized
@@ -2499,6 +2512,7 @@ class PeerMessageBlock(ExpandableActionBlock):
             _SUMMARY_FLOOR,
             COLLAPSE_HINT,
             EXPAND_HINT,
+            row_body_width,
             row_indent,
             truncate_cells,
         )
@@ -2512,7 +2526,10 @@ class PeerMessageBlock(ExpandableActionBlock):
         # `_built_width`, which this runs before updating, and through the
         # ledger's one derivation so the copy gutter reads the same rule.
         indent = row_indent(width)
-        width = max(width - 2 - indent, 10)  # 1-cell inner padding each side (kit rule)
+        # The content box this row is built in — the SAME derivation
+        # `_refresh_row` records the name column against, so the guard's question
+        # and the builder's answer cannot be asked of two different widths (R2).
+        width = row_body_width(width)
 
         icon = tool_icon(self.tool_name)
         label = display_name(self.tool_name)

--- a/scripts/ledger_paged_row_shot.py
+++ b/scripts/ledger_paged_row_shot.py
@@ -1,0 +1,169 @@
+"""Capture the ledger's shared name column against the rows a PAGE brings in.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/ledger_paged_row_shot.py OUT.svg [COLSxROWS] [CASE]
+
+``CASE`` selects which authoring order the paged row arrives by, because that is
+the variable this script exists to show:
+
+    hint  (default)  the row is authored the way the replay and paging paths
+                     author one: ``set_fold_hint`` with the width it is about to
+                     be given, content written while it is still parentless, then
+                     appended. Paged in beside a row that is already on screen
+                     and already on the shared column.
+    fallback         the same row authored with no hint at all, on a terminal
+                     whose transcript content region IS ``FALLBACK_WIDTH`` — the
+                     width a parentless build falls back to, so the row is again
+                     laid out at exactly the width it authored at.
+
+Both cases put a short-named row (``bash``) on screen beside rows that share a
+wider column, so the frame answers one question: is every row's summary in the
+same cell? A frame where the paged row's summary starts six cells left of its
+neighbours' is the tear — two `bash` rows at different offsets, which a pointer
+crossing that row used to repair one row at a time.
+
+The numbers are printed beside the frame (``--geometry`` on stderr) because the
+stills show the symptom and the cells show the cause. No provider request, live
+session or operator config is used: ``isolate_capture`` redirects HOME, config
+and caches first, and every inherited ``CMUX_*`` variable is dropped before the
+application is imported.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot must not rename the operator's real workspace through inherited CMUX IDs.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.glyphs import display_name  # noqa: E402
+from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH, ToolCard  # noqa: E402
+from local_operator.tui.widgets.transcript import TranscriptView  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: Rows already on screen, one of them naming the column. `list_variables` is the
+#: long one, so the shared column sits well above the floor before the page lands.
+SEEDED_ROWS = [
+    ("i1", "list_variables", "list them", "4 variables"),
+    ("i2", "bash", "git status --short", "3 files"),
+]
+
+#: The paged row: short name, so the page does NOT move the column — which is
+#: exactly the case a repaint broadcast cannot rescue.
+PAGED_ROW = ("p1", "bash", "rg -n 'column' src/ | head -9")
+
+#: The terminal whose transcript content region is the fallback width.
+FALLBACK_TERMINAL = (84, 24)
+
+
+def _settled(view: TranscriptView, call_id: str, name: str, command: str, result: str) -> ToolCard:
+    """A row appended the LIVE way: built detached, appended, then settled.
+
+    The settle lands while the row is mounted, so its content is re-authored with
+    a ledger to ask — which is why the seeded rows are the reference in the frame.
+    """
+    card = ToolCard(call_id, name, {"command": command})
+    view.append_block(card)
+    card.mark_done(result)
+    return card
+
+
+def _paged(name: str, command: str, destination: int | None) -> ToolCard:
+    """A row authored the way a restored or paged row is authored.
+
+    ``destination`` is the fold hint — the width the row is about to be given,
+    which is what keeps it from folding twice — and ``None`` leaves the parentless
+    build to fall back, which is the same trap on a terminal of that width.
+    """
+    card = ToolCard("p1", name, {"command": command})
+    if destination is not None:
+        card.set_fold_hint(destination)
+    card.mark_done("paged in")
+    return card
+
+
+def _geometry(app: OperatorApp, view: TranscriptView, rows: list[ToolCard]) -> None:
+    """Print each painted row's summary cell, straight off the compositor."""
+    strips = list(app.screen._compositor.render_strips())
+    print(
+        f"  size={app.screen.size} content={view.scrollable_content_region.width} "
+        f"col={view.tool_name_col} applied={view._name_col_applied}",
+        file=sys.stderr,
+    )
+    columns = {}
+    for card in rows:
+        text = strips[card.region.y].text
+        label = display_name(card.tool_name)
+        at = text.find(getattr(card, "region_marker", ""))
+        if at < 0:
+            at = text.find(label)
+            tail = text[at + len(label) :] if at >= 0 else ""
+            at = at + len(label) + (len(tail) - len(tail.lstrip(" "))) if at >= 0 else -1
+        columns.setdefault(at, []).append(card.tool_call_id)
+        print(
+            f"    {card.tool_call_id} summary@{at} built_width={card._built_width}",
+            file=sys.stderr,
+        )
+    if len(columns) > 1:
+        print(
+            f"  !! the ledger is torn: rows sit at different summary cells: {columns}",
+            file=sys.stderr,
+        )
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+    case = sys.argv[3] if len(sys.argv) > 3 else "hint"
+    if case == "fallback":
+        size = FALLBACK_TERMINAL
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        seeded = [_settled(view, *row) for row in SEEDED_ROWS]
+        for card, row in zip(seeded, SEEDED_ROWS):
+            card.region_marker = row[2]  # type: ignore[attr-defined]
+        await pilot.pause()
+        await pilot.pause()
+
+        destination = view.scrollable_content_region.width if case == "hint" else None
+        paged = _paged(PAGED_ROW[1], PAGED_ROW[2], destination)
+        paged.region_marker = PAGED_ROW[2]  # type: ignore[attr-defined]
+        if case == "fallback":
+            # The fallback case only traps when the row's own width IS the
+            # fallback; say so rather than capturing a frame that proves nothing.
+            assert destination is None
+            assert view.scrollable_content_region.width == FALLBACK_WIDTH, (
+                "the fallback case needs a transcript content region of "
+                f"{FALLBACK_WIDTH}; this terminal gives "
+                f"{view.scrollable_content_region.width}"
+            )
+        view.insert_blocks(0, [paged])
+        await pilot.pause()
+        await pilot.pause()
+
+        print(f"case={case}", file=sys.stderr)
+        _geometry(app, view, [paged, *seeded])
+        save_capture(app, out)
+
+
+asyncio.run(main())

--- a/tests/unit/tui/test_transcript_name_col.py
+++ b/tests/unit/tui/test_transcript_name_col.py
@@ -51,14 +51,22 @@ from textual.app import App
 from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH, ToolCard
 from local_operator.tui.widgets.transcript import (
     TOOL_NAME_COL,
+    PeerMessageBlock,
     TranscriptBlock,
     TranscriptView,
+    WakeBlock,
 )
 from tests.unit.tui.conftest import StyledTranscriptApp
 
 #: A name long enough to widen the column past the floor. It renders through
 #: ``display_name`` as a SHORTER label, so the tests measure what is painted
 #: rather than what was passed in.
+#: A live fire, the shape `test_ledger_row_inset` uses. Only PART of a wake's
+#: text reaches the row (the schedule, not the envelope), which is why the marker
+#: below is the fragment the frame paints rather than the whole string.
+WAKE_TEXT = "(alarm) Scheduled wake w7 (1/3, every 1h) \u2014 check the build"
+SENDER = {"pid": 48213, "conversation_name": "lo-probe"}
+
 WIDE_TOOL = "mcp__linear_create_initiative"
 LONGER_TOOL = "list_variables"
 
@@ -292,6 +300,88 @@ async def test_a_sidebar_toggle_refits_every_row_the_frame_shows() -> None:
                 assert summary_col(app, card, f"echo {seeded.index(card)}") == before
                 card._set_hovered(False)
                 await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_the_recorded_column_is_the_column_the_row_paints() -> None:
+    """The guard's term has to be the column the BUILDER asked for (R2).
+
+    A builder asks the shared column of the width it builds its content IN: the
+    card's one-cell inner padding each side and the ledger inset come off the row
+    width first, and the gate that drops a row to the floor is applied to THAT
+    number. In the band where the two answers differ — a 72-cell row builds in 69
+    cells, so the shared column is not reachable even though the row's own width
+    clears the gate — a record taken of the outer width claims the shared column
+    while the row paints the floor, and the guard can no longer see the row it
+    exists to guard.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(76, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        wide = ToolCard("wide", LONGER_TOOL, {"command": "list them"}, "")
+        view.append_block(wide)
+        wide.mark_done("done")
+        await _settle(pilot)
+
+        assert view.tool_name_col == TOOL_NAME_COL + 6, "the shared column is up"
+        assert wide._built_width == 72, "precondition: this terminal's row width"
+        # The row builds in 69 cells, under `NAME_GROWTH_MIN_ROW`, so it paints the
+        # floor — and that is what must have been recorded.
+        assert wide._built_name_col == TOOL_NAME_COL
+
+
+@pytest.mark.parametrize("kind", ["tool", "wake", "peer"])
+@pytest.mark.asyncio
+async def test_every_ledger_row_class_refits_when_it_lands_in_a_ledger(kind: str) -> None:
+    """All THREE row classes, because the guard lives on the base.
+
+    ``ToolCard``, ``WakeBlock`` and ``PeerMessageBlock`` are one ledger, and the
+    re-fit is one behaviour: each class's ``on_resize`` asks
+    :meth:`ExpandableActionBlock._layout_moved`. A class left on the older
+    width-only guard keeps the floor column until a pointer crosses it, which is
+    the operator's tear — review round 1 found exactly that on the peer row, on
+    this head, through the real replay path. Parametrized rather than written
+    once per class so a future row type cannot quietly be the odd one out, and
+    authored the way the replay authors each of them: a fold hint naming the
+    width the row is about to be given, content written while parentless.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        wide = ToolCard("wide", LONGER_TOOL, {"command": "list them"}, "")
+        view.append_block(wide)
+        wide.mark_done("done")
+        await _settle(pilot)
+        shared = summary_col(app, wide, "list them")
+        destination = view.scrollable_content_region.width
+
+        if kind == "tool":
+            paged: TranscriptBlock = ToolCard("paged", "bash", {"command": "reveal me"}, "")
+            paged.set_fold_hint(destination)  # type: ignore[attr-defined]
+            paged.mark_done("done")  # type: ignore[attr-defined]
+            marker = "reveal me"
+        elif kind == "wake":
+            paged = WakeBlock(WAKE_TEXT, fold_width=destination)
+            marker = "w7 (1/3"
+        else:
+            paged = PeerMessageBlock("gates are green", SENDER, fold_width=destination)
+            # The peer row's summary LEADS with the sender, so this fragment is
+            # the summary's first cell; the message follows it inside the summary.
+            marker = '"lo-probe"'
+        assert paged._built_width == destination
+        assert paged._built_name_col == TOOL_NAME_COL  # authored with no ledger to ask
+
+        view.insert_blocks(0, [paged])
+        await _settle(pilot)
+
+        # No pointer anywhere in this sequence.
+        assert summary_col(app, paged, marker) == shared, (
+            f"{type(paged).__name__} paints its summary at "
+            f"{summary_col(app, paged, marker)} while its neighbours are at {shared}"
+        )
+        paged._set_hovered(True)
+        await pilot.pause()
+        assert summary_col(app, paged, marker) == shared
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_transcript_name_col.py
+++ b/tests/unit/tui/test_transcript_name_col.py
@@ -22,6 +22,19 @@ In every case hovering a row repaired that row alone (``on_enter`` →
 a time. The assertions here are on the frame the compositor painted, with no
 pointer anywhere in the sequence.
 
+A fourth path survived all three fixes, and it is the one the operator saw
+again on the released build. A row paged in or restored from history is
+authored while it is still PARENTLESS: the builders set a fold hint naming the
+width the row is about to be given and then author its content (`session_
+presentation`, and ``insert_blocks`` for the pages it mounts). With no ledger to
+ask, the row bakes the floor column, and because the hint is the width it really
+is given, the resize guard compared width with width, read "unchanged", and
+skipped the rebuild that would have re-read the column. So the paged row stayed
+on the floor while its mounted neighbours painted the shared column — and a
+pointer crossing it re-fitted that one row, which is the tearing-under-the-cursor
+symptom. The guard now compares the column too (``_layout_moved``), which is the
+second input the row's geometry is built from.
+
 What is asserted is the COLUMN, never frame bytes or whole-row text: hover
 legitimately rewrites a row's own text (``_build_row`` lights the ``⟨expand⟩``
 offer when the row is hovered), so "the frame is unchanged" is the wrong
@@ -35,7 +48,7 @@ import pytest
 from rich.text import Text
 from textual.app import App
 
-from local_operator.tui.widgets.tool_card import ToolCard
+from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH, ToolCard
 from local_operator.tui.widgets.transcript import (
     TOOL_NAME_COL,
     TranscriptBlock,
@@ -150,6 +163,135 @@ async def test_appending_a_longer_name_repaints_the_rows_already_painted() -> No
         assert expected > narrow
         assert summary_col(app, first, "echo alpha") == expected
         assert summary_col(app, second, "echo beta") == expected
+
+
+#: A terminal whose TRANSCRIPT content region is exactly ``FALLBACK_WIDTH``.
+#: The same trap as the hint, reached with no hint at all: a row authored while
+#: it was parentless falls back to that width, so on a terminal of this size the
+#: row is laid out at exactly the width it authored at.
+FALLBACK_TERMINAL = (84, 24)
+
+
+@pytest.mark.asyncio
+async def test_a_row_authored_before_it_was_appended_paints_the_shared_column() -> None:
+    """The authoring order the replay and paging paths use: hint, then append.
+
+    ``session_presentation`` tells a restored row the width it is about to be
+    given *before* the state calls that author its content, so the row folds once
+    instead of flashing at the console width — the reason ``set_fold_hint``
+    exists. The cost of that order is that the content is written with no ledger
+    to ask, so the row bakes the floor column, and its authored width is exactly
+    the width it is then handed. A guard reading only the width reports
+    "unchanged" and never re-fits it: the paged row keeps the floor while the
+    rows around it paint the shared column.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        wide = ToolCard("wide", LONGER_TOOL, {"command": "list them"}, "")
+        view.append_block(wide)
+        await _settle(pilot)
+        shared = summary_col(app, wide, "list them")
+
+        # The paging path, reproduced in its own order.
+        destination = view.scrollable_content_region.width
+        paged = ToolCard("paged", "bash", {"command": "reveal me"}, "")
+        paged.set_fold_hint(destination)
+        paged.mark_done("done")  # authors the row while it has no parent
+        assert paged._built_width == destination  # ... at exactly that width
+        view.insert_blocks(0, [paged])
+        await _settle(pilot)
+
+        # No pointer anywhere in this sequence: the row finds the ledger's column
+        # on its own layout pass, like any other newcomer.
+        assert summary_col(app, paged, "reveal me") == shared
+
+        # And a pointer crossing it changes nothing — hover is not load-bearing
+        # for alignment, which is the claim the operator's report is about.
+        paged._set_hovered(True)
+        await pilot.pause()
+        assert summary_col(app, paged, "reveal me") == shared
+
+
+@pytest.mark.asyncio
+async def test_a_row_that_lands_at_the_width_it_was_authored_at_still_fits() -> None:
+    """The same trap with no hint at all: the ``FALLBACK_WIDTH`` landmine.
+
+    On a terminal whose content region IS the fallback width, every parentless
+    build is laid out at exactly the width it authored at, so nothing about the
+    hint is special — the width-only guard was. Nothing else in the frame can be
+    trusted as a reference either, because every row is stale together at this
+    size; the frame is self-consistently wrong, which is why the claim is made
+    against a row whose width MOVED under it (and therefore re-fitted).
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=FALLBACK_TERMINAL) as pilot:
+        view = app.query_one(TranscriptView)
+        assert view.scrollable_content_region.width == FALLBACK_WIDTH
+        # The reference row is APPENDED BEFORE it is settled, so its content is
+        # authored while it is mounted — the one order in this frame that can read
+        # the shared column. Everything authored while parentless lands on the
+        # fallback width here, which is exactly the point.
+        wide = ToolCard("wide", LONGER_TOOL, {"command": "list them"}, "")
+        view.append_block(wide)
+        wide.mark_done("done")
+        await _settle(pilot)
+        shared = summary_col(app, wide, "list them")
+
+        paged = ToolCard("paged", "read", {"command": "reveal me"}, "")
+        paged.mark_done("done")
+        assert paged._built_width == FALLBACK_WIDTH
+        view.insert_blocks(0, [paged])
+        await _settle(pilot)
+
+        assert summary_col(app, paged, "reveal me") == shared
+
+
+@pytest.mark.asyncio
+async def test_a_sidebar_toggle_refits_every_row_the_frame_shows() -> None:
+    """The WIDTH/RIGHT-EDGE invariant across the gesture the operator reported.
+
+    The second report was the same tear on the right: rows whose right-aligned
+    status sits at different cells after a sidebar toggle and a scroll, mending
+    one row at a time under the pointer. A toggle moves the lane the transcript is
+    given, so every row's width moves with it, and a row left at the old width
+    paints its status in the wrong column.
+
+    A GUARD, not a reproduction, and it says so deliberately: it passes on the
+    unfixed tree as well, because the width term of ``on_resize`` already caught
+    every width change these harnesses can drive (the search, and what it could
+    not reach, is recorded on the PR). What it can see is the shape a regression
+    in the refit path would take: every mounted row must agree with the pane on
+    the width it was BUILT at, after the toggle settles and again after a hover,
+    because hover must never be load-bearing for geometry.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        seeded = []
+        for index, name in enumerate(("bash", "list_variables", "read", "web_search")):
+            card = ToolCard(f"c{index}", name, {"command": f"echo {index}"}, "")
+            view.append_block(card)
+            card.mark_done("done")
+            seeded.append(card)
+        await _settle(pilot)
+
+        for key in ("ctrl+b", "pageup", "pagedown", "ctrl+b"):
+            await pilot.press(key)
+            await _settle(pilot)
+            pane = view.scrollable_content_region.width
+            for card in seeded:
+                assert card._built_width == pane, (
+                    f"{card.tool_call_id} paints at {card._built_width} while the "
+                    f"pane is {pane} (after {key})"
+                )
+                before = summary_col(app, card, f"echo {seeded.index(card)}")
+                card._set_hovered(True)
+                await pilot.pause()
+                assert card._built_width == pane
+                assert summary_col(app, card, f"echo {seeded.index(card)}") == before
+                card._set_hovered(False)
+                await pilot.pause()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Symptom

The operator reported the ledger tear again on the released `v0.54.27`, which already contains the first funnel fix (`95fccacd`). Their own words, in two reports:

> *…initially on bash calls for example the alignment of the detail text in the tool card is more tightly to the left but then later on another tool call can happen which has more padding … until I move my mouse over that row it will stay that way* — and, on the release: *This still seems to be an issue in the latest TUI version.*

Their original frame (measured off the attachment) shows one `bash` row's summary six cells left of its neighbours' while the rows appended after the column grew sit on the wide column. The earlier fix closed every path that moved the column and repainted nobody. This was a different hole: a row **authored before it had a ledger to ask**, so it baked the floor column, and nothing ever re-fitted it.

## Root cause

`ToolCard`, `WakeBlock` and `PeerMessageBlock` all re-fit themselves through the same guard:

```python
if size is not None and size.width == self._built_width:
    return          # "a resize that only changed the HEIGHT reproduces the rows byte for byte"
```

That claim needs **two** inputs, and the guard only read one. A ledger row's painted geometry is a function of its state, its width **and the ledger's shared name column** — and the column cannot be read while the row is parentless.

The replay and paging paths author a row exactly that way, on purpose: `session_presentation` (and `insert_blocks` for the pages it mounts) call `set_fold_hint(<the width the row is about to be given>)` *before* the state calls that write the row's content, so the row folds once at its destination width instead of flashing at the console width. With no parent to ask, `ToolCard._name_col` falls through to `NAME_COL` — the floor, 8 — and the row records the hinted width it authored at (`ToolCard._refresh_row`, `WakeBlock._refresh_row`, `PeerMessageBlock._refresh_row`).

Then the row is laid out at **exactly that width** — what the hint promises, and what the 80-cell `FALLBACK_WIDTH` coincides with on an 80-cell transcript. The width term says *unchanged*, the rebuild is skipped, and the row keeps the floor while its mounted neighbours paint the shared column. `TranscriptView._repaint_ledger_rows` cannot rescue it either: it repaints on a column **change**, and a page of short-named rows moves nothing.

A pointer crossing the row calls `on_enter` → `refresh_row` → `_refresh_row` at its own (correct) width, and *that* rebuild is the first one with a ledger to ask. Hence: one row at a time, under the cursor.

## Fix

* `ExpandableActionBlock._built_name_col` — the column the applied content was really built with, written beside `_built_width` by all three row classes. `None` is "nothing applied yet", so a row that has never painted always re-fits on its first layout pass.
* `ExpandableActionBlock._layout_moved(width)` — the guard's question, now asked of both terms, through each subclass's own `_name_col` so the builder's ladder and the guard cannot disagree.
* `ToolCard.on_resize`, `WakeBlock.on_resize`, `PeerMessageBlock.on_resize` — one guard
  line each, no new contract. All three, which review round 1 had to insist on: `PeerMessageBlock`
  was left on the width-only form (R1) and kept the floor column until a pointer crossed it.
* `row_body_width(width)` — the width a row builds its content in, derived once next to
  `row_indent` and used by the three builders *and* by the guard's question, because the
  name-column gate is applied to the width the row builds in, not to its own width (R2).
* `TranscriptView._repaint_ledger_rows`'s comment that an unmounted row "derives the column on that pass" now names what makes that true.

Cost: one extra `_build_content` per row at its first layout, at the *same* width, so the row count does not move and no reflow is requested. No per-frame work, no hover dependence.

## Repro — fails pre-fix, passes post-fix

`tests/unit/tui/test_transcript_name_col.py`:

* `test_a_row_authored_before_it_was_appended_paints_the_shared_column` — the paging/replay authoring order (hint, then append) beside a row already on the shared column. Asserts the paged row's summary cell **off the compositor**, with no pointer in the sequence, then that a hover does not move it.
* `test_a_row_that_lands_at_the_width_it_was_authored_at_still_fits` — the same trap with no hint at all, on a terminal whose transcript content region is `FALLBACK_WIDTH`.

Pre-fix, on `3aec94b92` (source stashed, tests kept):

```
E  AssertionError: assert 14 == 20
FAILED tests/unit/tui/test_transcript_name_col.py::test_a_row_authored_before_it_was_appended_paints_the_shared_column
FAILED tests/unit/tui/test_transcript_name_col.py::test_a_row_that_lands_at_the_width_it_was_authored_at_still_fits
2 failed, 7 passed
```

`14` is the floor column's offset, `20` the shared column's. Post-fix the module is `10 passed`.

## Visual evidence

Rendered frames of the real application (`OperatorApp` under a headless pilot, the app that loads `local_operator.tcss`, captured with `scripts.visual_capture.save_capture`), produced by the new reusable shot script `scripts/ledger_paged_row_shot.py` and **inspected as images**:

| frame | paged row | `list_variables` row | seeded `bash` row |
|---|---|---|---|
| before, `hint` | summary@**14** | summary@20 | summary@20 |
| after, `hint` | summary@20 | summary@20 | summary@20 |
| before, `fallback` | summary@**14** | summary@20 | summary@20 |
| after, `fallback` | summary@20 | summary@20 | summary@20 |

Frames: `~/workspace/lo-hoverfix-evidence/{before,after}-{hint,fallback}.{svg,png}` and `before-after.png`. Deliberately **not** committed (AGENTS.md, "Evidence goes on the PR, never into the repository"). The before frame shows the defect the operator described — one `bash` row six cells tighter than the two below it; the after frame shows one column.

## The second report — right-edge rows, and what I could NOT reproduce

The operator also reported the same class on the right (*"some lines will be full width and some won't be … moving the mouse over them updates them"*). **This PR does not claim to fix that, because I could not reproduce it**, and saying so is part of the evidence:

* Their second frame was measured off the attachment: the rows' trailing status runs sit at ~740-768 px in one group and ~964-989 px in another — a real painted-width difference of ~22-23 cells, with both groups' statuses visible inside the crop.
* The app never pins a ledger row's width: the only `styles.width` writes onto transcript blocks are in `_sync_boot_column_width`, and they target `.notice-block` children only (`app.py:15616`).
* Everything I could drive re-fits, and the harness says so explicitly: 9 synthetic event scenarios plus randomised sequences (several seeds) that hover every mounted row through the real `on_enter` path; 40-row ledgers toggled off-screen; deliberately wrong fold hints (±16/+24 cells); the *real* resume/replay path on a 60-tool-row seeded transcript driven through `ctrl+b` and paging — in all of them `_built_width == region.width` for every row at every settled frame, and no hover moves any row's width, right edge or left offsets. A single-frame search (reading every frame from the toggle onward with no settle) found no transient either.
* One number argues the frame is not the toggle delta I modelled: a docked sidebar moves the transcript lane by **33 cells** at the sizes measured here (`96 → 63` at 100×30), not the ~22-23 in their frame. So the two-group split in their screenshot has some other cause, and the next step is their live frame with the affected rows identified (or an architect's read of the row-rendering paths this search did not reach) rather than a speculative change here.

A guard test on the reachable shape is included and **labelled as a guard rather than a reproduction**: `test_a_sidebar_toggle_refits_every_row_the_frame_shows` pins "every mounted row agrees with the pane on the width it was built at, after a toggle and after a hover". It passes on the unfixed tree too; it exists so a future regression in the refit path fails loudly.

**Breadth, corrected after review round 1 (R3).** The search above was written as "could not
reproduce" while every surface in it was a **tool** row, and the ledger has three row classes —
so the statement was true of the paths driven and premature as a statement of absence. R1 is
exactly that gap: a peer row, on this head, kept the floor column through the real replay path
until a pointer crossed it, and the same search with a peer row in the ledger would have found
it. With R1 fixed, `test_every_ledger_row_class_refits_when_it_lands_in_a_ledger` pins all
three classes instead of one. Note that R1 does not explain the operator's right-edge frame
either: the name column moves a row's *left* offsets, not its total width or right-aligned
status, so that cause stays with the architect/QA streams.

## Verification

* `flake8 .` clean; `uvx --from black==26.1.0 black --check .` → 1265 files unchanged; `uvx isort==5.13.2 --check .` clean; `pyright` → 0 errors, 0 warnings.
* `tests/unit` — full tree, on this head.
* `tests/e2e -m e2e -n0` — 107 passed, 7 skipped.

## Not addressed

* A **user-run** row (`! command` from the composer) leads with a five-cell `you: ` attribution chip, which puts its summary start five cells right of an agent-run row's *by construction* — measured, stable across hover, on this head. It is not this defect (nothing re-fits it; it is where the row is built), but it is the same *appearance* — two `bash` rows at different summary offsets — so it is recorded here rather than silently changed: making user-run rows share the spine is a geometry decision affecting every row, and it wants a design call, not a drive-by.
