### PR TITLE
feat(session): make delegated runs reachable in the sidebar catalog, and pins durable

### DIFF
--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -432,6 +432,27 @@ CATALOG_SCAN_LIMIT = 200
 #: Newest subagent runs the sidebar's ⌥ layer lists when it is switched on.
 #: One screenful of headroom past the ~38-row window, matching the reasoning
 #: behind CATALOG_SCAN_LIMIT. No paging: the layer answers "what just ran".
+#:
+#: WHAT THIS CAP DOES AND DOES NOT BOUND. The cap bounds the PAGE, not the
+#: selection. The per-row reads on the capped page — `origin.json` and
+#: `session_created_at` — are O(cap): measured flat at 85 `origin.json` reads
+#: with the hidden population at 50, 100, 400 and 800. What is NOT capped is
+#: the step-2 selection sweep in `load_catalog`, which stats every hidden
+#: directory to find the newest CAP of them: that is O(hidden population),
+#: linear at a stable ~6.0 µs/dir measured from 250 to 4000 dirs, and it is
+#: the term that scales.
+#:
+#: So the ON-path delta grows with the store, not with this constant. The
+#: +6.6 ms measured today was ruled ACCEPTED-with-documentation rather than a
+#: regression because the original +2.7 ms budget was set on a 462-hidden
+#: store and the store outgrew it — the sweep is the prescribed algorithm
+#: costing what it costs at a larger population, not a leak of the capped
+#: reads into the population. Memoizing the sweep is the follow-up, and it
+#: becomes worth its own invalidation surface at roughly 2,000 hidden
+#: directories (~12 ms, 0.6% of the 2 s poll), not before.
+#:
+#: The ruling, with the measurements: `BRIEF-sidebar-slice-b.md`,
+#: "## Lead check — round 1".
 SUBAGENT_LAYER_CAP = 40
 
 #: `session_id -> ((activity_mtime, transcript_size), SessionRow)`. A row's

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -7,6 +7,7 @@ The catalog has no acknowledgement path: listing a conversation is not reading i
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sqlite3
@@ -35,10 +36,28 @@ class CatalogEntry:
     #: that build entries positionally, keep working unchanged.
     completion_token: str = ""
     anchor_id: str = ""
+    #: Set ONLY on rows from the hidden subagent population.
+    #:
+    #: Load-bearing for SECTIONING, not decoration: `active` is
+    #: `pending or unseen or live_state`, and 45% of subagent directories carry
+    #: an unseen attention receipt, so without this flag they sort into ACTIVE
+    #: SESSIONS above the user's own work.
+    subagent: bool = False
+    #: `origin.json`'s `agent` (role) and `label` (task label), read only for
+    #: the capped page. Empty for every main row.
+    agent: str = ""
+    label: str = ""
 
     @property
     def id(self) -> str:
         return self.row.id
+
+    @property
+    def sub_title(self) -> str:
+        """`label · role`, degrading to whichever half exists, else the name."""
+        if self.label and self.agent:
+            return f"{self.label} · {self.agent}"
+        return self.label or self.agent or self.row.name
 
     @property
     def rank(self) -> tuple[int, int, float, str]:
@@ -410,6 +429,11 @@ def decorate_rows(
 #: viewport keeps paging and ranking honest without materialising the tail.
 CATALOG_SCAN_LIMIT = 200
 
+#: Newest subagent runs the sidebar's ⌥ layer lists when it is switched on.
+#: One screenful of headroom past the ~38-row window, matching the reasoning
+#: behind CATALOG_SCAN_LIMIT. No paging: the layer answers "what just ran".
+SUBAGENT_LAYER_CAP = 40
+
 #: `session_id -> ((activity_mtime, transcript_size), SessionRow)`. A row's
 #: name and fork mark change only when its transcript does, and the scan
 #: already stats that file to rank the session, so the key is free. Only the
@@ -509,13 +533,58 @@ def cached_session_rows(
     return rows
 
 
-def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[CatalogEntry]:
+def _subagent_marker(session_dir: Path) -> tuple[str, str]:
+    """``(agent, label)`` from a subagent's ``origin.json``; ``("", "")`` if unreadable.
+
+    Best-effort by contract, like every other marker read on this path: a
+    missing, truncated or non-object marker costs the row its role and task
+    label, never the row itself.
+    """
+    try:
+        payload = json.loads((session_dir / "origin.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ("", "")
+    if not isinstance(payload, dict):
+        return ("", "")
+    values = []
+    for key in ("agent", "label"):
+        value = payload.get(key)
+        values.append(value if isinstance(value, str) and value else "")
+    return (values[0], values[1])
+
+
+def subagent_population(directory: Path) -> int:
+    """How many hidden subagent runs the store holds — the footer chip's count.
+
+    A full second scan of the store: ``_scan_sessions`` is not memoized, so
+    this costs about as much as ``load_catalog`` itself (+2.36 ms measured on a
+    156-visible/462-hidden store). Call it on a slow cadence — the sidebar
+    reads it on open and then every fifteenth poll — never once per poll.
+    """
+    from local_operator.resume import _scan_sessions
+
+    return len(_scan_sessions(directory)[1])
+
+
+def load_catalog(
+    directory: Path,
+    limit: int = CATALOG_SCAN_LIMIT,
+    *,
+    include_subagents: bool = False,
+    pinned_hidden_ids: Sequence[str] = (),
+) -> list[CatalogEntry]:
     """Rank a shared lightweight candidate snapshot before materializing a page.
 
     Discovery already stats the whole namespace. Applying a recency cap before
     attention lost old unread work; reading names for the entire store would
     undo the sidebar's bounded I/O. Rank cheap rows first, then hydrate only the
     requested prefix through the existing transcript-stat cache.
+
+    ``include_subagents`` adds a capped page of the hidden subagent population
+    as a SEPARATE layer, and ``pinned_hidden_ids`` keeps individually pinned
+    hidden sessions resolvable while that layer is off. Both are keyword-only
+    and default to the behaviour every existing caller already has: with the
+    layer off this function issues exactly the syscalls it did before.
     """
     from dataclasses import replace
 
@@ -532,6 +601,69 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
     # below for why a hidden directory cannot carry a desktop marker.
     candidates, hidden = _scan_sessions(directory)
     source = {session_id: (session_id, mtime, origin) for session_id, mtime, origin in candidates}
+    # -- the opt-in subagent layer (PROPOSAL 5a) ----------------------------
+    #
+    # Every syscall this layer costs is inside this branch: with both keyword
+    # arguments at their defaults nothing below runs, and the poll is byte-for-
+    # byte the scan it was. `hidden` is already in hand from the scan above, so
+    # the OFF path does not even pay a directory read to learn it is off.
+    #
+    # THESE ROWS DELIBERATELY BYPASS `decorate_rows` AND THE ATTENTION LOOKUP
+    # BELOW. `CatalogEntry.active` is `pending or unseen or live_state`, and the
+    # attention store keys on conversation identity -- which answers for
+    # subagent ids too, 45% of them carrying an unseen receipt. A sub row placed
+    # in `rows` therefore comes out `active=True` and sections into Active
+    # Sessions, above the user's own work. No filter inside that path avoids it;
+    # the only fix is not to be on the path. So these are built by hand, in
+    # their own list, with the quiet fields left at their empty defaults, and
+    # they rejoin the main flow at exactly one point: the `rank_entries` call.
+    subagent_entries: list[CatalogEntry] = []
+    if include_subagents or pinned_hidden_ids:
+        pinned = [session_id for session_id in pinned_hidden_ids if session_id in hidden]
+        wanted = set(hidden) if include_subagents else set()
+        wanted.update(pinned)
+        stamped: list[tuple[float, str]] = []
+        for session_id in wanted:
+            transcript = directory / "sessions" / session_id / TRANSCRIPT_FILENAME
+            try:
+                stamped.append((transcript.stat().st_mtime, session_id))
+            except OSError:
+                # No readable transcript: nothing to hydrate a row from, and
+                # `_row_stat_key` would decline to cache it anyway.
+                continue
+        stamped.sort(key=lambda item: (-item[0], item[1]))
+        mtimes = {session_id: mtime for mtime, session_id in stamped}
+        # Pinned ids are exempt from the cap -- a pin to the 300th-oldest run
+        # must still resolve, or the pin renders as nothing at all.
+        selected = list(
+            dict.fromkeys(
+                [session_id for _, session_id in stamped[:SUBAGENT_LAYER_CAP]]
+                + [session_id for session_id in pinned if session_id in mtimes]
+            )
+        )
+        for session_id in selected:
+            session_dir = directory / "sessions" / session_id
+            agent, label = _subagent_marker(session_dir)
+            # Added to `source` ONLY -- never to `candidates`, never to `rows`.
+            # `source` is what the single `cached_session_rows` call below looks
+            # rows up in, so this alone is what buys these rows their real name.
+            source[session_id] = (session_id, mtimes[session_id], "subagent")
+            subagent_entries.append(
+                CatalogEntry(
+                    SessionRow(
+                        session_id,
+                        mtimes[session_id],
+                        "",
+                        # Stamped, never left at the 0.0 default: rows that all
+                        # tie there fall through to the id tie-break, which
+                        # silently reverses newest-first order.
+                        created_at=session_created_at(session_dir),
+                    ),
+                    subagent=True,
+                    agent=agent,
+                    label=label,
+                )
+            )
     # Creation time is the immutable ordering key (#800), so every construction
     # site must stamp it. Rows left at the 0.0 default all tie and fall through
     # to the session-id tie-break, which silently reverses newest-first order.
@@ -626,8 +758,23 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
                 )
                 for row in rows
             ]
+            # The ONE join point. Sub entries are concatenated here rather than
+            # being members of `rows`, so they never pass through the
+            # decoration and attention work above -- and this stays a single
+            # `rank_entries` call over a single list.
+            + subagent_entries
         )
     )[:limit]
+    # KNOWN LIMITATION, decided rather than missed. This slice applies to the
+    # COMBINED list, so a store with more than ~160 visible sessions cannot fit
+    # both populations in CATALOG_SCAN_LIMIT. Sub rows do not lose that race:
+    # their `session_category` inputs are all falsy by construction, giving them
+    # the same tier as a cold visible row, where the tie-break is `-created_at`
+    # and subagent runs are recent. So what is pushed past the slice is the
+    # user's OLDEST COLD sessions, never an active row. Raising the limit would
+    # restore the per-poll row-building cost the comment on CATALOG_SCAN_LIMIT
+    # exists to document removing, so it is deliberately not raised.
+    # Pinned by `test_the_layer_competes_for_the_page_on_a_full_store`.
     named = {
         row.id: row
         for row in cached_session_rows(

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -1259,6 +1259,19 @@ SETTINGS: tuple[Setting, ...] = (
             Choice("right", "right", "sessions to the right of the conversation"),
         ),
     ),
+    Setting(
+        key="tui.sidebar_show_subagents",
+        path=("tui", "sidebar_show_subagents"),
+        section="appearance",
+        label="Sidebar subagent layer",
+        kind=Kind.BOOL,
+        default=False,
+        help=(
+            "List recent subagent runs below your own sessions. "
+            "Ctrl+A toggles the layer while the sidebar has focus."
+        ),
+        choices=_bool_choices("list recent subagent runs", "show only your own sessions"),
+    ),
     # -- hotkeys ------------------------------------------------------------
     # DERIVED from `keymap.KEY_ACTIONS` rather than spelled out, because the
     # id is simultaneously this key, the `Binding` id in `OperatorApp.BINDINGS`

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -12,16 +12,19 @@ from typing import Any, Literal
 
 from local_operator.session.catalog import (  # noqa: F401 -- compatibility API
     CATALOG_SCAN_LIMIT,
+    SUBAGENT_LAYER_CAP,
     CatalogEntry,
     cached_session_rows,
     decorate_rows,
     load_catalog,
     rank_entries,
     session_directory_name,
+    subagent_population,
 )
 
 DEFAULT_SIDEBAR_VISIBLE = False
 DEFAULT_SIDEBAR_POSITION = "left"
+DEFAULT_SIDEBAR_SHOW_SUBAGENTS = False
 SidebarPosition = Literal["left", "right"]
 
 
@@ -29,6 +32,9 @@ SidebarPosition = Literal["left", "right"]
 class SidebarSettings:
     visible: bool = DEFAULT_SIDEBAR_VISIBLE
     position: SidebarPosition = "left"
+    #: Appended last so positional construction — `SidebarSettings(False,
+    #: "left")`, which `scripts/sidebar_shot.py` uses — keeps working.
+    show_subagents: bool = DEFAULT_SIDEBAR_SHOW_SUBAGENTS
 
     @classmethod
     def from_values(cls, values: Mapping[str, Any]) -> SidebarSettings:
@@ -36,7 +42,13 @@ class SidebarSettings:
         section = section if isinstance(section, Mapping) else {}
         visible = section.get("sidebar_visible", DEFAULT_SIDEBAR_VISIBLE)
         position = section.get("sidebar_position", DEFAULT_SIDEBAR_POSITION)
+        show_subagents = section.get("sidebar_show_subagents", DEFAULT_SIDEBAR_SHOW_SUBAGENTS)
         return cls(
             visible=visible if isinstance(visible, bool) else DEFAULT_SIDEBAR_VISIBLE,
             position="right" if position == "right" else "left",
+            show_subagents=(
+                show_subagents
+                if isinstance(show_subagents, bool)
+                else DEFAULT_SIDEBAR_SHOW_SUBAGENTS
+            ),
         )

--- a/local_operator/tui/sidebar_pins.py
+++ b/local_operator/tui/sidebar_pins.py
@@ -1,0 +1,108 @@
+"""The sidebar's durable pinned-session list.
+
+Kept free of widget imports for the reason :mod:`local_operator.tui.move_targets`
+is: reading and toggling a pin are pure functions over a config root, so they
+are testable — and reusable by a non-Textual frontend — without importing
+Textual to learn which sessions a user pinned.
+
+WHY A FILE AT ALL. Everything else the sidebar ranks by is live state: activity
+mtimes, the runtime registry, the attention store. Quit every session and all of
+it goes empty. A pin is the opposite — a deliberate, durable statement that
+*this* conversation stays at the top until the user says otherwise — so it needs
+the smallest durable thing that survives a restart: a capped JSON array of
+session ids, newest pin first.
+
+A BARE ARRAY, NOT A VERSIONED OBJECT, deliberately. The shape cannot evolve into
+something a reader must interpret, and an unreadable file already degrades to
+"no pins", so a version field would buy a migration path for a format that has
+nowhere to go.
+
+MULTI-PROCESS: LAST WRITER WINS, accepted. Two ``lop`` sessions pinning at the
+same instant means the second write is what the file holds; no precedent in this
+codebase takes a cross-process lock for a small index, and the same-directory
+``os.replace`` means a reader never sees a torn file — only an older one.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PINS_FILE = "sidebar-pins.json"
+#: Against ``move_targets.RECENTS_LIMIT = 20``: a pin is a user's deliberate,
+#: durable selection rather than a trace of where they have been, so a small
+#: multiple of the recents cap is the right order of magnitude.
+PINS_LIMIT = 50
+
+
+def read_pins(config_dir: Path) -> list[str]:
+    """The pinned session ids, newest pin first; ``[]`` when unreadable.
+
+    Best-effort by contract. This file is an enhancement to a list that ranks
+    perfectly well without it, so every failure mode — absent, truncated,
+    holding a JSON object instead of an array, holding non-strings — degrades
+    to "no pinned sessions" rather than costing the user the sidebar.
+
+    PRUNED AT READ against the session store: an id whose directory is gone
+    (cleanup removed it, or the user deleted it) is dropped here rather than
+    rendered as a broken row. Doing it on the read path is what keeps this
+    module free of any coordination with ``session/cleanup.py`` — deletion
+    needs to know nothing about pins.
+    """
+    directory = Path(config_dir)
+    try:
+        raw = json.loads((directory / PINS_FILE).read_text())
+    except FileNotFoundError:
+        return []
+    except (OSError, ValueError):
+        logger.debug("sidebar pins unreadable; continuing without them", exc_info=True)
+        return []
+    if not isinstance(raw, list):
+        return []
+    sessions = directory / "sessions"
+    return [item for item in raw if isinstance(item, str) and item and (sessions / item).is_dir()]
+
+
+def toggle_pin(config_dir: Path, session_id: str) -> bool:
+    """Pin ``session_id`` if it is not pinned, unpin it if it is.
+
+    Returns the NEW state: ``True`` when the session is now pinned, ``False``
+    when the pin was removed. A pin re-applied to an already-pinned session is
+    an unpin, which is what makes one chord both verbs.
+
+    Written to a temporary file in the SAME directory and ``os.replace``d over
+    the target, the discipline every small index here uses (``config.py``,
+    ``move_targets.py``, ``multiplexer/markers.py``): a torn read of this file
+    would silently empty a user's pins, and same-directory replace is the only
+    form that is atomic.
+
+    Never raises. This runs from a keypress the user has already been given
+    feedback for, so a read-only config directory must cost them the pin and
+    not the session.
+    """
+    directory = Path(config_dir)
+    current = read_pins(directory)
+    entries = [item for item in current if item != session_id]
+    # Nothing was removed, so this is a pin rather than an unpin.
+    pinned = len(entries) == len(current)
+    if pinned:
+        entries.insert(0, session_id)
+    del entries[PINS_LIMIT:]
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        handle_fd, temporary = tempfile.mkstemp(dir=directory, prefix=".sidebar-pins-")
+        try:
+            with os.fdopen(handle_fd, "w") as handle:
+                json.dump(entries, handle)
+            os.replace(temporary, directory / PINS_FILE)
+        except BaseException:
+            Path(temporary).unlink(missing_ok=True)
+            raise
+    except OSError:
+        logger.debug("could not record the sidebar pin", exc_info=True)
+    return pinned

--- a/local_operator/tui/sidebar_pins.py
+++ b/local_operator/tui/sidebar_pins.py
@@ -17,6 +17,11 @@ something a reader must interpret, and an unreadable file already degrades to
 "no pins", so a version field would buy a migration path for a format that has
 nowhere to go.
 
+UNPINNING THE LAST PIN LEAVES THE FILE HOLDING ``[]``, deliberately: an empty
+array is this module's resting state and reads back identically to an absent
+file, so there is no second write path to keep correct beside the one atomic
+replace.
+
 MULTI-PROCESS: LAST WRITER WINS, accepted. Two ``lop`` sessions pinning at the
 same instant means the second write is what the file holds; no precedent in this
 codebase takes a cross-process lock for a small index, and the same-directory
@@ -30,6 +35,8 @@ import logging
 import os
 import tempfile
 from pathlib import Path
+
+from local_operator.session.catalog import session_directory_name
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +72,22 @@ def read_pins(config_dir: Path) -> list[str]:
     if not isinstance(raw, list):
         return []
     sessions = directory / "sessions"
-    return [item for item in raw if isinstance(item, str) and item and (sessions / item).is_dir()]
+    return [
+        item
+        for item in raw
+        # A pin is a session id: ONE bare directory name. Checked before the
+        # store-prune below, because the prune joins the id onto `sessions/`
+        # and `Path.__truediv__` does not keep it there — `sessions / "/tmp"`
+        # IS `/tmp`, and `../agents` climbs out of the store. Nothing renders
+        # from a bogus entry today (`load_catalog` hydrates none of them), so
+        # this is defence in depth: the same rule `session_directory_name`
+        # states for discovery metadata, reused rather than re-spelled, so a
+        # file this app wrote cannot redirect a read outside `sessions/`.
+        if isinstance(item, str)
+        and item == Path(item).name
+        and session_directory_name(item)
+        and (sessions / item).is_dir()
+    ]
 
 
 def toggle_pin(config_dir: Path, session_id: str) -> bool:

--- a/tests/unit/session/test_catalog_scan_cost.py
+++ b/tests/unit/session/test_catalog_scan_cost.py
@@ -888,3 +888,333 @@ def test_an_idle_exec_row_says_what_it_is_instead_of_ready(tmp_path) -> None:
     assert idle.status == "Running headless (exec)"
     assert busy.status == "Working"
     assert mine.status == "Ready"
+
+
+class TestTheSubagentLayerIsOptIn:
+    """The sidebar's ⌥ layer: hidden subagent runs, listed without becoming rows.
+
+    Two properties are load-bearing here and both were measured before this
+    layer was written.
+
+    SUB ROWS MUST NOT BE ORDINARY ROWS. ``CatalogEntry.active`` is
+    ``pending or unseen or live_state``, and the attention store keys on
+    conversation identity — which answers for subagent ids too, with 45% of real
+    subagent directories carrying an unseen receipt. A sub row routed through
+    ``decorate_rows`` and the attention comprehension therefore comes out
+    ``active=True`` and sections into Active Sessions, ABOVE the user's own
+    work. There is no filter inside that path that avoids it, so sub rows are
+    built by hand outside ``rows`` and rejoin at the single ``rank_entries``
+    call. ``test_a_sub_row_is_never_active`` is that guard.
+
+    MAINS AND SUBS HYDRATE IN ONE CALL. ``cached_session_rows`` ends
+    ``_ROW_CACHE.clear(); _ROW_CACHE.update(fresh)``, so a second call evicts
+    the first call's rows — a warm 2.0 ms poll becomes 12.2 ms, a 6x regression
+    on the hottest path the sidebar has.
+    ``test_the_hydration_cache_is_not_evicted_by_the_layer`` is that guard.
+
+    And the whole layer is opt-in: with the flag off this function must issue
+    exactly the syscalls it issued before it existed.
+    """
+
+    def test_the_flag_off_is_byte_identical_to_today(self, tmp_path: Path) -> None:
+        """The default path may not pay for a feature it is not using."""
+        for index in range(6):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(20):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+        load_catalog(tmp_path)  # warm every cache
+
+        with _counting() as implicit:
+            bare = [entry.id for entry in load_catalog(tmp_path)]
+        with _counting() as explicit:
+            flagged = [entry.id for entry in load_catalog(tmp_path, include_subagents=False)]
+
+        assert bare == flagged
+        assert explicit.total == implicit.total
+
+    def test_the_layer_appends_hidden_rows_when_it_is_on(self, tmp_path: Path) -> None:
+        for index in range(3):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(5):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        entries = load_catalog(tmp_path, include_subagents=True)
+        assert len(entries) == 8
+        assert sum(1 for entry in entries if entry.subagent) == 5
+        assert {entry.id for entry in entries if not entry.subagent} == {
+            f"user{index:08x}" for index in range(3)
+        }
+
+    def test_the_layer_is_capped(self, tmp_path: Path) -> None:
+        """The layer answers "what just ran", so it is capped rather than paged."""
+        from local_operator.session.catalog import SUBAGENT_LAYER_CAP
+
+        _session(tmp_path, "user00000000", stamp=1000.0)
+        for index in range(SUBAGENT_LAYER_CAP + 10):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        entries = load_catalog(tmp_path, include_subagents=True)
+        assert sum(1 for entry in entries if entry.subagent) == SUBAGENT_LAYER_CAP
+
+    def test_the_layer_is_newest_first(self, tmp_path: Path) -> None:
+        """``rank``'s third key is ``-created_at``, so every sub row must have
+        its creation time STAMPED. A row left at the 0.0 default ties with every
+        other one and falls through to the id tie-break, silently reversing the
+        order the user is promised."""
+        from local_operator.session.catalog import SUBAGENT_LAYER_CAP
+
+        for index in range(SUBAGENT_LAYER_CAP + 5):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        entries = [e for e in load_catalog(tmp_path, include_subagents=True) if e.subagent]
+        stamps = [entry.row.created_at for entry in entries]
+        assert stamps == sorted(stamps, reverse=True)
+        newest = f"sub{SUBAGENT_LAYER_CAP + 4:09x}"
+        assert newest in {entry.id for entry in entries}
+        assert f"sub{0:09x}" not in {entry.id for entry in entries}
+
+    def test_a_sub_row_is_never_active(self, tmp_path: Path) -> None:
+        """THE SECTIONING GUARD. This directory looks like 45% of the real
+        subagent population: it carries an unseen attention receipt. Routed
+        through the ordinary row path it would come out ``active=True`` and sort
+        above the user's own sessions, which is the blocker this layer is shaped
+        around."""
+        import uuid
+
+        from local_operator.session.attention import (
+            AttentionStore,
+            conversation_identity,
+        )
+
+        _session(tmp_path, "user00000000", stamp=1000.0)
+        directory = _session(tmp_path, "sub000000001", origin="subagent", stamp=900.0)
+        store = AttentionStore(tmp_path / "attention.db")
+        # A real token: the store parses it as a UUID.
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "anchor-1", "complete")
+        # The receipt really is unseen, or this test proves nothing.
+        assert store.state(conversation_identity(directory))["unseen"] is True
+
+        entry = next(
+            e for e in load_catalog(tmp_path, include_subagents=True) if e.id == "sub000000001"
+        )
+        assert entry.subagent is True
+        assert entry.active is False
+        assert entry.unseen is False
+        assert entry.completion_kind == ""
+        assert entry.completion_token == ""
+        assert entry.anchor_id == ""
+        assert entry.row.live_state == ""
+        assert entry.row.pending is None
+        assert entry.row.wakes == 0
+
+    def test_a_sub_row_carries_its_role_and_label(self, tmp_path: Path) -> None:
+        directory = tmp_path / "sessions" / "sub000000001"
+        _session(tmp_path, "sub000000001", origin="subagent", stamp=900.0)
+        (directory / "origin.json").write_text(
+            json.dumps({"origin": "subagent", "agent": "reviewer", "label": "round 2"}),
+            encoding="utf-8",
+        )
+
+        entry = next(e for e in load_catalog(tmp_path, include_subagents=True) if e.subagent)
+        assert entry.agent == "reviewer"
+        assert entry.label == "round 2"
+        assert entry.sub_title == "round 2 · reviewer"
+
+    def test_a_sub_row_keeps_its_marker_fields_through_hydration(self, tmp_path: Path) -> None:
+        """The hydration pass rebuilds ``entry.row``; it must not drop the
+        entry's own fields on the way."""
+        from local_operator.resume import write_session_title
+
+        directory = _session(tmp_path, "sub000000001", origin="subagent", stamp=900.0)
+        (directory / "origin.json").write_text(
+            json.dumps({"origin": "subagent", "agent": "qa", "label": "smoke"}),
+            encoding="utf-8",
+        )
+        # Through the real naming path, so the name resolves the way the picker
+        # and the sidebar resolve it rather than through a hand-written sidecar.
+        write_session_title(directory, "a real name", user_set=False, past_names=[])
+
+        entry = next(e for e in load_catalog(tmp_path, include_subagents=True) if e.subagent)
+        # A name proves it went through `cached_session_rows` rather than
+        # keeping the empty placeholder its hand-built row started with.
+        assert entry.row.name == "a real name"
+        assert entry.subagent is True
+        assert entry.agent == "qa"
+        assert entry.label == "smoke"
+
+    def test_a_corrupt_origin_marker_degrades_to_the_session_name(self, tmp_path: Path) -> None:
+        """A marker is best-effort: it may cost the row its role and label,
+        never the row."""
+        broken = _session(tmp_path, "sub000000001", origin="subagent", stamp=900.0)
+        (broken / "origin.json").write_text("{not json", encoding="utf-8")
+        empty = _session(tmp_path, "sub000000002", origin="subagent", stamp=800.0)
+        (empty / "origin.json").write_text("{}", encoding="utf-8")
+
+        entries = {entry.id: entry for entry in load_catalog(tmp_path, include_subagents=True)}
+        assert {"sub000000001", "sub000000002"} <= set(entries)
+        for session_id in ("sub000000001", "sub000000002"):
+            entry = entries[session_id]
+            assert entry.agent == ""
+            assert entry.label == ""
+            assert entry.sub_title == entry.row.name
+
+    def test_a_pinned_hidden_id_is_hydrated_with_the_layer_off(self, tmp_path: Path) -> None:
+        """A pin outranks the layer switch: pinning a subagent run and then
+        turning the layer off must not make the pin render as nothing."""
+        _session(tmp_path, "user00000000", stamp=1000.0)
+        for index in range(3):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        entries = load_catalog(tmp_path, pinned_hidden_ids=["sub000000001"])
+        by_id = {entry.id: entry for entry in entries}
+        assert by_id["sub000000001"].subagent is True
+        assert "sub000000000" not in by_id
+        assert "sub000000002" not in by_id
+
+    def test_a_pinned_hidden_id_beyond_the_cap_is_still_hydrated(self, tmp_path: Path) -> None:
+        """Pins are exempt from the cap, or a pin to an old run would resolve to
+        nothing the moment 40 newer runs existed."""
+        from local_operator.session.catalog import SUBAGENT_LAYER_CAP
+
+        for index in range(SUBAGENT_LAYER_CAP + 5):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+        oldest = f"sub{0:09x}"
+
+        entries = load_catalog(tmp_path, include_subagents=True, pinned_hidden_ids=[oldest])
+        subs = [entry for entry in entries if entry.subagent]
+        assert oldest in {entry.id for entry in subs}
+        assert len(subs) == SUBAGENT_LAYER_CAP + 1
+
+    def test_a_pinned_id_that_is_not_hidden_costs_nothing(self, tmp_path: Path) -> None:
+        """A visible session is already in the listing; pinning it must not add
+        a second copy through the hidden path."""
+        for index in range(3):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        load_catalog(tmp_path)
+
+        plain = [entry.id for entry in load_catalog(tmp_path)]
+        pinned = [entry.id for entry in load_catalog(tmp_path, pinned_hidden_ids=["user00000001"])]
+        assert pinned == plain
+        assert len(pinned) == len(set(pinned))
+
+    def test_the_hydration_cache_is_not_evicted_by_the_layer(self, tmp_path: Path) -> None:
+        """THE CACHE GUARD. ``cached_session_rows`` ends with
+        ``_ROW_CACHE.clear(); _ROW_CACHE.update(fresh)``, so hydrating mains and
+        subs in TWO calls leaves only the second call's rows cached and the
+        next poll rebuilds the rest from disk — measured 2.0 ms warm against
+        12.2 ms cache-wiped. Both populations must go through ONE call with a
+        concatenated candidate list.
+
+        Every fixture directory here carries a transcript deliberately, not
+        decoratively: ``_ROW_CACHE`` is written only when ``_row_stat_key``
+        succeeds, and the layer itself drops a hidden name whose transcript stat
+        raises. Bare directories would produce a cache of 10 and zero sub rows —
+        a fixture failure wearing the costume of the bug this guards. The sub
+        count is asserted alongside so the two are distinguishable at a glance.
+        """
+        from local_operator.session.catalog import _ROW_CACHE
+
+        for index in range(10):
+            _session(tmp_path, f"user{index:08x}", transcript="{}\n", stamp=1000.0 + index)
+        for index in range(10):
+            _session(
+                tmp_path,
+                f"sub{index:09x}",
+                transcript="{}\n",
+                origin="subagent",
+                stamp=500.0 + index,
+            )
+
+        entries = load_catalog(tmp_path, include_subagents=True)
+        assert sum(1 for entry in entries if entry.subagent) == 10, "fixture: no sub rows built"
+        assert len(_ROW_CACHE) == 20, "a second cached_session_rows call evicted the first's rows"
+
+        # And the warm poll agrees with the cold one.
+        assert [entry.id for entry in load_catalog(tmp_path, include_subagents=True)] == [
+            entry.id for entry in entries
+        ]
+
+    def test_the_layer_competes_for_the_page_on_a_full_store(self, tmp_path: Path) -> None:
+        """A KNOWN, ACCEPTED trade-off, pinned so the next reader can tell it was
+        decided rather than missed.
+
+        ``[:limit]`` applies to the COMBINED list, so a store with more than
+        ~160 visible sessions cannot fit both populations in
+        ``CATALOG_SCAN_LIMIT``. Sub rows do not lose that race: their
+        ``session_category`` inputs are all falsy by construction, so they share
+        a tier with a cold visible row and the tie-break is ``-created_at``,
+        where recent subagent runs win. What gets pushed past the slice is
+        therefore the user's OLDEST COLD sessions — never an active row, which
+        ranks above the whole contest.
+
+        Raising the limit would restore the per-poll row-building cost
+        ``CATALOG_SCAN_LIMIT``'s comment exists to document removing, so the
+        trade is taken deliberately: the layer is opt-in, the rows at stake are
+        past rank 160, and ``/resume`` — the surface for finding an old session
+        — does not go through ``load_catalog`` at all.
+        """
+        from local_operator.session.catalog import (
+            CATALOG_SCAN_LIMIT,
+            SUBAGENT_LAYER_CAP,
+        )
+
+        # Just under the cap, so the store fits ENTIRELY with the layer off and
+        # the rows that vanish can only be the ones the layer displaced.
+        visible = CATALOG_SCAN_LIMIT - 10
+        # Visible sessions carry the OLDER creation stamps; `created_at` is
+        # written explicitly rather than left to the filesystem birthtime, which
+        # macOS has and Linux does not — on CI every row would otherwise tie at
+        # 0.0 and rank by session id, testing the tie-break instead of the order.
+        for index in range(visible):
+            directory = _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+            (directory / "created_at.json").write_text(str(1000.0 + index), encoding="utf-8")
+        oldest_visible = "user00000000"
+        for index in range(SUBAGENT_LAYER_CAP):
+            directory = _session(
+                tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index
+            )
+            # Subagent runs are RECENT, which is what wins them the tie-break.
+            (directory / "created_at.json").write_text(str(9000.0 + index), encoding="utf-8")
+
+        # With the layer off the whole store fits and nothing is displaced.
+        assert oldest_visible in {entry.id for entry in load_catalog(tmp_path)}
+
+        entries = load_catalog(tmp_path, include_subagents=True)
+        assert len(entries) == CATALOG_SCAN_LIMIT
+        subs = [entry for entry in entries if entry.subagent]
+        assert len(subs) == SUBAGENT_LAYER_CAP, "sub rows must not be what falls off the end"
+        assert len(entries) - len(subs) == CATALOG_SCAN_LIMIT - SUBAGENT_LAYER_CAP
+        # The user's oldest sessions are precisely what the layer displaced.
+        surviving = {entry.id for entry in entries}
+        assert oldest_visible not in surviving
+        displaced = visible + SUBAGENT_LAYER_CAP - CATALOG_SCAN_LIMIT
+        for index in range(displaced):
+            assert f"user{index:08x}" not in surviving
+        assert f"user{displaced:08x}" in surviving
+
+    def test_subagent_population_counts_the_hidden_store(self, tmp_path: Path) -> None:
+        from local_operator.session.catalog import subagent_population
+
+        for index in range(4):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(7):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        assert subagent_population(tmp_path) == 7
+
+    def test_the_layer_does_not_reach_the_deletion_authority(self, tmp_path: Path) -> None:
+        """THE STRUCTURAL GUARANTEE. ``session.cleanup`` DELETES, and it decides
+        what to protect from ``recent_sessions(..., revalidate=True)`` rather
+        than from ``load_catalog``. It takes no layer flag and cannot be given
+        one, so sub rows are structurally unable to reach it — asserted here so
+        a future refactor that routes cleanup through the catalog fails loudly
+        instead of quietly counting subagent runs against the user's guard.
+        """
+        from local_operator.session.cleanup import _picker_rows
+
+        for index in range(2):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(5):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        assert set(_picker_rows(tmp_path)) == {"user00000000", "user00000001"}

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -164,6 +164,24 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "<path>.unlink",
         "Removes only its own named temporary file after a failed atomic replacement",
     ),
+    # The sidebar's pin store, the same shape and the same argument as
+    # `remember_recent` above: both paths are the config ROOT joined with a
+    # fixed basename (`sidebar-pins.json`, or a `.sidebar-pins-` temp minted by
+    # `mkstemp` in that same directory), so neither is derived from a session id
+    # and neither can resolve under sessions/. The value written is a list of
+    # session-id STRINGS, never a path this module opens or removes — pruning a
+    # stale pin drops the id from that list and touches no directory.
+    (
+        "local_operator/tui/sidebar_pins.py::toggle_pin",
+        "os.replace",
+        "Atomic replacement of the single sidebar-pins.json file in the config dir, "
+        "never a directory and never under sessions/",
+    ),
+    (
+        "local_operator/tui/sidebar_pins.py::toggle_pin",
+        "<path>.unlink",
+        "Removes only its own named temporary file after a failed atomic replacement",
+    ),
     # -- the one legitimate remover -----------------------------------------
     (
         "local_operator/session/cleanup.py::remove_session_dir",

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -65,6 +65,7 @@ def _consumer_defaults() -> dict[str, object]:
     from local_operator.tools.builtin import BASH_SHELL_DEFAULT
     from local_operator.tui.session_catalog import (
         DEFAULT_SIDEBAR_POSITION,
+        DEFAULT_SIDEBAR_SHOW_SUBAGENTS,
         DEFAULT_SIDEBAR_VISIBLE,
     )
     from local_operator.tui.theme import DEFAULT_THEME
@@ -84,6 +85,7 @@ def _consumer_defaults() -> dict[str, object]:
         "display.time_format": DEFAULT_TIME_FORMAT,
         "tui.sidebar_visible": DEFAULT_SIDEBAR_VISIBLE,
         "tui.sidebar_position": DEFAULT_SIDEBAR_POSITION,
+        "tui.sidebar_show_subagents": DEFAULT_SIDEBAR_SHOW_SUBAGENTS,
         "retry.enabled": retry.enabled,
         "retry.maxRetries": retry.max_retries,
         "retry.baseDelayMs": retry.base_delay_ms,

--- a/tests/unit/tui/test_sidebar_pins.py
+++ b/tests/unit/tui/test_sidebar_pins.py
@@ -108,6 +108,31 @@ def test_a_pin_to_a_deleted_session_is_pruned_at_read(tmp_path: Path) -> None:
     assert read_pins(tmp_path) == ["a" * 12]
 
 
+def test_an_id_bearing_a_path_separator_is_rejected(tmp_path: Path) -> None:
+    """A pin is a session id — ONE bare directory name — and the check runs
+    BEFORE the store-prune, because the prune is what would follow the escape:
+    it joins the id onto ``sessions/``, and ``sessions / "/tmp"`` IS ``/tmp``
+    while ``../agents`` climbs out of the store entirely. ``..`` is rejected
+    too, and would otherwise survive both halves — ``Path("..").name`` is
+    ``".."`` and ``sessions/..`` is a real directory.
+
+    Defence in depth rather than a live bug: nothing renders from a bogus
+    entry today, since ``load_catalog`` hydrates none of them. This keeps the
+    house rule — discovery metadata cannot redirect a read outside
+    ``sessions/`` — true of this file as well.
+    """
+    _session(tmp_path, "real")
+    (tmp_path / "agents").mkdir()
+
+    (tmp_path / PINS_FILE).write_text(json.dumps(["../agents", "..", "/tmp"]))
+    assert read_pins(tmp_path) == []
+
+    (tmp_path / PINS_FILE).write_text(
+        json.dumps(["real", "../agents", "..", ".", "/tmp", "sessions/../../etc", "real/../real"])
+    )
+    assert read_pins(tmp_path) == ["real"]
+
+
 def test_the_write_is_atomic(tmp_path: Path) -> None:
     """Same-directory temp then replace. Asserted by proving no temp file
     survives a successful write — a torn read would silently empty the pins."""

--- a/tests/unit/tui/test_sidebar_pins.py
+++ b/tests/unit/tui/test_sidebar_pins.py
@@ -1,0 +1,157 @@
+"""The sidebar's durable pinned-session list.
+
+Two properties carry this module. The first is that a pin SURVIVES — it is the
+only thing the sidebar ranks by that is not live state, so a torn or half-written
+file costs the user a deliberate choice rather than a cache. The second is that
+it never costs them anything else: a pin is recorded immediately after a keypress
+the user has already been given feedback for, so every failure mode here —
+unreadable file, unwritable directory, a pin to a session that has since been
+deleted — degrades to "no pins" instead of raising into the TUI.
+
+Everything runs against a real temporary filesystem rather than mocks, for the
+reason ``test_move_targets.py`` does: these functions exist to answer questions
+about files, and a mocked filesystem would assert that the code calls what it
+calls rather than that it gives right answers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator.tui.sidebar_pins import PINS_FILE, PINS_LIMIT, read_pins, toggle_pin
+
+
+def _session(config: Path, session_id: str) -> Path:
+    """A session directory, so the read-path prune keeps this id."""
+    directory = config / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def test_an_absent_file_reads_as_no_pins(tmp_path: Path) -> None:
+    """Reading must not be a write: a sidebar that has never pinned anything
+    should leave no trace in the config directory."""
+    assert read_pins(tmp_path) == []
+    assert not (tmp_path / PINS_FILE).exists()
+
+
+def test_a_pin_round_trips(tmp_path: Path) -> None:
+    _session(tmp_path, "aaaaaaaaaaaa")
+    assert toggle_pin(tmp_path, "aaaaaaaaaaaa") is True
+    assert read_pins(tmp_path) == ["aaaaaaaaaaaa"]
+
+
+def test_a_second_toggle_unpins(tmp_path: Path) -> None:
+    """One chord is both verbs, so the return value is the NEW state."""
+    _session(tmp_path, "aaaaaaaaaaaa")
+    toggle_pin(tmp_path, "aaaaaaaaaaaa")
+    assert toggle_pin(tmp_path, "aaaaaaaaaaaa") is False
+    assert read_pins(tmp_path) == []
+
+
+def test_the_newest_pin_leads(tmp_path: Path) -> None:
+    for session_id in ("a" * 12, "b" * 12, "c" * 12):
+        _session(tmp_path, session_id)
+        toggle_pin(tmp_path, session_id)
+    assert read_pins(tmp_path) == ["c" * 12, "b" * 12, "a" * 12]
+
+
+def test_repinning_moves_it_to_the_front(tmp_path: Path) -> None:
+    """Unpin then repin is how a user promotes an old pin, and the list is
+    newest-first, so the repinned id must lead rather than return to its slot."""
+    for session_id in ("a" * 12, "b" * 12):
+        _session(tmp_path, session_id)
+        toggle_pin(tmp_path, session_id)
+    toggle_pin(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "a" * 12)
+    assert read_pins(tmp_path) == ["a" * 12, "b" * 12]
+
+
+def test_the_cap_holds(tmp_path: Path) -> None:
+    """The OLDEST pins are what a full list drops, never the newest."""
+    for index in range(PINS_LIMIT + 10):
+        session_id = f"{index:012x}"
+        _session(tmp_path, session_id)
+        toggle_pin(tmp_path, session_id)
+    pins = read_pins(tmp_path)
+    assert len(pins) == PINS_LIMIT
+    assert pins[0] == f"{PINS_LIMIT + 9:012x}"
+    assert f"{0:012x}" not in pins
+
+
+@pytest.mark.parametrize("body", ["not json", '{"pins": []}'])
+def test_a_corrupt_file_degrades_to_no_pins(tmp_path: Path, body: str) -> None:
+    """Best-effort by contract: the sidebar ranks perfectly well without pins,
+    so an unreadable file must never be the thing that costs the user the list."""
+    (tmp_path / PINS_FILE).write_text(body)
+    assert read_pins(tmp_path) == []
+
+
+def test_non_string_members_are_dropped(tmp_path: Path) -> None:
+    _session(tmp_path, "abc123abc123")
+    (tmp_path / PINS_FILE).write_text(json.dumps([1, None, "abc123abc123", ""]))
+    assert read_pins(tmp_path) == ["abc123abc123"]
+
+
+def test_a_pin_to_a_deleted_session_is_pruned_at_read(tmp_path: Path) -> None:
+    """Pruning on the READ path is what keeps this module free of any
+    coordination with ``session/cleanup.py``: deletion needs to know nothing
+    about pins, and a pin to a cleaned-up session renders as nothing rather
+    than as a broken row."""
+    _session(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "b" * 12)
+    assert read_pins(tmp_path) == ["a" * 12]
+
+
+def test_the_write_is_atomic(tmp_path: Path) -> None:
+    """Same-directory temp then replace. Asserted by proving no temp file
+    survives a successful write — a torn read would silently empty the pins."""
+    _session(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "a" * 12)
+    leftovers = [path.name for path in tmp_path.iterdir() if path.name.startswith(".sidebar-pins-")]
+    assert leftovers == []
+    assert json.loads((tmp_path / PINS_FILE).read_text()) == ["a" * 12]
+
+
+def test_a_failing_write_never_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The keypress has already been acknowledged on screen when this runs."""
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise OSError("no space left on device")
+
+    _session(tmp_path, "a" * 12)
+    monkeypatch.setattr(os, "replace", boom)
+    assert toggle_pin(tmp_path, "a" * 12) is True
+    leftovers = [path.name for path in tmp_path.iterdir() if path.name.startswith(".sidebar-pins-")]
+    assert leftovers == [], "the temp file must not survive a failed replace"
+
+
+@pytest.mark.skipif(os.getuid() == 0, reason="root writes to unwritable directories anyway")
+def test_an_unwritable_directory_never_raises(tmp_path: Path) -> None:
+    config = tmp_path / "readonly"
+    config.mkdir()
+    config.chmod(0o500)
+    try:
+        assert toggle_pin(config, "a" * 12) is True
+        assert read_pins(config) == []
+    finally:
+        config.chmod(0o700)
+
+
+def test_last_writer_wins(tmp_path: Path) -> None:
+    """Documents the accepted multi-process behaviour rather than guarding
+    against it: two sessions pinning at once means the second write is what the
+    file holds. No precedent here takes a cross-process lock for a small index,
+    and the atomic replace means a reader sees an older list, never a torn one."""
+    for session_id in ("a" * 12, "b" * 12):
+        _session(tmp_path, session_id)
+    # Both "processes" observed the same empty base state.
+    assert read_pins(tmp_path) == []
+    toggle_pin(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "b" * 12)
+    assert read_pins(tmp_path) == ["b" * 12, "a" * 12]


### PR DESCRIPTION
## What this changes

The data and persistence half of the `ctrl+b` sidebar upgrade. Nothing user-visible changes when it lands: the layer is opt-in and off, and the pin store has no writer until the UI half arrives.

Production has hidden **every** subagent session since #154. On this machine that is 498 hidden runs against 162 visible — ~75% of the store is invisible, and the sessions a person actually returns to are buried among the ones they do not. This slice makes the hidden population *reachable and labelled* rather than either absent or noise.

| capability | what it is |
| --- | --- |
| `load_catalog(..., *, include_subagents=False, pinned_hidden_ids=())` | an opt-in second pass over the `hidden` set `_scan_sessions` already computes — ranked newest-first, capped at `SUBAGENT_LAYER_CAP = 40`, reading `agent`/`label` from `origin.json` for the capped page only |
| `local_operator/tui/sidebar_pins.py` | an ordered durable id list at `sidebar-pins.json`, copying the `move-recents.json` pattern in `tui/move_targets.py` — mkstemp same-dir + `os.replace`, never raises, prune-at-read, last-writer-wins, `PINS_LIMIT = 50` |
| `tui.sidebar_show_subagents` | `Kind.BOOL`, appearance section, default `False` — the layer's startup default |

`CatalogEntry` gains defaulted `subagent`/`agent`/`label` and a `sub_title`; `subagent_population(directory)` supplies the "N hidden" count.

**Sub rows deliberately carry no live-state and no attention decoration.** Not for cost — those fields decide `CatalogEntry.active`, which decides sectioning. 45% of subagent directories carry an unseen receipt, so decorating them would sort delegated runs into **Active Sessions above the user's own work**. That is why they are built in a separate list that never reaches `decorate_rows` or the attention comprehension, joining only at the single `rank_entries` call.

The UI half is `feat/sidebar-pins-and-chips` and lands as a separate PR on top of this one.

## Evidence

**The layer, off and on, against a seeded store**

```
OFF → 3 rows      ON → 8 rows, 5 of them subagent=True
sub row:  active=False  unseen=False  live_state=''  pending=None
sub_title: 'round 4 · reviewer'
_ROW_CACHE after the ON call: 8   (both populations, ONE cached_session_rows call)
pinned_hidden_ids with the layer OFF: hydrates exactly the one pinned hidden row
```

**Flag OFF costs zero new syscalls** — counted, not asserted:

```
OFF path (before) {scandir: 3, stat: 44}
OFF path (after)  {scandir: 3, stat: 44}     identical ids
```

**Both load-bearing hazards have red-green proofs.** Each was re-broken deliberately and the guard fired:

```
leave the attention lookup on for sub rows
  → AssertionError: assert True is False        (unseen=True in the repr → Active Sessions)

add a second cached_session_rows call
  → AssertionError: a second call evicted the first's rows / assert 10 == 20
     (the function ends with _ROW_CACHE.clear())
```

Both reverted; sources byte-identical after revert.

**`completion_reason` still flows after the merge.** This branch merges `origin/main` (898 commits of drift), and main's liveness rework landed directly on this slice's regions — `CatalogEntry`'s field list, `load_catalog`'s docstring, its body and its tail. The tail is the dangerous one: taking this branch's inline 5-arg `CatalogEntry(...)` instead of main's `entry_for(row, attention.get(...))` drops `completion_reason` **with the whole suite still green**. Probed with a unique sentence through a real `AttentionStore`:

```
merged resolution  → completion_reason == 'PROVIDER ERROR: boom (proof-sentence)'
wrong resolution   → completion_reason == ''   (other four fields identical)

dataclasses.fields: [..., anchor_id, completion_reason, subagent, agent, label]
entry_for's 6th positional `reason` (str) lands in completion_reason (str), not subagent (bool)
```

## Cost: +6.6 ms on the ON path, accepted with documentation

Measured against a documented **+2.7 ms** budget. Read the components before reading it as a regression:

| component | measured | predicted |
| --- | --- | --- |
| step-2 selection sweep, all hidden dirs | 2.96 ms | 0.99 ms (446 dirs) |
| step-4 `origin.json`, capped 40 | **1.04 ms** | 2.03 ms |
| step-4 `created_at`, capped 40 | **1.03 ms** | 1.42 ms |

Both capped-page reads came in *under* prediction, so nothing is leaking into the population. `origin.json` reads measured **85 / 85 / 85 / 85** at hidden populations of 50 / 100 / 400 / 800 — flat. The overage is the prescribed step-2 sweep, linear at ~6.0 µs/dir (measured 250→4000).

The budget was **outgrown, not missed**: +2.7 ms was set on a 462-hidden store and the store is now ~500. Re-measured at load 13.68 after the first reading at load 331 — the delta reproduced at +6.64 ms, so contention was not the explanation. 6.6 ms once per 2 s poll is 0.33%, ON only; every OFF caller pays zero.

Memoizing the sweep becomes worth its own invalidation surface at roughly **2,000 hidden directories** (~12 ms, 0.6% of the poll), not before. That ceiling is recorded in a `#:` block at `SUBAGENT_LAYER_CAP` so the next reader inherits the measurement rather than the conclusion.

## Known limitation

`CATALOG_SCAN_LIMIT = 200` bounds the materialized page. Past ~160 visible sessions the layer competes for it — and since sub rows take `session_category` tier 6 (the cold-row bucket, tie-broken by `-created_at`) while subagent runs are recent, **it is the user's oldest visible sessions that get pushed off**, not the sub rows. Pinned by `test_the_layer_competes_for_the_page_on_a_full_store` (190 visible rows) and commented at the `[:limit]` slice. Raising the limit or adding paging was out of scope.

## Gates

```
black --check (26.1.0)   1447 files unchanged      isort --check-only (5.13.2)   OK
flake8 (7.3.0)           OK                        pyright                       0 errors, 0 warnings

targeted set                      802 passed
  test_catalog_scan_cost.py        46      test_sidebar_pins.py          15
  test_settings_io.py             253      test_no_session_deletion.py  212
  + main's test_catalog_read_failures.py

tests/unit    22822 passed, 28 skipped, 5 failed   (27:33)
coverage      TOTAL 87%, --fail-under=80 exit 0
```

The 5 failures are `tests/unit/test_procname.py`, and the honest characterization is **unstable count, stable identity, reproduces on main**: a pure-`main` control extracted with `git archive` gave 3 then 5 failures on consecutive runs; this tree gave 5 then 4. Every failure is the same spawned-interpreter bootstrap fault (`init_fs_encoding` / `No module named 'encodings'`), both procname files are byte-identical to main, and neither imports anything this branch touches.

Every run used `env -i HOME=<temp> LOCAL_OPERATOR_CONFIG_DIR=<temp>`; `grep -c "REAL CONFIG CHANGED"` was **0** in all logs. Worth stating for whoever runs this suite next: pytest here constructs real `ConfigManager`s and, run unisolated, writes to the operator's live `~/.local-operator/config.yml`.

## Review record

Three rounds at `cf245c56` → APPROVE-terminal. Round 1 raised one MAJOR (the accepted-cost ruling existed nowhere in the code) closed by a comment-only commit; rounds 2 and 3 closed two MINOR QA defects — a `read_pins` containment predicate, and a docstring stating the empty-array file is a deliberate resting state.

A convergence round scoped to `cf245c56..6147662d` re-reviewed the merge alone: **APPROVE, terminal, zero findings**, with the reviewer writing its own discriminating probe for the `completion_reason` hazard rather than accepting the coder's.

QA attacked the integrated tree: 0 BLOCKER, 0 MAJOR, 3 MINOR, all closed. It swept the click hit-test at every y from −3 to height+4 across heights 6–59 and widths 24–44 with zero mismatches, and ran 4 processes × 200 concurrent pin toggles against the same id without corruption.

## Follow-ups, deliberately not fixed here

Both are this slice's own pre-existing behaviour at its approved SHA, verified present at the base. Fixing either inside a merge commit would put unreviewed behaviour change in the worst possible place.

1. `subagent_population` reads the store **non-strictly** — it returns `0` where `load_catalog` raises `SessionStoreUnavailable`. An unnamed silent negative, against this repo's own doctrine that decorations must be named.
2. `tui.sidebar_show_subagents` sits in a `Scope.LIVE` section, but `_apply_sidebar_settings()` is called only from `on_mount` and the two config-watch sites — never the 2 s poll — so it applies at relaunch while the settings UI headers it live.

Found and not fixed, and **not** this branch's defect: `sidebar_content_width` promises 30 cells but the widget renders 29 — `_sync_sidebar_layout` docks `content_width + gutter`, then spends one more on left padding. Verified pre-existing at the base SHA; the UI slice pins the behaviour with a test, and the docstring is now false by one cell.

Release: patch — delegated runs are reachable in the sidebar catalog, and a pinned run survives a restart.
