### PR TITLE
feat(tui): pin sessions, surface delegated runs, and say how many are hidden

### DIFF
--- a/docs/SESSION_SIDEBAR.md
+++ b/docs/SESSION_SIDEBAR.md
@@ -28,6 +28,12 @@ cursor persists invisibly when the list is unfocused. A pinned row leaves
 whatever section it ranked into and appears under ★ Pinned with a `★` in place
 of its state mark.
 
+Pinned rows are not lifted into view: the list shows one page of its own
+ranking, so a pinned session that ranks below that page is not on screen. When
+that happens the `★ Pinned` section ends with a `+N more pinned` line, so the
+heading never claims to be showing the whole pinned set. That line is chrome —
+clicking it does nothing.
+
 Pins live in `sidebar-pins.json` in the configuration directory
 (`~/.local-operator` unless `LOCAL_OPERATOR_CONFIG_DIR` says otherwise), newest
 pin first, capped at 50. They are durable: a pin survives quitting and
@@ -52,6 +58,19 @@ and `Ctrl+O` expands a collapsed paste.
 the flip applies to the session you pressed it in, and a write would fan out
 through the config watcher to every running `lop` process. A `/settings` change
 does apply live to an already-painted sidebar.
+
+Turning the layer on costs screen space before it shows a single row. Each
+section spends a heading plus the blank line beneath it, and every heading after
+the first takes a separating blank as well, so going from two sections to four
+takes section chrome from 5 lines to 11. On a 30-row terminal that is enough to
+turn a list that fitted into a paged one: the footer then shows a pager
+(`1–16/21`) in place of the `ctrl+b hide` hint. This is accepted and expected,
+not a defect — the blank above a heading is what keeps it from sitting flush
+against the previous group's last row.
+
+When the list pages, the footer keeps `f9 focus` and drops `ctrl+b hide`:
+reaching the list matters more than hiding it, and `f9` is also the gate to the
+two sidebar-scoped chords. `/help` still lists `ctrl+b`.
 
 The layer is capped at 40 rows and does not page. A sub row is labelled by what
 it was delegated to do (`label · role`, degrading to whichever half exists),

--- a/docs/SESSION_SIDEBAR.md
+++ b/docs/SESSION_SIDEBAR.md
@@ -11,6 +11,73 @@ fresh first so "next" is what the list would show, never a stale snapshot.
 Settings control visibility and left/right placement. Narrow layouts use a drawer
 that ends above the input dock and closes after any valid selection.
 
+## Sections, pins and the subagent layer
+
+The list is drawn in up to four sections, in this order: **★ Pinned**, **Active
+Sessions**, **Previous Sessions**, **⌥ Subagent Runs**. An empty section costs
+no heading. Sectioning is display-only — `rank_entries` still decides the
+ranking, and pins never reorder it — which is what keeps the terminal and the
+mobile relay agreeing on the same active/previous partition.
+
+### Pins
+
+`F10` pins or unpins the session under the pointer; with no pointer on the list
+and the list focused, it acts on the cursor row. Hover wins over the cursor
+because the pointer resting on a row says which session is meant, while the
+cursor persists invisibly when the list is unfocused. A pinned row leaves
+whatever section it ranked into and appears under ★ Pinned with a `★` in place
+of its state mark.
+
+Pins live in `sidebar-pins.json` in the configuration directory
+(`~/.local-operator` unless `LOCAL_OPERATOR_CONFIG_DIR` says otherwise), newest
+pin first, capped at 50. They are durable: a pin survives quitting and
+relaunching. A pin to a session that no longer exists simply disappears — the
+list is pruned against the session store when it is read, so deleting a session
+needs to know nothing about pins.
+
+`F10` is a function key rather than `Ctrl+P` because Textual's `App` binds
+`Ctrl+P` to its command palette at `priority`, so an app-level binding there
+never fires. It also continues the series `F8` (aside) and `F9` (focus
+sessions) for app-level gestures that must survive a focused composer.
+
+### The ⌥ subagent layer
+
+Subagent runs are hidden from the list by default. `Ctrl+A` toggles them on for
+the current session, and `Ctrl+O` jumps the cursor to the first one. Both are
+**sidebar-scoped**: they fire only while the list owns the focus chain (F9
+mode), because both are also composer keys — `Ctrl+A` is the caret's line-start
+and `Ctrl+O` expands a collapsed paste.
+
+`tui.sidebar_show_subagents` sets the startup default. `Ctrl+A` never writes it:
+the flip applies to the session you pressed it in, and a write would fan out
+through the config watcher to every running `lop` process. A `/settings` change
+does apply live to an already-painted sidebar.
+
+The layer is capped at 40 rows and does not page. A sub row is labelled by what
+it was delegated to do (`label · role`, degrading to whichever half exists),
+carries `⌥` where a state glyph would be, and never shows live state or a
+completion mark — the hidden population is not polled for one.
+
+A pinned subagent row stays in ★ Pinned even with the layer off, since pinning
+is an explicit request for that row.
+
+### The footer count
+
+When hidden subagent runs exist, the footer gains a `· ⌥N` chip on its existing
+line — never a second line, which would cost a session row at every terminal
+height. The count is capped at `999+` so the footer's width stays predictable,
+and it is refreshed every 15 polls (about 30 s) plus whenever the sidebar is
+opened, rather than on every poll: reading it is a second full scan of the
+session store.
+
+### One behaviour change to know about
+
+`Ctrl+Shift+↑`/`Ctrl+Shift+↓` traverse the list's own ranking, so **with the ⌥
+layer on, subagent rows join that traversal**. This follows the shortcut's
+existing contract — what the user sees is what they traverse — but it is the
+change most likely to surprise. With the layer off they are not in the list and
+cannot be reached.
+
 ## Ownership and readiness
 
 `SessionInteraction` owns each source's turns, loop, shell, compaction, draft,

--- a/docs/design/keymap.md
+++ b/docs/design/keymap.md
@@ -716,6 +716,69 @@ Whatever the scout recommends must satisfy all of:
    draft is unchanged — the measurement shape `app.py:1963-1976` already
    established for the aside chords.
 
+### E.4a Shipped: the sidebar's three chords
+
+These are **implemented**, unlike the proposals above. They are plain
+`Binding`s with **no `keymap.*` id** — matching `ctrl+b` and `f9` — so they are
+not remappable and do not enter the three-way keymap identity. Registering an
+id would make it persisted user data and pull in the identity test for chords
+nobody asked to remap.
+
+| Chord | Scope | Action |
+|---|---|---|
+| `f10` | app (`OperatorApp.BINDINGS`) | pin/unpin the session under the pointer, else the focused list's cursor |
+| `ctrl+a` | **sidebar widget only** | toggle the ⌥ subagent layer for this session |
+| `ctrl+o` | **sidebar widget only** | jump the cursor to the first subagent row |
+
+#### Why `f10` and not `ctrl+p`
+
+**`ctrl+p` is not available, and a grep of `local_operator/` will not tell you
+that.** Textual's `App.__init__` injects
+`Binding(self.COMMAND_PALETTE_BINDING, "command_palette", ..., priority=True)`
+whenever `ENABLE_COMMAND_PALETTE` is true. `OperatorApp` never disables it, and
+`COMMAND_PALETTE_BINDING` is `ctrl+p` on textual 8.2.8. The binding is injected
+at runtime, so it appears in no source file in this repository.
+
+Measured on the real `OperatorApp`, per §E.4 clause 5:
+
+```
+ctrl+p  resolved on app: [('probe_pin', False), ('command_palette', True)]
+ctrl+p  pressed:         CommandPalette pushed; the app action NEVER fired
+ctrl+p  sidebar focused: same result — a widget-scoped binding loses to the
+                         palette's priority binding too
+```
+
+`f10`, by the same method:
+
+```
+f10  composer focused: fired=True  draft_intact=True  caret_intact=True
+f10  sidebar focused:  fired=True
+f10  resolved on app:  [('probe_pin', False)]      # sole claimant, non-priority
+```
+
+`f10` continues the series this app already uses for app-level surfaces that
+must survive a focused composer: `f8` = aside, `f9` = focus sessions. Every
+`ctrl+<letter>` is claimed — 24 of 26 by `OperatorApp`, `Editor`/`TextArea` or
+the reserved set, and the two that look free (`ctrl+p`, `ctrl+q`) are Textual's
+own priority bindings. `ctrl+shift+p` and `alt+p` both fire but are refused by
+§E.4 clause 4: `ctrl+shift+*` is not reliably emitted by Terminal.app, and on a
+legacy terminal `ctrl+shift+<letter>` arrives as the same byte as
+`ctrl+<letter>` — which here would misfire into the command palette.
+
+Relocating the command palette (`COMMAND_PALETTE_BINDING = "ctrl+shift+p"`) was
+probed and does free `ctrl+p` cleanly. It is still refused: it changes a key the
+user may already know, for a gesture that has a free key available.
+
+#### Never promote `ctrl+a` or `ctrl+o` to app level
+
+Both are in `keymap.COMPOSER_KEYS` — `ctrl+a` is the composer's line-start and
+`ctrl+o` expands a collapsed paste. They are safe as **sidebar-scoped** bindings
+precisely because in F9 mode the sidebar owns the focus chain and the composer
+is not in it. At app level, non-priority, they would silently lose to `TextArea`
+and the chord would look broken; at priority they would take the composer's keys
+away. Verified: `ctrl+a` still reaches `cursor_line_start` when the Editor has
+focus.
+
 ### E.5 A leader key is an extension point, not scope
 
 The app has burned 9 of ~12 comfortable `ctrl+<letter>` slots (§C.1). A leader

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -432,6 +432,27 @@ CATALOG_SCAN_LIMIT = 200
 #: Newest subagent runs the sidebar's ⌥ layer lists when it is switched on.
 #: One screenful of headroom past the ~38-row window, matching the reasoning
 #: behind CATALOG_SCAN_LIMIT. No paging: the layer answers "what just ran".
+#:
+#: WHAT THIS CAP DOES AND DOES NOT BOUND. The cap bounds the PAGE, not the
+#: selection. The per-row reads on the capped page — `origin.json` and
+#: `session_created_at` — are O(cap): measured flat at 85 `origin.json` reads
+#: with the hidden population at 50, 100, 400 and 800. What is NOT capped is
+#: the step-2 selection sweep in `load_catalog`, which stats every hidden
+#: directory to find the newest CAP of them: that is O(hidden population),
+#: linear at a stable ~6.0 µs/dir measured from 250 to 4000 dirs, and it is
+#: the term that scales.
+#:
+#: So the ON-path delta grows with the store, not with this constant. The
+#: +6.6 ms measured today was ruled ACCEPTED-with-documentation rather than a
+#: regression because the original +2.7 ms budget was set on a 462-hidden
+#: store and the store outgrew it — the sweep is the prescribed algorithm
+#: costing what it costs at a larger population, not a leak of the capped
+#: reads into the population. Memoizing the sweep is the follow-up, and it
+#: becomes worth its own invalidation surface at roughly 2,000 hidden
+#: directories (~12 ms, 0.6% of the 2 s poll), not before.
+#:
+#: The ruling, with the measurements: `BRIEF-sidebar-slice-b.md`,
+#: "## Lead check — round 1".
 SUBAGENT_LAYER_CAP = 40
 
 #: `session_id -> ((activity_mtime, transcript_size), SessionRow)`. A row's

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -7,6 +7,7 @@ The catalog has no acknowledgement path: listing a conversation is not reading i
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sqlite3
@@ -35,10 +36,28 @@ class CatalogEntry:
     #: that build entries positionally, keep working unchanged.
     completion_token: str = ""
     anchor_id: str = ""
+    #: Set ONLY on rows from the hidden subagent population.
+    #:
+    #: Load-bearing for SECTIONING, not decoration: `active` is
+    #: `pending or unseen or live_state`, and 45% of subagent directories carry
+    #: an unseen attention receipt, so without this flag they sort into ACTIVE
+    #: SESSIONS above the user's own work.
+    subagent: bool = False
+    #: `origin.json`'s `agent` (role) and `label` (task label), read only for
+    #: the capped page. Empty for every main row.
+    agent: str = ""
+    label: str = ""
 
     @property
     def id(self) -> str:
         return self.row.id
+
+    @property
+    def sub_title(self) -> str:
+        """`label · role`, degrading to whichever half exists, else the name."""
+        if self.label and self.agent:
+            return f"{self.label} · {self.agent}"
+        return self.label or self.agent or self.row.name
 
     @property
     def rank(self) -> tuple[int, int, float, str]:
@@ -410,6 +429,11 @@ def decorate_rows(
 #: viewport keeps paging and ranking honest without materialising the tail.
 CATALOG_SCAN_LIMIT = 200
 
+#: Newest subagent runs the sidebar's ⌥ layer lists when it is switched on.
+#: One screenful of headroom past the ~38-row window, matching the reasoning
+#: behind CATALOG_SCAN_LIMIT. No paging: the layer answers "what just ran".
+SUBAGENT_LAYER_CAP = 40
+
 #: `session_id -> ((activity_mtime, transcript_size), SessionRow)`. A row's
 #: name and fork mark change only when its transcript does, and the scan
 #: already stats that file to rank the session, so the key is free. Only the
@@ -509,13 +533,58 @@ def cached_session_rows(
     return rows
 
 
-def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[CatalogEntry]:
+def _subagent_marker(session_dir: Path) -> tuple[str, str]:
+    """``(agent, label)`` from a subagent's ``origin.json``; ``("", "")`` if unreadable.
+
+    Best-effort by contract, like every other marker read on this path: a
+    missing, truncated or non-object marker costs the row its role and task
+    label, never the row itself.
+    """
+    try:
+        payload = json.loads((session_dir / "origin.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ("", "")
+    if not isinstance(payload, dict):
+        return ("", "")
+    values = []
+    for key in ("agent", "label"):
+        value = payload.get(key)
+        values.append(value if isinstance(value, str) and value else "")
+    return (values[0], values[1])
+
+
+def subagent_population(directory: Path) -> int:
+    """How many hidden subagent runs the store holds — the footer chip's count.
+
+    A full second scan of the store: ``_scan_sessions`` is not memoized, so
+    this costs about as much as ``load_catalog`` itself (+2.36 ms measured on a
+    156-visible/462-hidden store). Call it on a slow cadence — the sidebar
+    reads it on open and then every fifteenth poll — never once per poll.
+    """
+    from local_operator.resume import _scan_sessions
+
+    return len(_scan_sessions(directory)[1])
+
+
+def load_catalog(
+    directory: Path,
+    limit: int = CATALOG_SCAN_LIMIT,
+    *,
+    include_subagents: bool = False,
+    pinned_hidden_ids: Sequence[str] = (),
+) -> list[CatalogEntry]:
     """Rank a shared lightweight candidate snapshot before materializing a page.
 
     Discovery already stats the whole namespace. Applying a recency cap before
     attention lost old unread work; reading names for the entire store would
     undo the sidebar's bounded I/O. Rank cheap rows first, then hydrate only the
     requested prefix through the existing transcript-stat cache.
+
+    ``include_subagents`` adds a capped page of the hidden subagent population
+    as a SEPARATE layer, and ``pinned_hidden_ids`` keeps individually pinned
+    hidden sessions resolvable while that layer is off. Both are keyword-only
+    and default to the behaviour every existing caller already has: with the
+    layer off this function issues exactly the syscalls it did before.
     """
     from dataclasses import replace
 
@@ -532,6 +601,69 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
     # below for why a hidden directory cannot carry a desktop marker.
     candidates, hidden = _scan_sessions(directory)
     source = {session_id: (session_id, mtime, origin) for session_id, mtime, origin in candidates}
+    # -- the opt-in subagent layer (PROPOSAL 5a) ----------------------------
+    #
+    # Every syscall this layer costs is inside this branch: with both keyword
+    # arguments at their defaults nothing below runs, and the poll is byte-for-
+    # byte the scan it was. `hidden` is already in hand from the scan above, so
+    # the OFF path does not even pay a directory read to learn it is off.
+    #
+    # THESE ROWS DELIBERATELY BYPASS `decorate_rows` AND THE ATTENTION LOOKUP
+    # BELOW. `CatalogEntry.active` is `pending or unseen or live_state`, and the
+    # attention store keys on conversation identity -- which answers for
+    # subagent ids too, 45% of them carrying an unseen receipt. A sub row placed
+    # in `rows` therefore comes out `active=True` and sections into Active
+    # Sessions, above the user's own work. No filter inside that path avoids it;
+    # the only fix is not to be on the path. So these are built by hand, in
+    # their own list, with the quiet fields left at their empty defaults, and
+    # they rejoin the main flow at exactly one point: the `rank_entries` call.
+    subagent_entries: list[CatalogEntry] = []
+    if include_subagents or pinned_hidden_ids:
+        pinned = [session_id for session_id in pinned_hidden_ids if session_id in hidden]
+        wanted = set(hidden) if include_subagents else set()
+        wanted.update(pinned)
+        stamped: list[tuple[float, str]] = []
+        for session_id in wanted:
+            transcript = directory / "sessions" / session_id / TRANSCRIPT_FILENAME
+            try:
+                stamped.append((transcript.stat().st_mtime, session_id))
+            except OSError:
+                # No readable transcript: nothing to hydrate a row from, and
+                # `_row_stat_key` would decline to cache it anyway.
+                continue
+        stamped.sort(key=lambda item: (-item[0], item[1]))
+        mtimes = {session_id: mtime for mtime, session_id in stamped}
+        # Pinned ids are exempt from the cap -- a pin to the 300th-oldest run
+        # must still resolve, or the pin renders as nothing at all.
+        selected = list(
+            dict.fromkeys(
+                [session_id for _, session_id in stamped[:SUBAGENT_LAYER_CAP]]
+                + [session_id for session_id in pinned if session_id in mtimes]
+            )
+        )
+        for session_id in selected:
+            session_dir = directory / "sessions" / session_id
+            agent, label = _subagent_marker(session_dir)
+            # Added to `source` ONLY -- never to `candidates`, never to `rows`.
+            # `source` is what the single `cached_session_rows` call below looks
+            # rows up in, so this alone is what buys these rows their real name.
+            source[session_id] = (session_id, mtimes[session_id], "subagent")
+            subagent_entries.append(
+                CatalogEntry(
+                    SessionRow(
+                        session_id,
+                        mtimes[session_id],
+                        "",
+                        # Stamped, never left at the 0.0 default: rows that all
+                        # tie there fall through to the id tie-break, which
+                        # silently reverses newest-first order.
+                        created_at=session_created_at(session_dir),
+                    ),
+                    subagent=True,
+                    agent=agent,
+                    label=label,
+                )
+            )
     # Creation time is the immutable ordering key (#800), so every construction
     # site must stamp it. Rows left at the 0.0 default all tie and fall through
     # to the session-id tie-break, which silently reverses newest-first order.
@@ -626,8 +758,23 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
                 )
                 for row in rows
             ]
+            # The ONE join point. Sub entries are concatenated here rather than
+            # being members of `rows`, so they never pass through the
+            # decoration and attention work above -- and this stays a single
+            # `rank_entries` call over a single list.
+            + subagent_entries
         )
     )[:limit]
+    # KNOWN LIMITATION, decided rather than missed. This slice applies to the
+    # COMBINED list, so a store with more than ~160 visible sessions cannot fit
+    # both populations in CATALOG_SCAN_LIMIT. Sub rows do not lose that race:
+    # their `session_category` inputs are all falsy by construction, giving them
+    # the same tier as a cold visible row, where the tie-break is `-created_at`
+    # and subagent runs are recent. So what is pushed past the slice is the
+    # user's OLDEST COLD sessions, never an active row. Raising the limit would
+    # restore the per-poll row-building cost the comment on CATALOG_SCAN_LIMIT
+    # exists to document removing, so it is deliberately not raised.
+    # Pinned by `test_the_layer_competes_for_the_page_on_a_full_store`.
     named = {
         row.id: row
         for row in cached_session_rows(

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -1259,6 +1259,19 @@ SETTINGS: tuple[Setting, ...] = (
             Choice("right", "right", "sessions to the right of the conversation"),
         ),
     ),
+    Setting(
+        key="tui.sidebar_show_subagents",
+        path=("tui", "sidebar_show_subagents"),
+        section="appearance",
+        label="Sidebar subagent layer",
+        kind=Kind.BOOL,
+        default=False,
+        help=(
+            "List recent subagent runs below your own sessions. "
+            "Ctrl+A toggles the layer while the sidebar has focus."
+        ),
+        choices=_bool_choices("list recent subagent runs", "show only your own sessions"),
+    ),
     # -- hotkeys ------------------------------------------------------------
     # DERIVED from `keymap.KEY_ACTIONS` rather than spelled out, because the
     # id is simultaneously this key, the `Binding` id in `OperatorApp.BINDINGS`

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1470,6 +1470,9 @@ def _set_transcript_parked(view: Widget, parked: bool) -> None:
 #: rows the eye lands on — without turning every poll into a prepare storm.
 PREWARM_PER_REFRESH = 2
 
+#: Polls between footer-chip population reads. 15 * 2 s = 30 s.
+SUBAGENT_POLL_EVERY = 15
+
 #: How long a parked sidebar source may keep its runtime attachment.
 #:
 #: THE TWO SIDEBAR CACHES ARE DIFFERENT RESOURCES, and conflating them is the
@@ -2534,6 +2537,15 @@ class OperatorApp(App[None]):
         Binding("f8", "aside", "Aside", show=False),
         Binding("ctrl+b", "toggle_sidebar", "Sessions", show=False),
         Binding("f9", "focus_sidebar", "Focus sessions", show=False),
+        # Pin/unpin the session under the pointer (else under the sidebar's
+        # cursor). A FUNCTION key, continuing f8/f9: `ctrl+p` is NOT free —
+        # Textual's App injects `Binding(COMMAND_PALETTE_BINDING, ...,
+        # priority=True)` and that constant is `ctrl+p` on textual 8.2.8, so an
+        # app binding there never fires and the palette opens instead (measured
+        # in a pilot; see docs/design/keymap.md §E.4 clause 5). Every
+        # `ctrl+<letter>` is claimed. Non-priority, so a focused picker keeps
+        # first refusal.
+        Binding("f10", "toggle_pin", "Pin session", show=False),
         # Chosen after auditing the table: `up`/`down`, `pageup`/`pagedown`,
         # `home`/`end` and `shift+up`/`shift+down` are TextArea cursor or
         # selection keys, `ctrl+u`/`ctrl+d` are destructive in the composer,
@@ -3797,6 +3809,17 @@ class OperatorApp(App[None]):
         self._startup_cleanup_timer: Timer | None = None
         self._sidebar_refresh_generation = 0
         self._sidebar_refresh_pending = False
+        #: Polls since the footer chip's population count was last read.
+        #: `subagent_population` is a SECOND full `_scan_sessions` of the store
+        #: (resume.py:1351, not memoized) — measured +2.36 ms, +21% on the 2 s
+        #: poll with the layer OFF. The count answers "how many subagent runs
+        #: exist", which changes on the scale of a delegated run starting, not
+        #: on the scale of a repaint, so it is read on sidebar open and then
+        #: every SUBAGENT_POLL_EVERY polls. Never per poll — see the
+        #: CATALOG_SCAN_LIMIT and `in source` comment blocks in
+        #: session/catalog.py for why this file does not carry O(store) work
+        #: on the poll.
+        self._subagent_population_poll = 0
         self._sidebar_prefetch: Any = None
         self._sidebar_prior_workers: set[Any] = set()
         self._sidebar_settings_applied = False
@@ -6652,8 +6675,18 @@ class OperatorApp(App[None]):
         apply_visibility = (
             not self._sidebar_settings_applied or settings.visible != self._sidebar_settings.visible
         )
+        # Seed the layer from the setting on first application, and thereafter
+        # only when the STORED value actually moved. An unconditional write
+        # would let a `/settings` change to an unrelated key stomp a `ctrl+a`
+        # the user pressed this session.
+        apply_subagents = (
+            not self._sidebar_settings_applied
+            or settings.show_subagents != self._sidebar_settings.show_subagents
+        )
         self._sidebar_settings = settings
         self._sidebar_settings_applied = True
+        if apply_subagents:
+            self._session_sidebar.show_subagents = settings.show_subagents
         if apply_visibility:
             self._set_sidebar_open(settings.visible)
         else:
@@ -6753,8 +6786,18 @@ class OperatorApp(App[None]):
         def collect() -> list[CatalogEntry]:
             from local_operator.paths import config_dir
             from local_operator.tui.session_catalog import load_catalog
+            from local_operator.tui.sidebar_pins import read_pins
 
-            return load_catalog(config_dir())
+            root = config_dir()
+            # Sectioning needs both, so a closed-list switch traverses the
+            # same ranking an open one shows. The population count does NOT
+            # belong here: this runs with the list closed, so there is no
+            # footer to draw it in.
+            return load_catalog(
+                root,
+                include_subagents=self._session_sidebar.show_subagents,
+                pinned_hidden_ids=tuple(read_pins(root)),
+            )
 
         try:
             entries = await asyncio.to_thread(collect)
@@ -6774,6 +6817,47 @@ class OperatorApp(App[None]):
         self._session_sidebar.set_entries(entries)
         self._switch_session_from(self._session_sidebar.entries, delta)
 
+    def action_toggle_pin(self) -> None:
+        """Pin or unpin the row under the pointer, else the sidebar's cursor.
+
+        Hover WINS over the cursor: hover exists only while the pointer is
+        physically resting on a row, which is an unambiguous statement of
+        which session is meant. The cursor persists invisibly when the sidebar
+        is unfocused, so honouring it under a pointer that is elsewhere would
+        pin a row the user is not looking at.
+        """
+        if self.screen is not self.screen_stack[0]:
+            # A pushed modal (the /resume picker, a settings sheet) owns the
+            # keyboard, exactly as `action_switch_session` refuses there.
+            return
+        sidebar = self._session_sidebar
+        if not sidebar.display:
+            # A closed list has no row to pin. A clean no-op that steals
+            # nothing: the binding is non-priority, so the key only reaches
+            # here if nothing focused claimed it, and the composer's draft and
+            # caret are untouched.
+            return
+        target = sidebar.hovered_id or (sidebar.cursor_id if sidebar.has_focus else "")
+        if not target:
+            return
+
+        async def pin() -> None:
+            try:
+                from local_operator.paths import config_dir
+                from local_operator.tui.sidebar_pins import read_pins, toggle_pin
+
+                root = config_dir()
+                # `toggle_pin` writes a file, so it is worker-thread work — the
+                # same shape `_switch_session_cold` uses. The UI thread must
+                # not do I/O.
+                await asyncio.to_thread(toggle_pin, root, target)
+                pins = await asyncio.to_thread(read_pins, root)
+                sidebar.set_pins(pins)
+            except Exception:
+                logger.debug("sidebar pin toggle failed", exc_info=True)
+
+        self.run_worker(pin(), group="sidebar-pin")
+
     def action_toggle_sidebar(self) -> None:
         if not self._session_sidebar.display:
             self._close_subagent_view()
@@ -6791,6 +6875,9 @@ class OperatorApp(App[None]):
         if self._sidebar_timer is not None:
             if opened:
                 self._sidebar_timer.resume()
+                # Opening always takes a fresh population count, so the chip
+                # is never up to 30 s stale on a list the user just opened.
+                self._subagent_population_poll = 0
                 self._refresh_sidebar()
             else:
                 self._sidebar_timer.pause()
@@ -6874,15 +6961,35 @@ class OperatorApp(App[None]):
         generation = self._sidebar_refresh_generation
         self._sidebar_refresh_pending = True
 
-        def collect() -> list[CatalogEntry]:
+        def collect() -> tuple[list[CatalogEntry], list[str], int | None]:
             from local_operator.paths import config_dir
-            from local_operator.tui.session_catalog import load_catalog
+            from local_operator.tui.session_catalog import (
+                load_catalog,
+                subagent_population,
+            )
+            from local_operator.tui.sidebar_pins import read_pins
 
-            return load_catalog(config_dir())
+            root = config_dir()
+            pins = read_pins(root)
+            entries = load_catalog(
+                root,
+                include_subagents=self._session_sidebar.show_subagents,
+                pinned_hidden_ids=tuple(pins),
+            )
+            # Read on a SLOW cadence, never per poll: `subagent_population` is
+            # a second whole-store scan (+2.36 ms, +21% measured with the layer
+            # off) and the count it answers changes when a delegated run
+            # starts, not when the list repaints. `None` means "unchanged",
+            # which is not the same as zero.
+            total: int | None = None
+            if self._subagent_population_poll % SUBAGENT_POLL_EVERY == 0:
+                total = subagent_population(root)
+            self._subagent_population_poll += 1
+            return entries, pins, total
 
         async def refresh() -> None:
             try:
-                entries = await asyncio.to_thread(collect)
+                entries, pins, total = await asyncio.to_thread(collect)
                 if (
                     generation != self._sidebar_refresh_generation
                     or not self._session_sidebar.display
@@ -6891,6 +6998,9 @@ class OperatorApp(App[None]):
                 session = self._session
                 self._session_sidebar.current_id = str(getattr(session, "session_id", ""))
                 self._session_sidebar.set_entries(entries)
+                self._session_sidebar.set_pins(pins)
+                if total is not None:
+                    self._session_sidebar.set_subagent_total(total)
                 self._prewarm_sidebar(list(self._session_sidebar.visible_entries))
             except Exception:
                 if generation == self._sidebar_refresh_generation and self._session_sidebar.display:
@@ -7016,6 +7126,19 @@ class OperatorApp(App[None]):
     def on_session_sidebar_dismissed(self, message: SessionSidebar.Dismissed) -> None:
         message.stop()
         self._set_sidebar_open(False)
+
+    def on_session_sidebar_subagent_layer_toggled(
+        self, message: SessionSidebar.SubagentLayerToggled
+    ) -> None:
+        """Re-poll the catalog so the ⌥ layer's rows arrive (or leave).
+
+        Nothing is written to config. `ctrl+g` cycles the dock density without
+        writing `display.dock` for the same reason: a `write_setting` here
+        would fan out through `ConfigWatcher` to every running `lop` process
+        and flip another terminal's sidebar.
+        """
+        message.stop()
+        self._refresh_sidebar()
 
     # -- composition --------------------------------------------------------
     def get_default_screen(self) -> Screen[None]:
@@ -23012,7 +23135,11 @@ class OperatorApp(App[None]):
         try:
             if message.key == "tui.theme" and message.value:
                 self._apply_theme(str(message.value))
-            elif message.key in ("tui.sidebar_visible", "tui.sidebar_position"):
+            elif message.key in (
+                "tui.sidebar_visible",
+                "tui.sidebar_position",
+                "tui.sidebar_show_subagents",
+            ):
                 self._apply_sidebar_settings()
             elif message.key == "display.comfortable_rows":
                 # Layout, not ink: the padding lives in the stylesheet behind
@@ -32007,6 +32134,12 @@ class OperatorApp(App[None]):
         # user learns what "next" means, and the one-press switch is otherwise
         # undiscoverable (UX round 3, U5).
         lines.append(_key_row("ctrl+shift+↑/↓", "switch to the previous/next conversation"))
+        # Sidebar block, and adjacent to F8/F9 so the function keys stay
+        # together. 63 composed cells against the 74-cell ceiling. The two
+        # sidebar-SCOPED chords (ctrl+a, ctrl+o) get no row here: /help lists
+        # app-wide keys, and a row for a chord that only fires in F9 mode
+        # would be a lie. They live in the footer chip and the docs.
+        lines.append(_key_row("F10", "pin or unpin the session under the pointer"))
         lines.append(_key_row("F8", "open an aside; ctrl+f forks it in"))
         # Directly under `F8`, because it is only meaningful once an aside
         # is open. ONE row for the pair rather than two: the partner chord fits

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -12,16 +12,19 @@ from typing import Any, Literal
 
 from local_operator.session.catalog import (  # noqa: F401 -- compatibility API
     CATALOG_SCAN_LIMIT,
+    SUBAGENT_LAYER_CAP,
     CatalogEntry,
     cached_session_rows,
     decorate_rows,
     load_catalog,
     rank_entries,
     session_directory_name,
+    subagent_population,
 )
 
 DEFAULT_SIDEBAR_VISIBLE = False
 DEFAULT_SIDEBAR_POSITION = "left"
+DEFAULT_SIDEBAR_SHOW_SUBAGENTS = False
 SidebarPosition = Literal["left", "right"]
 
 
@@ -29,6 +32,9 @@ SidebarPosition = Literal["left", "right"]
 class SidebarSettings:
     visible: bool = DEFAULT_SIDEBAR_VISIBLE
     position: SidebarPosition = "left"
+    #: Appended last so positional construction — `SidebarSettings(False,
+    #: "left")`, which `scripts/sidebar_shot.py` uses — keeps working.
+    show_subagents: bool = DEFAULT_SIDEBAR_SHOW_SUBAGENTS
 
     @classmethod
     def from_values(cls, values: Mapping[str, Any]) -> SidebarSettings:
@@ -36,7 +42,13 @@ class SidebarSettings:
         section = section if isinstance(section, Mapping) else {}
         visible = section.get("sidebar_visible", DEFAULT_SIDEBAR_VISIBLE)
         position = section.get("sidebar_position", DEFAULT_SIDEBAR_POSITION)
+        show_subagents = section.get("sidebar_show_subagents", DEFAULT_SIDEBAR_SHOW_SUBAGENTS)
         return cls(
             visible=visible if isinstance(visible, bool) else DEFAULT_SIDEBAR_VISIBLE,
             position="right" if position == "right" else "left",
+            show_subagents=(
+                show_subagents
+                if isinstance(show_subagents, bool)
+                else DEFAULT_SIDEBAR_SHOW_SUBAGENTS
+            ),
         )

--- a/local_operator/tui/sidebar_pins.py
+++ b/local_operator/tui/sidebar_pins.py
@@ -1,0 +1,108 @@
+"""The sidebar's durable pinned-session list.
+
+Kept free of widget imports for the reason :mod:`local_operator.tui.move_targets`
+is: reading and toggling a pin are pure functions over a config root, so they
+are testable — and reusable by a non-Textual frontend — without importing
+Textual to learn which sessions a user pinned.
+
+WHY A FILE AT ALL. Everything else the sidebar ranks by is live state: activity
+mtimes, the runtime registry, the attention store. Quit every session and all of
+it goes empty. A pin is the opposite — a deliberate, durable statement that
+*this* conversation stays at the top until the user says otherwise — so it needs
+the smallest durable thing that survives a restart: a capped JSON array of
+session ids, newest pin first.
+
+A BARE ARRAY, NOT A VERSIONED OBJECT, deliberately. The shape cannot evolve into
+something a reader must interpret, and an unreadable file already degrades to
+"no pins", so a version field would buy a migration path for a format that has
+nowhere to go.
+
+MULTI-PROCESS: LAST WRITER WINS, accepted. Two ``lop`` sessions pinning at the
+same instant means the second write is what the file holds; no precedent in this
+codebase takes a cross-process lock for a small index, and the same-directory
+``os.replace`` means a reader never sees a torn file — only an older one.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PINS_FILE = "sidebar-pins.json"
+#: Against ``move_targets.RECENTS_LIMIT = 20``: a pin is a user's deliberate,
+#: durable selection rather than a trace of where they have been, so a small
+#: multiple of the recents cap is the right order of magnitude.
+PINS_LIMIT = 50
+
+
+def read_pins(config_dir: Path) -> list[str]:
+    """The pinned session ids, newest pin first; ``[]`` when unreadable.
+
+    Best-effort by contract. This file is an enhancement to a list that ranks
+    perfectly well without it, so every failure mode — absent, truncated,
+    holding a JSON object instead of an array, holding non-strings — degrades
+    to "no pinned sessions" rather than costing the user the sidebar.
+
+    PRUNED AT READ against the session store: an id whose directory is gone
+    (cleanup removed it, or the user deleted it) is dropped here rather than
+    rendered as a broken row. Doing it on the read path is what keeps this
+    module free of any coordination with ``session/cleanup.py`` — deletion
+    needs to know nothing about pins.
+    """
+    directory = Path(config_dir)
+    try:
+        raw = json.loads((directory / PINS_FILE).read_text())
+    except FileNotFoundError:
+        return []
+    except (OSError, ValueError):
+        logger.debug("sidebar pins unreadable; continuing without them", exc_info=True)
+        return []
+    if not isinstance(raw, list):
+        return []
+    sessions = directory / "sessions"
+    return [item for item in raw if isinstance(item, str) and item and (sessions / item).is_dir()]
+
+
+def toggle_pin(config_dir: Path, session_id: str) -> bool:
+    """Pin ``session_id`` if it is not pinned, unpin it if it is.
+
+    Returns the NEW state: ``True`` when the session is now pinned, ``False``
+    when the pin was removed. A pin re-applied to an already-pinned session is
+    an unpin, which is what makes one chord both verbs.
+
+    Written to a temporary file in the SAME directory and ``os.replace``d over
+    the target, the discipline every small index here uses (``config.py``,
+    ``move_targets.py``, ``multiplexer/markers.py``): a torn read of this file
+    would silently empty a user's pins, and same-directory replace is the only
+    form that is atomic.
+
+    Never raises. This runs from a keypress the user has already been given
+    feedback for, so a read-only config directory must cost them the pin and
+    not the session.
+    """
+    directory = Path(config_dir)
+    current = read_pins(directory)
+    entries = [item for item in current if item != session_id]
+    # Nothing was removed, so this is a pin rather than an unpin.
+    pinned = len(entries) == len(current)
+    if pinned:
+        entries.insert(0, session_id)
+    del entries[PINS_LIMIT:]
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        handle_fd, temporary = tempfile.mkstemp(dir=directory, prefix=".sidebar-pins-")
+        try:
+            with os.fdopen(handle_fd, "w") as handle:
+                json.dump(entries, handle)
+            os.replace(temporary, directory / PINS_FILE)
+        except BaseException:
+            Path(temporary).unlink(missing_ok=True)
+            raise
+    except OSError:
+        logger.debug("could not record the sidebar pin", exc_info=True)
+    return pinned

--- a/local_operator/tui/sidebar_pins.py
+++ b/local_operator/tui/sidebar_pins.py
@@ -17,6 +17,11 @@ something a reader must interpret, and an unreadable file already degrades to
 "no pins", so a version field would buy a migration path for a format that has
 nowhere to go.
 
+UNPINNING THE LAST PIN LEAVES THE FILE HOLDING ``[]``, deliberately: an empty
+array is this module's resting state and reads back identically to an absent
+file, so there is no second write path to keep correct beside the one atomic
+replace.
+
 MULTI-PROCESS: LAST WRITER WINS, accepted. Two ``lop`` sessions pinning at the
 same instant means the second write is what the file holds; no precedent in this
 codebase takes a cross-process lock for a small index, and the same-directory
@@ -30,6 +35,8 @@ import logging
 import os
 import tempfile
 from pathlib import Path
+
+from local_operator.session.catalog import session_directory_name
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +72,22 @@ def read_pins(config_dir: Path) -> list[str]:
     if not isinstance(raw, list):
         return []
     sessions = directory / "sessions"
-    return [item for item in raw if isinstance(item, str) and item and (sessions / item).is_dir()]
+    return [
+        item
+        for item in raw
+        # A pin is a session id: ONE bare directory name. Checked before the
+        # store-prune below, because the prune joins the id onto `sessions/`
+        # and `Path.__truediv__` does not keep it there — `sessions / "/tmp"`
+        # IS `/tmp`, and `../agents` climbs out of the store. Nothing renders
+        # from a bogus entry today (`load_catalog` hydrates none of them), so
+        # this is defence in depth: the same rule `session_directory_name`
+        # states for discovery metadata, reused rather than re-spelled, so a
+        # file this app wrote cannot redirect a read outside `sessions/`.
+        if isinstance(item, str)
+        and item == Path(item).name
+        and session_directory_name(item)
+        and (sessions / item).is_dir()
+    ]
 
 
 def toggle_pin(config_dir: Path, session_id: str) -> bool:

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -162,6 +162,21 @@ def sidebar_content_width(terminal_width: int) -> int:
 #: the other surfaces read that one and are not paying this cost.
 SIDEBAR_SPINNER_INTERVAL_S = 0.15
 
+
+def _strip_dangling_separator(title: str) -> str:
+    """Drop a ``·`` left stranded at the end of a truncated ``label · role``.
+
+    ``truncate_cells`` cuts on a cell boundary, so a sub row whose role does
+    not fit can land on the separator and render ``label ·…`` — which reads as
+    a rendering fault rather than as an ellipsis. Only the separator is
+    removed; the ellipsis stays, because the title genuinely is cut.
+    """
+    for suffix in ("·…", "· …"):
+        if title.endswith(suffix):
+            return title[: -len(suffix)].rstrip() + "…"
+    return title
+
+
 #: Section key (``_section_of``) to the name its header row carries. One
 #: mapping so `_display_rows` and `render` can never disagree about which
 #: sections exist.
@@ -304,10 +319,42 @@ class SessionSidebar(Widget, can_focus=True):
         if not self.entries:
             return 0
         tiers = {self._section_of(entry) for entry in self.entries}
-        # Per section: its heading and the blank beneath it, plus a blank
-        # above every heading after the first. The outer "Sessions" title is
-        # not counted — it is not drawn at all once any header is (`render`).
-        return len(tiers) * 2 + (len(tiers) - 1)
+        # Per section: its heading and the blank BENEATH it. There is no blank
+        # above a heading any more — that was a doubled separator, and at four
+        # sections it cost three lines of a list that has to fit in a terminal.
+        # Going two sections to four took chrome from 5 lines to 11 and flipped
+        # a 30-row terminal from "everything fits" to paged, which displaced
+        # the `f9 focus` hint for the footer's pager. The heading owns the
+        # space beneath it and its muted treatment is its own separation.
+        # Per section: its heading, the blank beneath it, and a blank above
+        # every heading after the first. The leading blank is load-bearing:
+        # without it a heading sits flush against the previous group's last
+        # ENTRY row (the section does not end in a blank — the blank belongs
+        # under the heading), and the two groups read as one. See the comment
+        # in `_display_rows` and the assertion it is defended by.
+        chrome = len(tiers) * 2 + (len(tiers) - 1)
+        # The `+N more pinned` note (`_display_rows`) is chrome too, and both
+        # sides have to charge it identically or the frame overruns its height.
+        # Sized against a window computed WITHOUT the note: adding the note can
+        # only shrink that window, which can only push more pinned rows out, so
+        # this never claims a note that `_display_rows` then declines to emit.
+        if 0 in tiers:
+            base = max(1, self.size.height - 1 - chrome)
+            window = self.entries[self._offset : self._offset + base]
+            if self._pinned_overflow(window):
+                chrome += 1
+        return chrome
+
+    def _pinned_overflow(self, window: Sequence[CatalogEntry]) -> int:
+        """How many pinned rows exist that ``window`` does not contain.
+
+        Pinned rows are NOT hoisted into the window — that keeps `page_size`,
+        `action_move` and `_entry_at` on one geometry — so at a short height a
+        pinned row can rank below the page. Without this the `★ Pinned` heading
+        silently claims to be the whole pinned set while showing part of it.
+        """
+        shown = {entry.id for entry in window}
+        return sum(1 for entry in self.entries if entry.id in self._pins and entry.id not in shown)
 
     @property
     def visible_entries(self) -> tuple[CatalogEntry, ...]:
@@ -316,20 +363,27 @@ class SessionSidebar(Widget, can_focus=True):
     def _special_mark(self, entry: CatalogEntry) -> tuple[str, str] | None:
         """``(glyph, ink)`` for a row whose mark is NOT its live state, else None.
 
-        Two rows do not own a state glyph. A pinned row draws ``★`` because
-        being pinned is the fact the section it sits in is about, and a
-        subagent row draws ``⌥`` because it carries no live state at all by
-        construction — the hidden population is never polled for one.
+        Only a SUBAGENT row qualifies: it carries no live state at all by
+        construction — the hidden population is never polled for one — so
+        ``⌥`` owning its mark column displaces nothing.
+
+        A pinned row does NOT qualify, and this is the correction the design
+        round forced. ``row_state_mark`` ranks by urgency because a person
+        blocked on a gate is the most important thing a list can say, and the
+        user pins the sessions they care about most: a ``★`` here made exactly
+        those sessions the only ones that could not report being blocked,
+        broken or finished. ``★`` is the DURABLE fact — it does not change
+        while the user looks at it — and the state glyph is the volatile one,
+        so the pin is what moves. It is painted in the cursor-prefix slot
+        (columns 0-1) by ``render`` instead.
 
         One helper, consulted by BOTH ``render`` and ``_advance_spinner``, so
         the full frame and the 150 ms mark-cell patch cannot disagree about who
         owns column 2. They did disagree in the first cut: a pinned BUSY row
         painted ``★`` on a full frame and then had a spinner frame patched over
         it on the very next tick, so the mark flickered between the two at
-        7 Hz.
+        7 Hz. With ``★`` out of that column the pinned row simply spins.
         """
-        if entry.id in self._pins:
-            return "★", "accent"
         if entry.subagent:
             return "⌥", "muted"
         return None
@@ -419,6 +473,21 @@ class SessionSidebar(Widget, can_focus=True):
                 rows.append(("blank", None))
                 section = current
             rows.append(("entry", entry))
+        # An honest heading: say how many pinned rows are not on this page
+        # rather than under-reporting the set. A CHROME row, never an entry —
+        # `entry=None` keeps it out of `self.entries` and makes `_entry_at`
+        # return `None` for it, so it is not a click target.
+        missing = self._pinned_overflow([entry for _kind, entry in rows if entry is not None])
+        if missing:
+            insert_at = next(
+                (
+                    index
+                    for index, (kind, entry) in enumerate(rows)
+                    if entry is not None and self._section_of(entry) != 0
+                ),
+                len(rows),
+            )
+            rows.insert(insert_at, ("note:pinned-overflow", None))
         return tuple(rows)
 
     def set_entries(self, entries: Sequence[CatalogEntry]) -> None:
@@ -432,7 +501,16 @@ class SessionSidebar(Widget, can_focus=True):
         self._catalog_loading = False
         self.error = ""
         if not any(entry.id == self.cursor_id for entry in ordered):
-            self.cursor_id = self.current_id or (ordered[0].id if ordered else "")
+            # `current_id` is adopted only when it is a row in THIS list. The
+            # attached session is not necessarily a catalog row, and adopting
+            # it blind left `cursor_id` naming nothing: `_cursor_index` falls
+            # back to 0 so the caret RENDERS on row 0 while `cursor_id`
+            # disagrees, and `action_select`'s membership guard then swallows
+            # ENTER entirely. Reachable before the ⌥ layer by letting a row age
+            # out of the page; `ctrl+a` turns it into a routine keystroke that
+            # drops up to 40 rows at once.
+            adopted = self.current_id if any(e.id == self.current_id for e in ordered) else ""
+            self.cursor_id = adopted or (ordered[0].id if ordered else "")
         self._offset = min(self._offset, max(0, len(ordered) - self.page_size))
         # Re-resolve against the NEW order at the pointer's unchanged position:
         # a reorder under a resting pointer must relabel the row it is actually
@@ -617,8 +695,11 @@ class SessionSidebar(Widget, can_focus=True):
             if entry is None:
                 continue
             requested = entry.id == self._requested_id and entry.id != self.current_id
-            if self._special_mark(entry) is not None:
-                # Its mark column is not a spinner's to patch (`_special_mark`).
+            if entry.subagent:
+                # A sub row's mark column is `⌥`, not a spinner's to patch
+                # (`_special_mark`). A PINNED row is no longer skipped: its
+                # `★` lives in the cursor-prefix slot, so column 2 is free to
+                # animate and a pinned busy row spins like any other.
                 continue
             if (requested and self._requested_spinning()) or (
                 entry.row.live_state == "busy"
@@ -691,11 +772,23 @@ class SessionSidebar(Widget, can_focus=True):
         self.post_message(self.SubagentLayerToggled(self.show_subagents))
 
     def action_jump_to_subagents(self) -> None:
-        """Move the cursor to the first subagent row, revealing it."""
+        """Move the cursor to the first subagent row, revealing it.
+
+        With the layer hidden this SHOWS it and then jumps, rather than doing
+        nothing: asking to go somewhere is asking to see it, and a chord that
+        no-ops with no feedback is indistinguishable from a chord that is
+        broken. The rows arrive with the app's re-poll, so the jump itself
+        lands on the next frame; this call only moves the cursor if the rows
+        are already here.
+        """
         if not self.show_subagents:
-            return
+            self.show_subagents = True
+            self.refresh()
+            self.post_message(self.SubagentLayerToggled(True))
         target = next((entry for entry in self.entries if entry.subagent), None)
         if target is None:
+            # Genuinely nothing to jump to — either the store holds no subagent
+            # runs, or the re-poll above has not delivered them yet.
             return
         self.cursor_id = target.id
         self._reveal()
@@ -949,6 +1042,16 @@ class SessionSidebar(Widget, can_focus=True):
                     style=theme_mod.semantic_color("muted"),
                 )
                 continue
+            if kind == "note:pinned-overflow":
+                # Keeps the `★ Pinned` heading honest when a pinned row ranks
+                # below the page. Same muted treatment as a heading and no new
+                # palette entry; it is chrome, so it is never a click target.
+                missing = self._pinned_overflow([row for _k, row in rows if row is not None])
+                result.append(
+                    truncate_cells(f"+{missing} more pinned", width).ljust(width),
+                    style=theme_mod.semantic_color("muted"),
+                )
+                continue
             assert entry is not None
             current = entry.id == self.current_id
             cursor = self.has_focus and entry.id == self.cursor_id
@@ -987,13 +1090,24 @@ class SessionSidebar(Widget, can_focus=True):
             # column, so nothing reflows and the ramp is untouched. Requested
             # wins when a row is both, because "this is opening" is the fact
             # the user is waiting on.
-            line.append("» " if requested else "› " if cursor else "  ")
+            # The pin rides in the CURSOR-PREFIX slot, never the mark column:
+            # `row_state_mark` owns column 2 and its urgency ladder must not be
+            # displaced by a durable property (see `_special_mark`). The caret
+            # still wins the slot when a pinned row is also the cursor or the
+            # requested row — the `★ Pinned` header already carries the pinned
+            # fact, while the caret is the only thing that says "here" or
+            # "opening".
+            if requested or cursor:
+                line.append("» " if requested else "› ")
+            elif entry.id in self._pins:
+                line.append("★ ", style=theme_mod.semantic_color("accent"))
+            else:
+                line.append("  ")
             mark, ink = row_state_mark(entry.row, self._frame)
             special = self._special_mark(entry)
             if special is not None:
-                # Pinned and subagent rows own their mark column outright; see
-                # `_special_mark`. Checked FIRST so neither the requested
-                # spinner nor a completion glyph can displace it.
+                # A subagent row has no live state to displace; see
+                # `_special_mark`.
                 mark, ink = special
             elif requested and self._requested_spinning():
                 # Same ink a busy row's spinner uses (``row_state_mark``), so one
@@ -1029,6 +1143,14 @@ class SessionSidebar(Widget, can_focus=True):
             # to `row.name` when it has neither.
             name = entry.sub_title if entry.subagent else entry.row.name
             title = truncate_cells(name or "Untitled conversation", title_width)
+            if entry.subagent:
+                # `sub_title` is "label · role", and the role is the half that
+                # truncation eats first. When the cut lands on the separator
+                # the row ends "label ·…" — a dangling separator reads as a
+                # rendering fault rather than an ellipsis, so drop it. Which
+                # HALF survives truncation is a separate question and belongs
+                # to `sub_title` itself.
+                title = _strip_dangling_separator(title)
             line.append(title)
             line.pad_right(max(0, width - line.cell_len - len(age)))
             line.append(age, style=theme_mod.semantic_color("dim"))
@@ -1049,14 +1171,24 @@ class SessionSidebar(Widget, can_focus=True):
         hint = "esc return" if self.has_focus else "f9 focus · ctrl+b hide"
         if len(self.entries) > self.page_size:
             last = min(len(self.entries), self._offset + self.page_size)
-            hint = f"{self._offset + 1}–{last}/{len(self.entries)} · ctrl+b hide"
+            # The pager displaces `ctrl+b hide`, NOT `f9 focus`. `ctrl+b`
+            # hides a list the user is looking at and can be rediscovered from
+            # `/help`; `f9` is how they reach the list they are already
+            # reading, and it is the chord the two sidebar-scoped gestures
+            # (`ctrl+a`, `ctrl+o`) are reachable behind. Dropping it exactly
+            # when the list grew big enough to page — i.e. when navigating it
+            # matters most — was the wrong thing to lose. Also 3 cells
+            # cheaper, which keeps the worst case (`… · f9 focus · ⌥999+` at
+            # 27 cells) inside the 29-cell floor instead of cropping the
+            # counter. See docs/design/keymap.md and the D3b ruling.
+            hint = f"{self._offset + 1}–{last}/{len(self.entries)} · f9 focus"
         if self._subagent_total > 0:
             # Merged onto the EXISTING footer line, never a second one: a
             # second line would cost a session row at every terminal height,
             # permanently. The `999+` cap is what keeps the width
-            # deterministic — `1–38/152 · ctrl+b hide · ⌥438` is 29 cells
-            # against the 30-cell floor, and an unbounded count would run over
-            # it. `truncate_cells` crops rather than wraps, so the worst case
+            # deterministic — `1–38/152 · f9 focus · ⌥999+` is 27 cells against
+            # the 29-cell content width, and an unbounded count would run over
+            # it. `truncate_cells` crops rather than wraps, so an overflow
             # degrades to a clipped counter, not a broken frame.
             count = "999+" if self._subagent_total > 999 else str(self._subagent_total)
             hint = f"{hint} · ⌥{count}"

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -162,6 +162,11 @@ def sidebar_content_width(terminal_width: int) -> int:
 #: the other surfaces read that one and are not paying this cost.
 SIDEBAR_SPINNER_INTERVAL_S = 0.15
 
+#: Section key (``_section_of``) to the name its header row carries. One
+#: mapping so `_display_rows` and `render` can never disagree about which
+#: sections exist.
+_SECTION_NAMES = {0: "pinned", 1: "active", 2: "previous", 3: "subagent"}
+
 
 class SessionSidebar(Widget, can_focus=True):
     #: Textual re-renders a widget on every pointer move to look for link
@@ -183,6 +188,15 @@ class SessionSidebar(Widget, can_focus=True):
         Binding("end", "edge(True)", show=False),
         Binding("enter", "select", show=False),
         Binding("escape", "leave", show=False),
+        # Sidebar-scoped on purpose. `ctrl+a` and `ctrl+o` are BOTH in
+        # `keymap.COMPOSER_KEYS` (keymap.py:212, :210) — `ctrl+a` is the
+        # composer's line-start and `ctrl+o` expands a collapsed paste. They are
+        # safe HERE because in F9 mode the sidebar owns the focus chain and the
+        # composer is not in it. Promoted to app level, non-priority, they would
+        # silently lose to TextArea and the chord would look broken. NEVER
+        # promote them.
+        Binding("ctrl+a", "toggle_subagents", show=False),
+        Binding("ctrl+o", "jump_to_subagents", show=False),
     ]
 
     class Selected(Message):
@@ -192,6 +206,18 @@ class SessionSidebar(Widget, can_focus=True):
 
     class Dismissed(Message):
         pass
+
+    class SubagentLayerToggled(Message):
+        """``ctrl+a`` flipped the ⌥ layer for this session.
+
+        Carries the new value so the app can re-poll the catalog with the flag.
+        The widget cannot load the catalog itself — that is worker-thread work
+        the app owns.
+        """
+
+        def __init__(self, show_subagents: bool) -> None:
+            super().__init__()
+            self.show_subagents = show_subagents
 
     def __init__(self) -> None:
         super().__init__(id="session-sidebar")
@@ -223,6 +249,16 @@ class SessionSidebar(Widget, can_focus=True):
         #: the description only once Textual's own show delay has elapsed
         #: since then, so it never appears earlier than Textual would show it.
         self._hover_since: float | None = None
+        #: Pinned ids, newest pin first, handed in by the app's poll. Display
+        #: only: pins lift rows into their own SECTION in `_display_rows` and
+        #: never touch `rank_entries`, which is the partition the mobile relay
+        #: shares.
+        self._pins: tuple[str, ...] = ()
+        #: Startup default from `tui.sidebar_show_subagents`; flipped by
+        #: `ctrl+a` for THIS session only, never written back to config.
+        self.show_subagents: bool = False
+        #: Hidden-population size for the footer chip, from `subagent_population`.
+        self._subagent_total: int = 0
         self.display = False
 
     @property
@@ -267,7 +303,7 @@ class SessionSidebar(Widget, can_focus=True):
         """
         if not self.entries:
             return 0
-        tiers = {0 if entry.active else 1 for entry in self.entries}
+        tiers = {self._section_of(entry) for entry in self.entries}
         # Per section: its heading and the blank beneath it, plus a blank
         # above every heading after the first. The outer "Sessions" title is
         # not counted — it is not drawn at all once any header is (`render`).
@@ -276,6 +312,45 @@ class SessionSidebar(Widget, can_focus=True):
     @property
     def visible_entries(self) -> tuple[CatalogEntry, ...]:
         return self.entries[self._offset : self._offset + self.page_size]
+
+    def _special_mark(self, entry: CatalogEntry) -> tuple[str, str] | None:
+        """``(glyph, ink)`` for a row whose mark is NOT its live state, else None.
+
+        Two rows do not own a state glyph. A pinned row draws ``★`` because
+        being pinned is the fact the section it sits in is about, and a
+        subagent row draws ``⌥`` because it carries no live state at all by
+        construction — the hidden population is never polled for one.
+
+        One helper, consulted by BOTH ``render`` and ``_advance_spinner``, so
+        the full frame and the 150 ms mark-cell patch cannot disagree about who
+        owns column 2. They did disagree in the first cut: a pinned BUSY row
+        painted ``★`` on a full frame and then had a spinner frame patched over
+        it on the very next tick, so the mark flickered between the two at
+        7 Hz.
+        """
+        if entry.id in self._pins:
+            return "★", "accent"
+        if entry.subagent:
+            return "⌥", "muted"
+        return None
+
+    def _section_of(self, entry: CatalogEntry) -> int:
+        """0 pinned, 1 active, 2 previous, 3 subagent.
+
+        A THREE-way key over ``active``, not a widening of it:
+        ``CatalogEntry.active`` is ``pending or unseen or live_state``, and the
+        attention store keys on conversation identity so it answers for
+        subagent ids too — 45% of them carry an unseen receipt. Ranking them by
+        ``active`` alone would put agent runs above the user's own work.
+
+        Pinned outranks subagent, which is what makes a pinned subagent row
+        appear in ``★ Pinned`` even while the layer is off.
+        """
+        if entry.id in self._pins:
+            return 0
+        if entry.subagent:
+            return 3
+        return 1 if entry.active else 2
 
     @staticmethod
     def _draws_section_headers(rows: tuple[tuple[str, CatalogEntry | None], ...]) -> bool:
@@ -298,19 +373,35 @@ class SessionSidebar(Widget, can_focus=True):
         presentational is also what makes keyboard traversal cross a boundary
         as an ordinary step, with no stall and no skip.
 
-        The boundary is ``CatalogEntry.active``, i.e. the tier
-        ``session_category`` assigns — 0 pending, 1 unseen-complete, 2 error,
-        3 interrupted, 4 busy and 5 live are active; 6 previous is not — which
-        is the same partition the mobile relay draws, so the two surfaces agree
-        without a new field. Ordering carries one further key than the tier (an
-        armed wake floats within PREVIOUS, where every row is cold), but it never
-        crosses this boundary and never applies above it. An empty section
-        contributes no header.
+        The boundary is ``_section_of``: pinned, then ``CatalogEntry.active``
+        — i.e. the tier ``session_category`` assigns, 0 pending, 1
+        unseen-complete, 2 error, 3 interrupted, 4 busy and 5 live are active;
+        6 previous is not — then the hidden subagent population. The
+        active/previous split is the same partition the mobile relay draws, so
+        the two surfaces agree without a new field; pins and sub rows are
+        DISPLAY-only lifts on top of it and never reach ``rank_entries``.
+        Ordering carries one further key than the tier (an armed wake floats
+        within PREVIOUS, where every row is cold), but it never crosses this
+        boundary and never applies above it. An empty section contributes no
+        header.
         """
         rows: list[tuple[str, CatalogEntry | None]] = []
         section: str | None = None
-        for entry in self.visible_entries:
-            current = "active" if entry.active else "previous"
+        # Sections must be CONTIGUOUS, and a pinned row can come from anywhere
+        # in the ranking. Sort the window's rows by section key alone, stably,
+        # so the catalog's own order survives inside each section.
+        # `self.entries` itself is NOT resorted and `visible_entries` is NOT
+        # widened: `action_move`, `_cursor_index` and `_switch_session_from`
+        # all index `entries` and must keep seeing the ranking's order. A
+        # consequence, accepted: a pinned row ranked below the window is not
+        # visible until the user pages to it — the same as any other row
+        # outside the window, and what keeps `page_size`/`action_move`/
+        # `_entry_at` on one geometry.
+        ordered = sorted(
+            enumerate(self.visible_entries), key=lambda pair: (self._section_of(pair[1]), pair[0])
+        )
+        for _index, entry in ordered:
+            current = _SECTION_NAMES[self._section_of(entry)]
             if current != section:
                 # A blank ABOVE every heading but the first, and one BELOW
                 # every heading. The ask was "an active sessions header and
@@ -355,6 +446,35 @@ class SessionSidebar(Widget, can_focus=True):
         # and Textual's compositor every two seconds in every open terminal.
         if self._paint_state() != self._painted_state:
             self.refresh()
+
+    def set_pins(self, ids: Sequence[str]) -> None:
+        """Replace the pinned-id set. Display-only; see `_display_rows`.
+
+        Refreshes only on an actual change: this runs on every catalog poll,
+        and an unconditional repaint here would re-ink the list every 2 s in
+        every open terminal.
+        """
+        pins = tuple(ids)
+        if pins == self._pins:
+            return
+        self._pins = pins
+        self.refresh()
+
+    def set_subagent_total(self, total: int) -> None:
+        """How many hidden subagent runs the store holds — the footer chip."""
+        if total == self._subagent_total:
+            return
+        self._subagent_total = total
+        self.refresh()
+
+    @property
+    def hovered_id(self) -> str:
+        """The row under the pointer, or "".
+
+        Public because the app's pin chord resolves its target from hover
+        first, and must not reach into `_hover_id`.
+        """
+        return self._hover_id
 
     def show_error(self, message: str) -> None:
         # A refresh error does not erase the last usable catalog.
@@ -443,6 +563,14 @@ class SessionSidebar(Widget, can_focus=True):
             self._catalog_loading,
             self.size,
             tuple(self._age(entry) for entry in self.visible_entries),
+            # Sectioning and the footer chip are paint inputs that do NOT live
+            # in `entries`. Omit them and either the ctrl+a toggle does not
+            # repaint, or `set_entries`' equality check passes on a frame whose
+            # pins changed and the lift is invisible until something else
+            # invalidates.
+            self._pins,
+            self.show_subagents,
+            self._subagent_total,
         )
 
     def refresh(
@@ -489,6 +617,9 @@ class SessionSidebar(Widget, can_focus=True):
             if entry is None:
                 continue
             requested = entry.id == self._requested_id and entry.id != self.current_id
+            if self._special_mark(entry) is not None:
+                # Its mark column is not a spinner's to patch (`_special_mark`).
+                continue
             if (requested and self._requested_spinning()) or (
                 entry.row.live_state == "busy"
                 and not entry.row.pending
@@ -544,6 +675,30 @@ class SessionSidebar(Widget, can_focus=True):
 
     def action_leave(self) -> None:
         self.post_message(self.Dismissed())
+
+    def action_toggle_subagents(self) -> None:
+        """Flip the ⌥ layer for THIS session. Never writes the setting.
+
+        A `write_setting` here would fan out through `ConfigWatcher` to every
+        running `lop` process and flip another terminal's sidebar. The same
+        rule `ctrl+g` follows for dock density.
+        """
+        self.show_subagents = not self.show_subagents
+        self.refresh()
+        # The widget cannot load the catalog itself: `load_catalog` is I/O and
+        # belongs on the app's worker thread. Announce the flip and let the
+        # app re-poll with it.
+        self.post_message(self.SubagentLayerToggled(self.show_subagents))
+
+    def action_jump_to_subagents(self) -> None:
+        """Move the cursor to the first subagent row, revealing it."""
+        if not self.show_subagents:
+            return
+        target = next((entry for entry in self.entries if entry.subagent), None)
+        if target is None:
+            return
+        self.cursor_id = target.id
+        self._reveal()
 
     def _entry_at(self, y: int) -> CatalogEntry | None:
         # Against the DISPLAY rows, not the entries: a header and its blank
@@ -780,7 +935,12 @@ class SessionSidebar(Widget, can_focus=True):
                 result.append(" " * width)
                 continue
             if kind.startswith("header:"):
-                label = "Active Sessions" if kind == "header:active" else "Previous Sessions"
+                label = {
+                    "header:pinned": "★ Pinned",
+                    "header:active": "Active Sessions",
+                    "header:previous": "Previous Sessions",
+                    "header:subagent": "⌥ Subagent Runs",
+                }[kind]
                 # Same treatment as the "Sessions" title above: `muted`, no
                 # rule, no new palette entry. Mirrors the mobile relay's two
                 # headings so the surfaces read the same.
@@ -829,7 +989,13 @@ class SessionSidebar(Widget, can_focus=True):
             # the user is waiting on.
             line.append("» " if requested else "› " if cursor else "  ")
             mark, ink = row_state_mark(entry.row, self._frame)
-            if requested and self._requested_spinning():
+            special = self._special_mark(entry)
+            if special is not None:
+                # Pinned and subagent rows own their mark column outright; see
+                # `_special_mark`. Checked FIRST so neither the requested
+                # spinner nor a completion glyph can displace it.
+                mark, ink = special
+            elif requested and self._requested_spinning():
                 # Same ink a busy row's spinner uses (``row_state_mark``), so one
                 # spinner means one thing everywhere in the list.
                 # Only after the delay: a switch that is taking long enough to
@@ -857,7 +1023,12 @@ class SessionSidebar(Widget, can_focus=True):
             line.append(f"{mark or ' '} ", style=theme_mod.semantic_color(ink))
             age = self._age(entry)
             title_width = max(1, width - 4 - (len(age) + 1 if age else 0))
-            title = truncate_cells(entry.row.name or "Untitled conversation", title_width)
+            # A subagent row is identified by what it was delegated to do
+            # ("label · role"), not by the session name the runtime generated
+            # for it. `sub_title` already degrades to either half alone, and
+            # to `row.name` when it has neither.
+            name = entry.sub_title if entry.subagent else entry.row.name
+            title = truncate_cells(name or "Untitled conversation", title_width)
             line.append(title)
             line.pad_right(max(0, width - line.cell_len - len(age)))
             line.append(age, style=theme_mod.semantic_color("dim"))
@@ -879,6 +1050,16 @@ class SessionSidebar(Widget, can_focus=True):
         if len(self.entries) > self.page_size:
             last = min(len(self.entries), self._offset + self.page_size)
             hint = f"{self._offset + 1}–{last}/{len(self.entries)} · ctrl+b hide"
+        if self._subagent_total > 0:
+            # Merged onto the EXISTING footer line, never a second one: a
+            # second line would cost a session row at every terminal height,
+            # permanently. The `999+` cap is what keeps the width
+            # deterministic — `1–38/152 · ctrl+b hide · ⌥438` is 29 cells
+            # against the 30-cell floor, and an unbounded count would run over
+            # it. `truncate_cells` crops rather than wraps, so the worst case
+            # degrades to a clipped counter, not a broken frame.
+            count = "999+" if self._subagent_total > 999 else str(self._subagent_total)
+            hint = f"{hint} · ⌥{count}"
         footer = "Refresh failed" if self.error else "Opening…" if self.requested_id else hint
         result.append(
             "\n" + truncate_cells(footer, width),

--- a/scripts/sidebar_shot.py
+++ b/scripts/sidebar_shot.py
@@ -117,6 +117,26 @@ UNSEEN_ROWS = [
 ]
 
 
+#: Hidden-population rows for the ⌥ layer. `(id, label, role, age)` — a sub row
+#: is identified by what it was delegated to do, never by the session name its
+#: runtime generated, so these carry no `name` at all. The third has an EMPTY
+#: label so the frame also shows the degraded `role only` form.
+SUBAGENT_ROWS = [
+    ("aaaaaaaaaad1", "section the sidebar", "coder", 4),
+    ("aaaaaaaaaad2", "audit the poll cost", "reviewer", 11),
+    ("aaaaaaaaaad3", "", "scout", 19),
+]
+
+#: Pinned in the capture. One ACTIVE row, to show that a pin LIFTS a row out of
+#: the section it ranked into, and one SUBAGENT row, to show a pinned agent run
+#: staying visible in ★ Pinned while the layer itself is off.
+PINNED_IDS = ("aaaaaaaaaaa3", "aaaaaaaaaad2")
+
+#: What the footer chip reports. Larger than the seeded rows on purpose: the
+#: chip counts the whole hidden population, not the capped slice on screen.
+SUBAGENT_TOTAL = 438
+
+
 def _entries() -> list[CatalogEntry]:
     entries = [
         CatalogEntry(
@@ -139,6 +159,15 @@ def _entries() -> list[CatalogEntry]:
             completion_kind=kind,
         )
         for session_id, name, age, state, kind in UNSEEN_ROWS
+    ]
+    entries += [
+        CatalogEntry(
+            SessionRow(id=session_id, mtime=NOW - age * 60, name=""),
+            subagent=True,
+            label=label,
+            agent=agent,
+        )
+        for session_id, label, agent, age in SUBAGENT_ROWS
     ]
     return entries
 
@@ -170,6 +199,12 @@ async def main() -> None:
         await pilot.press("ctrl+b")
         await pilot.pause()
         sidebar = app._session_sidebar
+        # The ⌥ layer ON, so the capture shows all four sections at once. The
+        # rows are handed in directly (as every other row here is) rather than
+        # loaded, so this never touches the developer's real store.
+        sidebar.show_subagents = True
+        sidebar.set_pins(PINNED_IDS)
+        sidebar.set_subagent_total(SUBAGENT_TOTAL)
         sidebar.set_entries(_entries())
         sidebar.current_id = "aaaaaaaaaaa1"
         sidebar.cursor_id = "aaaaaaaaaaa1"

--- a/tests/unit/session/test_catalog_scan_cost.py
+++ b/tests/unit/session/test_catalog_scan_cost.py
@@ -888,3 +888,333 @@ def test_an_idle_exec_row_says_what_it_is_instead_of_ready(tmp_path) -> None:
     assert idle.status == "Running headless (exec)"
     assert busy.status == "Working"
     assert mine.status == "Ready"
+
+
+class TestTheSubagentLayerIsOptIn:
+    """The sidebar's ⌥ layer: hidden subagent runs, listed without becoming rows.
+
+    Two properties are load-bearing here and both were measured before this
+    layer was written.
+
+    SUB ROWS MUST NOT BE ORDINARY ROWS. ``CatalogEntry.active`` is
+    ``pending or unseen or live_state``, and the attention store keys on
+    conversation identity — which answers for subagent ids too, with 45% of real
+    subagent directories carrying an unseen receipt. A sub row routed through
+    ``decorate_rows`` and the attention comprehension therefore comes out
+    ``active=True`` and sections into Active Sessions, ABOVE the user's own
+    work. There is no filter inside that path that avoids it, so sub rows are
+    built by hand outside ``rows`` and rejoin at the single ``rank_entries``
+    call. ``test_a_sub_row_is_never_active`` is that guard.
+
+    MAINS AND SUBS HYDRATE IN ONE CALL. ``cached_session_rows`` ends
+    ``_ROW_CACHE.clear(); _ROW_CACHE.update(fresh)``, so a second call evicts
+    the first call's rows — a warm 2.0 ms poll becomes 12.2 ms, a 6x regression
+    on the hottest path the sidebar has.
+    ``test_the_hydration_cache_is_not_evicted_by_the_layer`` is that guard.
+
+    And the whole layer is opt-in: with the flag off this function must issue
+    exactly the syscalls it issued before it existed.
+    """
+
+    def test_the_flag_off_is_byte_identical_to_today(self, tmp_path: Path) -> None:
+        """The default path may not pay for a feature it is not using."""
+        for index in range(6):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(20):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+        load_catalog(tmp_path)  # warm every cache
+
+        with _counting() as implicit:
+            bare = [entry.id for entry in load_catalog(tmp_path)]
+        with _counting() as explicit:
+            flagged = [entry.id for entry in load_catalog(tmp_path, include_subagents=False)]
+
+        assert bare == flagged
+        assert explicit.total == implicit.total
+
+    def test_the_layer_appends_hidden_rows_when_it_is_on(self, tmp_path: Path) -> None:
+        for index in range(3):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(5):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        entries = load_catalog(tmp_path, include_subagents=True)
+        assert len(entries) == 8
+        assert sum(1 for entry in entries if entry.subagent) == 5
+        assert {entry.id for entry in entries if not entry.subagent} == {
+            f"user{index:08x}" for index in range(3)
+        }
+
+    def test_the_layer_is_capped(self, tmp_path: Path) -> None:
+        """The layer answers "what just ran", so it is capped rather than paged."""
+        from local_operator.session.catalog import SUBAGENT_LAYER_CAP
+
+        _session(tmp_path, "user00000000", stamp=1000.0)
+        for index in range(SUBAGENT_LAYER_CAP + 10):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        entries = load_catalog(tmp_path, include_subagents=True)
+        assert sum(1 for entry in entries if entry.subagent) == SUBAGENT_LAYER_CAP
+
+    def test_the_layer_is_newest_first(self, tmp_path: Path) -> None:
+        """``rank``'s third key is ``-created_at``, so every sub row must have
+        its creation time STAMPED. A row left at the 0.0 default ties with every
+        other one and falls through to the id tie-break, silently reversing the
+        order the user is promised."""
+        from local_operator.session.catalog import SUBAGENT_LAYER_CAP
+
+        for index in range(SUBAGENT_LAYER_CAP + 5):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        entries = [e for e in load_catalog(tmp_path, include_subagents=True) if e.subagent]
+        stamps = [entry.row.created_at for entry in entries]
+        assert stamps == sorted(stamps, reverse=True)
+        newest = f"sub{SUBAGENT_LAYER_CAP + 4:09x}"
+        assert newest in {entry.id for entry in entries}
+        assert f"sub{0:09x}" not in {entry.id for entry in entries}
+
+    def test_a_sub_row_is_never_active(self, tmp_path: Path) -> None:
+        """THE SECTIONING GUARD. This directory looks like 45% of the real
+        subagent population: it carries an unseen attention receipt. Routed
+        through the ordinary row path it would come out ``active=True`` and sort
+        above the user's own sessions, which is the blocker this layer is shaped
+        around."""
+        import uuid
+
+        from local_operator.session.attention import (
+            AttentionStore,
+            conversation_identity,
+        )
+
+        _session(tmp_path, "user00000000", stamp=1000.0)
+        directory = _session(tmp_path, "sub000000001", origin="subagent", stamp=900.0)
+        store = AttentionStore(tmp_path / "attention.db")
+        # A real token: the store parses it as a UUID.
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "anchor-1", "complete")
+        # The receipt really is unseen, or this test proves nothing.
+        assert store.state(conversation_identity(directory))["unseen"] is True
+
+        entry = next(
+            e for e in load_catalog(tmp_path, include_subagents=True) if e.id == "sub000000001"
+        )
+        assert entry.subagent is True
+        assert entry.active is False
+        assert entry.unseen is False
+        assert entry.completion_kind == ""
+        assert entry.completion_token == ""
+        assert entry.anchor_id == ""
+        assert entry.row.live_state == ""
+        assert entry.row.pending is None
+        assert entry.row.wakes == 0
+
+    def test_a_sub_row_carries_its_role_and_label(self, tmp_path: Path) -> None:
+        directory = tmp_path / "sessions" / "sub000000001"
+        _session(tmp_path, "sub000000001", origin="subagent", stamp=900.0)
+        (directory / "origin.json").write_text(
+            json.dumps({"origin": "subagent", "agent": "reviewer", "label": "round 2"}),
+            encoding="utf-8",
+        )
+
+        entry = next(e for e in load_catalog(tmp_path, include_subagents=True) if e.subagent)
+        assert entry.agent == "reviewer"
+        assert entry.label == "round 2"
+        assert entry.sub_title == "round 2 · reviewer"
+
+    def test_a_sub_row_keeps_its_marker_fields_through_hydration(self, tmp_path: Path) -> None:
+        """The hydration pass rebuilds ``entry.row``; it must not drop the
+        entry's own fields on the way."""
+        from local_operator.resume import write_session_title
+
+        directory = _session(tmp_path, "sub000000001", origin="subagent", stamp=900.0)
+        (directory / "origin.json").write_text(
+            json.dumps({"origin": "subagent", "agent": "qa", "label": "smoke"}),
+            encoding="utf-8",
+        )
+        # Through the real naming path, so the name resolves the way the picker
+        # and the sidebar resolve it rather than through a hand-written sidecar.
+        write_session_title(directory, "a real name", user_set=False, past_names=[])
+
+        entry = next(e for e in load_catalog(tmp_path, include_subagents=True) if e.subagent)
+        # A name proves it went through `cached_session_rows` rather than
+        # keeping the empty placeholder its hand-built row started with.
+        assert entry.row.name == "a real name"
+        assert entry.subagent is True
+        assert entry.agent == "qa"
+        assert entry.label == "smoke"
+
+    def test_a_corrupt_origin_marker_degrades_to_the_session_name(self, tmp_path: Path) -> None:
+        """A marker is best-effort: it may cost the row its role and label,
+        never the row."""
+        broken = _session(tmp_path, "sub000000001", origin="subagent", stamp=900.0)
+        (broken / "origin.json").write_text("{not json", encoding="utf-8")
+        empty = _session(tmp_path, "sub000000002", origin="subagent", stamp=800.0)
+        (empty / "origin.json").write_text("{}", encoding="utf-8")
+
+        entries = {entry.id: entry for entry in load_catalog(tmp_path, include_subagents=True)}
+        assert {"sub000000001", "sub000000002"} <= set(entries)
+        for session_id in ("sub000000001", "sub000000002"):
+            entry = entries[session_id]
+            assert entry.agent == ""
+            assert entry.label == ""
+            assert entry.sub_title == entry.row.name
+
+    def test_a_pinned_hidden_id_is_hydrated_with_the_layer_off(self, tmp_path: Path) -> None:
+        """A pin outranks the layer switch: pinning a subagent run and then
+        turning the layer off must not make the pin render as nothing."""
+        _session(tmp_path, "user00000000", stamp=1000.0)
+        for index in range(3):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        entries = load_catalog(tmp_path, pinned_hidden_ids=["sub000000001"])
+        by_id = {entry.id: entry for entry in entries}
+        assert by_id["sub000000001"].subagent is True
+        assert "sub000000000" not in by_id
+        assert "sub000000002" not in by_id
+
+    def test_a_pinned_hidden_id_beyond_the_cap_is_still_hydrated(self, tmp_path: Path) -> None:
+        """Pins are exempt from the cap, or a pin to an old run would resolve to
+        nothing the moment 40 newer runs existed."""
+        from local_operator.session.catalog import SUBAGENT_LAYER_CAP
+
+        for index in range(SUBAGENT_LAYER_CAP + 5):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+        oldest = f"sub{0:09x}"
+
+        entries = load_catalog(tmp_path, include_subagents=True, pinned_hidden_ids=[oldest])
+        subs = [entry for entry in entries if entry.subagent]
+        assert oldest in {entry.id for entry in subs}
+        assert len(subs) == SUBAGENT_LAYER_CAP + 1
+
+    def test_a_pinned_id_that_is_not_hidden_costs_nothing(self, tmp_path: Path) -> None:
+        """A visible session is already in the listing; pinning it must not add
+        a second copy through the hidden path."""
+        for index in range(3):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        load_catalog(tmp_path)
+
+        plain = [entry.id for entry in load_catalog(tmp_path)]
+        pinned = [entry.id for entry in load_catalog(tmp_path, pinned_hidden_ids=["user00000001"])]
+        assert pinned == plain
+        assert len(pinned) == len(set(pinned))
+
+    def test_the_hydration_cache_is_not_evicted_by_the_layer(self, tmp_path: Path) -> None:
+        """THE CACHE GUARD. ``cached_session_rows`` ends with
+        ``_ROW_CACHE.clear(); _ROW_CACHE.update(fresh)``, so hydrating mains and
+        subs in TWO calls leaves only the second call's rows cached and the
+        next poll rebuilds the rest from disk — measured 2.0 ms warm against
+        12.2 ms cache-wiped. Both populations must go through ONE call with a
+        concatenated candidate list.
+
+        Every fixture directory here carries a transcript deliberately, not
+        decoratively: ``_ROW_CACHE`` is written only when ``_row_stat_key``
+        succeeds, and the layer itself drops a hidden name whose transcript stat
+        raises. Bare directories would produce a cache of 10 and zero sub rows —
+        a fixture failure wearing the costume of the bug this guards. The sub
+        count is asserted alongside so the two are distinguishable at a glance.
+        """
+        from local_operator.session.catalog import _ROW_CACHE
+
+        for index in range(10):
+            _session(tmp_path, f"user{index:08x}", transcript="{}\n", stamp=1000.0 + index)
+        for index in range(10):
+            _session(
+                tmp_path,
+                f"sub{index:09x}",
+                transcript="{}\n",
+                origin="subagent",
+                stamp=500.0 + index,
+            )
+
+        entries = load_catalog(tmp_path, include_subagents=True)
+        assert sum(1 for entry in entries if entry.subagent) == 10, "fixture: no sub rows built"
+        assert len(_ROW_CACHE) == 20, "a second cached_session_rows call evicted the first's rows"
+
+        # And the warm poll agrees with the cold one.
+        assert [entry.id for entry in load_catalog(tmp_path, include_subagents=True)] == [
+            entry.id for entry in entries
+        ]
+
+    def test_the_layer_competes_for_the_page_on_a_full_store(self, tmp_path: Path) -> None:
+        """A KNOWN, ACCEPTED trade-off, pinned so the next reader can tell it was
+        decided rather than missed.
+
+        ``[:limit]`` applies to the COMBINED list, so a store with more than
+        ~160 visible sessions cannot fit both populations in
+        ``CATALOG_SCAN_LIMIT``. Sub rows do not lose that race: their
+        ``session_category`` inputs are all falsy by construction, so they share
+        a tier with a cold visible row and the tie-break is ``-created_at``,
+        where recent subagent runs win. What gets pushed past the slice is
+        therefore the user's OLDEST COLD sessions — never an active row, which
+        ranks above the whole contest.
+
+        Raising the limit would restore the per-poll row-building cost
+        ``CATALOG_SCAN_LIMIT``'s comment exists to document removing, so the
+        trade is taken deliberately: the layer is opt-in, the rows at stake are
+        past rank 160, and ``/resume`` — the surface for finding an old session
+        — does not go through ``load_catalog`` at all.
+        """
+        from local_operator.session.catalog import (
+            CATALOG_SCAN_LIMIT,
+            SUBAGENT_LAYER_CAP,
+        )
+
+        # Just under the cap, so the store fits ENTIRELY with the layer off and
+        # the rows that vanish can only be the ones the layer displaced.
+        visible = CATALOG_SCAN_LIMIT - 10
+        # Visible sessions carry the OLDER creation stamps; `created_at` is
+        # written explicitly rather than left to the filesystem birthtime, which
+        # macOS has and Linux does not — on CI every row would otherwise tie at
+        # 0.0 and rank by session id, testing the tie-break instead of the order.
+        for index in range(visible):
+            directory = _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+            (directory / "created_at.json").write_text(str(1000.0 + index), encoding="utf-8")
+        oldest_visible = "user00000000"
+        for index in range(SUBAGENT_LAYER_CAP):
+            directory = _session(
+                tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index
+            )
+            # Subagent runs are RECENT, which is what wins them the tie-break.
+            (directory / "created_at.json").write_text(str(9000.0 + index), encoding="utf-8")
+
+        # With the layer off the whole store fits and nothing is displaced.
+        assert oldest_visible in {entry.id for entry in load_catalog(tmp_path)}
+
+        entries = load_catalog(tmp_path, include_subagents=True)
+        assert len(entries) == CATALOG_SCAN_LIMIT
+        subs = [entry for entry in entries if entry.subagent]
+        assert len(subs) == SUBAGENT_LAYER_CAP, "sub rows must not be what falls off the end"
+        assert len(entries) - len(subs) == CATALOG_SCAN_LIMIT - SUBAGENT_LAYER_CAP
+        # The user's oldest sessions are precisely what the layer displaced.
+        surviving = {entry.id for entry in entries}
+        assert oldest_visible not in surviving
+        displaced = visible + SUBAGENT_LAYER_CAP - CATALOG_SCAN_LIMIT
+        for index in range(displaced):
+            assert f"user{index:08x}" not in surviving
+        assert f"user{displaced:08x}" in surviving
+
+    def test_subagent_population_counts_the_hidden_store(self, tmp_path: Path) -> None:
+        from local_operator.session.catalog import subagent_population
+
+        for index in range(4):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(7):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        assert subagent_population(tmp_path) == 7
+
+    def test_the_layer_does_not_reach_the_deletion_authority(self, tmp_path: Path) -> None:
+        """THE STRUCTURAL GUARANTEE. ``session.cleanup`` DELETES, and it decides
+        what to protect from ``recent_sessions(..., revalidate=True)`` rather
+        than from ``load_catalog``. It takes no layer flag and cannot be given
+        one, so sub rows are structurally unable to reach it — asserted here so
+        a future refactor that routes cleanup through the catalog fails loudly
+        instead of quietly counting subagent runs against the user's guard.
+        """
+        from local_operator.session.cleanup import _picker_rows
+
+        for index in range(2):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(5):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0 + index)
+
+        assert set(_picker_rows(tmp_path)) == {"user00000000", "user00000001"}

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -164,6 +164,24 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "<path>.unlink",
         "Removes only its own named temporary file after a failed atomic replacement",
     ),
+    # The sidebar's pin store, the same shape and the same argument as
+    # `remember_recent` above: both paths are the config ROOT joined with a
+    # fixed basename (`sidebar-pins.json`, or a `.sidebar-pins-` temp minted by
+    # `mkstemp` in that same directory), so neither is derived from a session id
+    # and neither can resolve under sessions/. The value written is a list of
+    # session-id STRINGS, never a path this module opens or removes — pruning a
+    # stale pin drops the id from that list and touches no directory.
+    (
+        "local_operator/tui/sidebar_pins.py::toggle_pin",
+        "os.replace",
+        "Atomic replacement of the single sidebar-pins.json file in the config dir, "
+        "never a directory and never under sessions/",
+    ),
+    (
+        "local_operator/tui/sidebar_pins.py::toggle_pin",
+        "<path>.unlink",
+        "Removes only its own named temporary file after a failed atomic replacement",
+    ),
     # -- the one legitimate remover -----------------------------------------
     (
         "local_operator/session/cleanup.py::remove_session_dir",

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -65,6 +65,7 @@ def _consumer_defaults() -> dict[str, object]:
     from local_operator.tools.builtin import BASH_SHELL_DEFAULT
     from local_operator.tui.session_catalog import (
         DEFAULT_SIDEBAR_POSITION,
+        DEFAULT_SIDEBAR_SHOW_SUBAGENTS,
         DEFAULT_SIDEBAR_VISIBLE,
     )
     from local_operator.tui.theme import DEFAULT_THEME
@@ -84,6 +85,7 @@ def _consumer_defaults() -> dict[str, object]:
         "display.time_format": DEFAULT_TIME_FORMAT,
         "tui.sidebar_visible": DEFAULT_SIDEBAR_VISIBLE,
         "tui.sidebar_position": DEFAULT_SIDEBAR_POSITION,
+        "tui.sidebar_show_subagents": DEFAULT_SIDEBAR_SHOW_SUBAGENTS,
         "retry.enabled": retry.enabled,
         "retry.maxRetries": retry.max_retries,
         "retry.baseDelayMs": retry.base_delay_ms,

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -12742,3 +12742,55 @@ async def test_a_settings_write_does_not_stomp_a_session_toggle(tmp_path, monkey
         app.on_settings_changed(SettingsChanged("tui.sidebar_position", "left"))
         await pilot.pause()
         assert sidebar.show_subagents is True, "an unrelated write stomped the session toggle"
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_shows_the_layer_when_it_is_hidden() -> None:
+    """D6: asking to go somewhere is asking to see it.
+
+    `ctrl+o` used to return silently with the layer off, which is
+    indistinguishable from a broken chord. It now turns the layer on, announces
+    it so the app re-polls, and lands the cursor on the first subagent row.
+    """
+    import time as _time
+
+    from local_operator.resume import SessionRow
+    from local_operator.session.catalog import CatalogEntry
+
+    now = _time.time()
+    rows = [
+        CatalogEntry(SessionRow("mine", now, "Mine", live_state="busy")),
+        CatalogEntry(
+            SessionRow("run1", now - 10, "untitled"), subagent=True, label="audit", agent="reviewer"
+        ),
+    ]
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = await _open_quiesced_sidebar(pilot, app, rows)
+        sidebar.show_subagents = False
+        sidebar.cursor_id = "mine"
+        sidebar.focus()
+        for _ in range(20):
+            await pilot.pause()
+            if sidebar.has_focus:
+                break
+
+        # The toggle asks the APP to re-poll, and against this tmp config the
+        # real catalog is empty — it would replace the fixture rows mid-test.
+        # The re-poll is covered by its own test; what this one is about is the
+        # chord revealing the layer and moving the cursor.
+        repolled: list[str] = []
+
+        def note_refresh():
+            repolled.append("refresh")
+
+        app._refresh_sidebar = note_refresh  # type: ignore[method-assign]
+
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert sidebar.show_subagents is True, "ctrl+o did not reveal the hidden layer"
+        assert repolled, "revealing the layer must ask the app to re-poll the catalog"
+        assert sidebar.cursor_id == "run1", "the cursor did not land on the first subagent row"

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -11569,6 +11569,7 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
             "ctrl+t",
             "ctrl+g",
             "ctrl+b",
+            "F10",
             "ctrl+pageup",
             "ctrl+r",
             "esc",
@@ -11600,6 +11601,7 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
             "ctrl+t",
             "ctrl+g",
             "ctrl+b",
+            "F10",
             "ctrl+pageup",
             "ctrl+r",
             "esc",
@@ -12438,3 +12440,305 @@ async def test_the_follower_band_agrees_with_the_owner_band_on_auth_required() -
         # The projection's own placeholder still counts when no manager exists.
         assert band_for(("github", "failed")).failed is True
         assert band_for(("github", "connected")).failed is False
+
+
+# -- f10 pins, the ⌥ layer and the sidebar's settings seam --------------------
+
+
+def _pin_entries(ids=("alpha", "beta", "gamma")):
+    """Plain catalog rows, ranked ACTIVE so they land in one section."""
+    import time as _time
+
+    from local_operator.resume import SessionRow
+    from local_operator.session.catalog import CatalogEntry
+
+    now = _time.time()
+    return [
+        CatalogEntry(SessionRow(sid, now - 60 * (i + 1), f"Session {sid}", live_state="busy"))
+        for i, sid in enumerate(ids)
+    ]
+
+
+def _seed_session_dirs(config_dir, ids=("alpha", "beta", "gamma")) -> None:
+    """Give each row a real ``sessions/<id>`` directory.
+
+    ``read_pins`` PRUNES against the session store — an id whose directory is
+    gone is dropped rather than rendered as a broken row, which is how a pin to
+    a deleted session disappears without `session/cleanup.py` knowing pins
+    exist. A fixture that skips this gets its pins pruned on the way back out
+    and the round trip silently reads empty.
+    """
+    for sid in ids:
+        (config_dir / "sessions" / sid).mkdir(parents=True, exist_ok=True)
+
+
+async def _open_quiesced_sidebar(pilot, app, entries=None):
+    """Open the list with the real catalog polls stopped, holding OUR rows."""
+    sidebar = app._session_sidebar
+    app._set_sidebar_open(True)
+    await pilot.pause()
+    if app._sidebar_timer is not None:
+        app._sidebar_timer.pause()
+    app._sidebar_refresh_generation += 1
+    sidebar.set_entries(entries if entries is not None else _pin_entries())
+    await pilot.pause()
+    return sidebar
+
+
+@pytest.mark.asyncio
+async def test_f10_pins_the_hovered_row(tmp_path, monkeypatch) -> None:
+    """Hover WINS over the cursor: the pointer resting on a row is an
+    unambiguous statement of which session is meant."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _seed_session_dirs(tmp_path)
+    from local_operator.tui.sidebar_pins import read_pins
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = await _open_quiesced_sidebar(pilot, app)
+        sidebar.focus()
+        await pilot.pause()
+        sidebar.cursor_id = "alpha"
+        sidebar._hover_id = "gamma"
+        assert sidebar.hovered_id == "gamma"
+
+        await pilot.press("f10")
+        for _ in range(40):
+            await pilot.pause()
+            if read_pins(tmp_path):
+                break
+        assert read_pins(tmp_path) == ["gamma"], "hover must outrank the cursor"
+        assert sidebar._pins == ("gamma",), "the widget was not handed the new pins"
+
+
+@pytest.mark.asyncio
+async def test_f10_falls_back_to_the_cursor_when_focused(tmp_path, monkeypatch) -> None:
+    """No pointer on the list: the focused cursor is the target."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _seed_session_dirs(tmp_path)
+    from local_operator.tui.sidebar_pins import read_pins
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = await _open_quiesced_sidebar(pilot, app)
+        sidebar.focus()
+        for _ in range(20):
+            await pilot.pause()
+            if sidebar.has_focus:
+                break
+        sidebar._hover_id = ""
+        sidebar.cursor_id = "beta"
+
+        await pilot.press("f10")
+        for _ in range(40):
+            await pilot.pause()
+            if read_pins(tmp_path):
+                break
+        assert read_pins(tmp_path) == ["beta"]
+
+
+@pytest.mark.asyncio
+async def test_f10_is_a_no_op_with_the_sidebar_closed(tmp_path, monkeypatch) -> None:
+    """Closed, the chord does nothing AND steals nothing.
+
+    The reason it bubbles rather than sitting at `priority`: with no list on
+    screen there is no row to pin, and the composer must keep the keystroke's
+    effect on its own draft (which is none).
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    from local_operator.tui.sidebar_pins import PINS_FILE, read_pins
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        editor.load_text("still typing")
+        await pilot.pause()
+        caret_before = editor.cursor_location
+        assert not app._session_sidebar.display
+
+        await pilot.press("f10")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert editor.text == "still typing"
+        assert editor.cursor_location == caret_before
+        assert app.screen.focused is editor
+        assert read_pins(tmp_path) == []
+        assert not (tmp_path / PINS_FILE).exists(), "a closed list wrote a pin file"
+
+
+@pytest.mark.asyncio
+async def test_f10_does_not_fire_through_a_pushed_modal(tmp_path, monkeypatch) -> None:
+    """A pushed picker owns the keyboard, the `action_switch_session`
+    precedent. Pinning underneath the very list the user is choosing from
+    would be a change they cannot see."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _seed_session_dirs(tmp_path)
+    import time as _time
+
+    from local_operator.resume import SessionRow
+    from local_operator.tui.sidebar_pins import read_pins
+    from local_operator.tui.widgets.session_picker import SessionPickerScreen
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = await _open_quiesced_sidebar(pilot, app)
+        sidebar.focus()
+        await pilot.pause()
+        sidebar.cursor_id = "alpha"
+
+        # Pushed directly rather than through `/resume`: the command reads the
+        # real store, and this tmp config has no sessions to offer, so the
+        # command is a no-op here. What this test is about is the GUARD — a
+        # pushed screen owning the keyboard — not how it came to be pushed.
+        app.push_screen(
+            SessionPickerScreen([SessionRow("alpha", _time.time(), "Session alpha")], _time.time())
+        )
+        for _ in range(40):
+            await pilot.pause()
+            if isinstance(app.screen, SessionPickerScreen):
+                break
+        assert isinstance(app.screen, SessionPickerScreen)
+
+        await pilot.press("f10")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert read_pins(tmp_path) == [], "f10 fired through a pushed modal"
+        assert isinstance(app.screen, SessionPickerScreen), "the picker lost the keyboard"
+
+
+@pytest.mark.asyncio
+async def test_f10_unpins_a_pinned_row(tmp_path, monkeypatch) -> None:
+    """The chord is a TOGGLE; a second press takes the row back out."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _seed_session_dirs(tmp_path)
+    from local_operator.tui.sidebar_pins import read_pins
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = await _open_quiesced_sidebar(pilot, app)
+        sidebar.focus()
+        await pilot.pause()
+        sidebar._hover_id = "beta"
+
+        await pilot.press("f10")
+        for _ in range(40):
+            await pilot.pause()
+            if read_pins(tmp_path):
+                break
+        assert read_pins(tmp_path) == ["beta"]
+
+        await pilot.press("f10")
+        for _ in range(40):
+            await pilot.pause()
+            if not read_pins(tmp_path):
+                break
+        assert read_pins(tmp_path) == []
+        assert sidebar._pins == ()
+
+
+@pytest.mark.asyncio
+async def test_ctrl_shift_down_traverses_subagent_rows_when_the_layer_is_on() -> None:
+    """The one behaviour change worth stating loudly.
+
+    `ctrl+shift+↑/↓` walks `self.entries`, whose documented contract is "the
+    list's own ranking, so what the user sees is what they traverse". With the
+    layer ON, subagent rows are in that list and therefore in the traversal.
+    """
+    import time as _time
+
+    from local_operator.resume import SessionRow
+    from local_operator.session.catalog import CatalogEntry
+
+    now = _time.time()
+    with_layer = [
+        CatalogEntry(SessionRow("mine", now, "Mine", live_state="busy")),
+        CatalogEntry(
+            SessionRow("run1", now - 10, "untitled"), subagent=True, label="audit", agent="reviewer"
+        ),
+    ]
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = await _open_quiesced_sidebar(pilot, app, with_layer)
+        sidebar.show_subagents = True
+        await pilot.pause()
+        assert any(entry.subagent for entry in sidebar.entries)
+        switched: list[str] = []
+
+        def record(entries, delta):
+            switched.append(entries[delta % len(entries)].id)
+
+        app._switch_session_from = record  # type: ignore[method-assign]
+        app._session_sidebar.current_id = "mine"
+        app.action_switch_session(1)
+        await pilot.pause()
+        assert switched, "the traversal never ran"
+
+        # Layer OFF: the catalog simply does not carry those rows, so the
+        # traversal cannot reach one.
+        sidebar.show_subagents = False
+        sidebar.set_entries([entry for entry in with_layer if not entry.subagent])
+        await pilot.pause()
+        assert not any(entry.subagent for entry in sidebar.entries)
+
+
+@pytest.mark.asyncio
+async def test_a_settings_change_applies_to_a_painted_sidebar(tmp_path, monkeypatch) -> None:
+    """`/settings` must reach a sidebar that is already on screen."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    from local_operator.tui.widgets.settings_view import SettingsChanged
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = await _open_quiesced_sidebar(pilot, app)
+        assert sidebar.show_subagents is False
+
+        with patch("local_operator.tui.session_catalog.SidebarSettings.from_values") as from_values:
+            from local_operator.tui.session_catalog import SidebarSettings
+
+            from_values.return_value = SidebarSettings(
+                visible=True, position="left", show_subagents=True
+            )
+            app.on_settings_changed(SettingsChanged("tui.sidebar_show_subagents", True))
+            await pilot.pause()
+
+        assert sidebar.show_subagents is True, "a live sidebar ignored the setting"
+
+
+@pytest.mark.asyncio
+async def test_a_settings_write_does_not_stomp_a_session_toggle(tmp_path, monkeypatch) -> None:
+    """`ctrl+a` is a THIS-SESSION flip. An unrelated `/settings` write must not
+    silently revert it — the stored value has not moved, so nothing reapplies."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    from local_operator.tui.widgets.settings_view import SettingsChanged
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = await _open_quiesced_sidebar(pilot, app)
+        sidebar.focus()
+        for _ in range(20):
+            await pilot.pause()
+            if sidebar.has_focus:
+                break
+        await pilot.press("ctrl+a")
+        await pilot.pause()
+        assert sidebar.show_subagents is True, "ctrl+a did not flip the layer"
+
+        # An UNRELATED key, whose branch still calls `_apply_sidebar_settings`.
+        app.on_settings_changed(SettingsChanged("tui.sidebar_position", "left"))
+        await pilot.pause()
+        assert sidebar.show_subagents is True, "an unrelated write stomped the session toggle"

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -2850,17 +2850,21 @@ async def test_ctrl_o_jumps_to_the_first_subagent_row():
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         entries = [_plain("a1", active=True), _plain("p1"), _sub("s1", label="one", agent="qa")]
-        sidebar = await _sidebar_with(pilot, app, entries, show_subagents=False)
+        sidebar = await _sidebar_with(pilot, app, entries, show_subagents=True)
         await _focus_settled(pilot, sidebar)
         sidebar.cursor_id = "a1"
         await pilot.press("ctrl+o")
         await pilot.pause()
-        assert sidebar.cursor_id == "a1", "the layer is off; there is nothing to reveal"
+        assert sidebar.cursor_id == "s1"
 
-        sidebar.show_subagents = True
+        # With no subagent row to reach, the chord is a genuine no-op — the
+        # layer state is not a reason to refuse, but an empty layer is.
+        plain_only = [entry for entry in entries if not entry.subagent]
+        sidebar.set_entries(plain_only)
+        sidebar.cursor_id = "a1"
         await pilot.press("ctrl+o")
         await pilot.pause()
-        assert sidebar.cursor_id == "s1"
+        assert sidebar.cursor_id == "a1", "there is no subagent row to jump to"
 
 
 @pytest.mark.asyncio
@@ -2877,14 +2881,17 @@ async def test_a_click_lands_on_the_row_it_looks_like(height):
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, height)) as pilot:
         await pilot.pause()
+        # Enough rows that a pinned one falls outside the window at the short
+        # heights, so the `+N more pinned` chrome row is in the frame under
+        # test too — it must hit-test to None like any other chrome.
         entries = (
             [_plain(f"pin{i}", active=True) for i in range(2)]
             + [_plain(f"a{i}", active=True) for i in range(3)]
-            + [_plain(f"p{i}") for i in range(3)]
+            + [_plain(f"p{i}") for i in range(12)]
             + [_sub(f"s{i}", label=f"run {i}", agent="coder") for i in range(3)]
         )
         sidebar = await _sidebar_with(
-            pilot, app, entries, pins=("pin0", "pin1"), show_subagents=True, total=40
+            pilot, app, entries, pins=("pin0", "pin1", "p11"), show_subagents=True, total=40
         )
         lines = sidebar.render().plain.splitlines()
         rows = sidebar._display_rows()
@@ -2902,3 +2909,200 @@ async def test_a_click_lands_on_the_row_it_looks_like(height):
             assert name.split(" · ")[0] in lines[y], f"y={y} does not paint {entry.id!r}"
             painted += 1
         assert painted, "no entry rows were drawn"
+        overflow = [y for y, (kind, _e) in enumerate(rows, title) if kind == "note:pinned-overflow"]
+        for y in overflow:
+            assert sidebar._entry_at(y) is None, f"+N more pinned at y={y} is a click target"
+
+
+# -- amendment round 1: column ownership, honest chrome, cursor safety --------
+
+
+@pytest.mark.asyncio
+async def test_a_pinned_row_keeps_its_urgency_glyph():
+    """D1: pinning must not hide "this needs you".
+
+    `row_state_mark` ranks by URGENCY — needs-you outranks everything, because
+    a person is blocked. The user pins the sessions they care about most, so a
+    pin that ate the state glyph made exactly those sessions the only ones that
+    could not say they were blocked, broken or finished.
+
+    `★` is the DURABLE fact (it does not change while the user looks at it) and
+    the state glyph is the volatile, time-critical one, so `★` is the one that
+    moves: it takes the cursor-prefix slot at columns 0-1 and leaves column 2
+    to the urgency ladder.
+    """
+    from local_operator.tui.widgets.session_picker import row_state_mark
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        now = time.time()
+        entry = CatalogEntry(SessionRow("needsyou", now, "Needs you", pending="approval"))
+        sidebar = await _sidebar_with(pilot, app, [entry], pins=("needsyou",))
+        row = next(line for line in sidebar.render().plain.splitlines() if "Needs you" in line)
+        expected, _ink = row_state_mark(entry.row, sidebar._frame)
+        assert expected == "!", "fixture must be a needs-you row"
+        assert row[2] == "!", f"column 2 lost the urgency glyph: {row!r}"
+        assert row[0] == "★", f"column 0 is not the pin slot: {row!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_pinned_busy_row_still_spins():
+    """D1's other half: the flicker fix must not cost the spinner.
+
+    The first cut skipped pinned rows in `_advance_spinner` because `★` lived
+    in the cell the tick patches. With `★` at columns 0-1 that conflict is
+    gone, so a pinned busy row animates like any other — and the pin mark is
+    left alone by a tick that only ever touches column 2.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        now = time.time()
+        entry = CatalogEntry(SessionRow("busy", now, "Working", live_state="busy"))
+        sidebar = await _sidebar_with(pilot, app, [entry], pins=("busy",))
+        seen = set()
+        for _ in range(2):
+            sidebar._advance_spinner()
+            await pilot.pause()
+            row = next(line for line in sidebar.render().plain.splitlines() if "Working" in line)
+            seen.add(row[2])
+            assert row[0] == "★", f"the tick disturbed the pin slot: {row!r}"
+        assert len(seen) == 2, f"column 2 did not animate across two ticks: {seen}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("height", [30, 40])
+async def test_the_pinned_header_never_overclaims(height):
+    """D2: a `★ Pinned` heading over rows that are not all there is.
+
+    Pinned rows are NOT hoisted into the window — that stays deferred — so at a
+    short height a pinned row can rank below the page. The heading then claims
+    to be the pinned set while showing part of it. One honest chrome row says
+    how many are missing rather than silently under-reporting.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, height)) as pilot:
+        await pilot.pause()
+        entries = (
+            [_plain(f"a{i}", active=True) for i in range(6)]
+            + [_plain(f"p{i}") for i in range(12)]
+            + [_sub(f"s{i}", label=f"run {i}", agent="coder") for i in range(3)]
+        )
+        sidebar = await _sidebar_with(
+            pilot, app, entries, pins=("a3", "s2"), show_subagents=True, total=40
+        )
+        rows = sidebar._display_rows()
+        rendered = {entry.id for _kind, entry in rows if entry is not None}
+        missing = [pid for pid in sidebar._pins if pid not in rendered]
+        lines = sidebar.render().plain.splitlines()
+        note = [line for line in lines if "more pinned" in line]
+        if missing:
+            assert note, f"{len(missing)} pinned row(s) off-window and no note: {missing}"
+            assert f"+{len(missing)} more pinned" in note[0], note[0]
+        else:
+            assert not note, f"nothing is missing but the note rendered: {note}"
+        assert len(lines) <= sidebar.size.height
+        assert all(cell_len(line) <= sidebar.size.width for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_a_cursor_never_dangles_after_a_layer_drop():
+    """QA D3: `set_entries` adopted `current_id` without checking membership.
+
+    Pre-existing, but `ctrl+a` turns it from "a row aged out of the page" into
+    a routine keystroke that drops up to 40 rows at once. A dangling cursor
+    renders on row 0 while `cursor_id` says otherwise, and ENTER is swallowed
+    by `action_select`'s membership guard — the keystroke does nothing at all.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sub = _sub("s1", label="one", agent="scout")
+        withlayer = [_plain("a1", active=True), sub]
+        sidebar = await _sidebar_with(pilot, app, withlayer, show_subagents=True)
+        # The attached session is NOT itself a catalog row — the shape that
+        # makes the old fallback produce a dangling id.
+        sidebar.current_id = "sess-not-in-list"
+        sidebar.cursor_id = "s1"
+
+        sidebar.set_entries([entry for entry in withlayer if not entry.subagent])
+        await pilot.pause()
+        assert sidebar.cursor_id in {
+            entry.id for entry in sidebar.entries
+        }, f"cursor {sidebar.cursor_id!r} is not a row in the list"
+
+        # ENTER's own precondition, asserted directly: `action_select` refuses
+        # unless `cursor_id` names a row it can find, so a cursor that passes
+        # this is a cursor ENTER will act on. Checked rather than driving the
+        # real handler, which attaches a session and is not what this test is
+        # about.
+        assert sidebar.cursor_id and any(
+            entry.id == sidebar.cursor_id for entry in sidebar.entries
+        ), "action_select's membership guard would swallow ENTER"
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_sub_row_never_ends_on_a_separator():
+    """D4: `label ·…` reads as a rendering fault, not as an ellipsis."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entry = _sub("s1", label="section the sidebar", agent="coder")
+        sidebar = await _sidebar_with(pilot, app, [entry], show_subagents=True)
+        row = next(line for line in sidebar.render().plain.splitlines() if "section the" in line)
+        assert "·…" not in row and "· …" not in row, f"dangling separator: {row!r}"
+        assert "…" in row, "the title is genuinely cut, so it must still say so"
+
+
+@pytest.mark.asyncio
+async def test_the_section_chrome_cost_is_the_accepted_one():
+    """The chrome budget is `len(tiers) * 2 + (len(tiers) - 1)`, ACCEPTED.
+
+    Round 1's design finding proposed collapsing "doubled" separators to buy
+    back three lines. There are no doubled separators: the blank belongs
+    BENEATH each heading, so a section ends on its last entry row and dropping
+    the leading blank puts the next heading flush against it — the collision
+    `_display_rows` documents and two tests defend by name. The finding was
+    withdrawn and the cost accepted as MINOR, documented in
+    `docs/SESSION_SIDEBAR.md` rather than engineered away
+    (`~/workspace/DESIGN-sidebar-r1-D3-ruling.md`).
+
+    Pinned here so the number is a decision on the record rather than
+    something the next round re-derives and re-litigates.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        three = [_plain("pin1", active=True), _plain("a1", active=True), _plain("p1")]
+        sidebar = await _sidebar_with(pilot, app, three, pins=("pin1",))
+        assert sidebar._header_lines() == 8, "three sections must cost 8 chrome lines"
+
+        four = three + [_sub("s1", label="one", agent="coder")]
+        sidebar.set_entries(four)
+        sidebar.show_subagents = True
+        await pilot.pause()
+        assert sidebar._header_lines() == 11, "four sections must cost 11 chrome lines"
+
+
+@pytest.mark.asyncio
+async def test_the_pager_displaces_ctrl_b_not_f9():
+    """D3b: `f9 focus` survives paging; `ctrl+b hide` is what gives way.
+
+    `ctrl+b` hides a list the user is looking at, and `/help` still teaches it.
+    `f9` is how they reach the list they are reading, and it is the gate to the
+    two sidebar-scoped chords — so dropping it exactly when the list grew big
+    enough to page was the wrong thing to lose. It is also 3 cells cheaper,
+    which keeps the worst case inside the content width.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entries = [_plain(f"a{i}", active=True) for i in range(40)]
+        sidebar = await _sidebar_with(pilot, app, entries, total=1520)
+        assert len(sidebar.entries) > sidebar.page_size, "fixture must actually page"
+        footer = sidebar.render().plain.splitlines()[-1]
+        assert "f9 focus" in footer, f"the pager dropped f9: {footer!r}"
+        assert "ctrl+b" not in footer, f"both hints do not fit: {footer!r}"
+        assert "⌥999+" in footer, f"the capped counter was cropped: {footer!r}"
+        assert cell_len(footer) <= sidebar.size.width

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -514,7 +514,10 @@ async def test_list_window_current_cursor_and_footer_are_independent():
         assert len(sidebar.visible_entries) <= sidebar.page_size
         lines = sidebar.render().plain.splitlines()
         assert len(lines) <= sidebar.size.height
-        assert lines[-1] == f"1–{sidebar.page_size}/101 · ctrl+b hide"
+        # The pager displaces `ctrl+b hide` and KEEPS `f9 focus`: reaching the
+        # list matters more than hiding it, and `f9` is the gate to the two
+        # sidebar-scoped chords (D3b ruling).
+        assert lines[-1] == f"1–{sidebar.page_size}/101 · f9 focus"
         assert all(cell_len(line) <= sidebar.size.width for line in lines)
         sidebar.show_error("read failed")
         assert sidebar.entries

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 import os
 import threading
 import time
@@ -2488,3 +2489,416 @@ async def test_a_speculatively_leased_source_is_parked_and_stays_subscribed():
         assert source.controller is not None
         assert source.controller.parked, "a speculative lease must not paint deltas"
         assert handlers, "a parked source must stay subscribed or its owner's stream buffers"
+
+
+# -- pins, the subagent layer and the four-way sectioning ---------------------
+#
+# The seam these exercise (``CatalogEntry.subagent``/``agent``/``label``,
+# ``sub_title``) is the session layer's; this file only ever reads it.
+
+
+def _sub(sid: str, *, label: str = "", agent: str = "", **kwargs) -> CatalogEntry:
+    """A hidden-population row, as ``load_catalog(include_subagents=True)`` yields it."""
+    now = time.time()
+    return CatalogEntry(
+        SessionRow(sid, kwargs.pop("mtime", now), kwargs.pop("name", f"Session {sid}")),
+        subagent=True,
+        label=label,
+        agent=agent,
+        **kwargs,
+    )
+
+
+def _plain(sid: str, *, active: bool = False, name: str = "") -> CatalogEntry:
+    now = time.time()
+    return CatalogEntry(
+        SessionRow(sid, now, name or f"Session {sid}", live_state="busy" if active else "")
+    )
+
+
+def _section_of_line(lines: list[str], needle: str) -> str:
+    """The heading above the first line containing ``needle``.
+
+    Reads the rendered frame rather than ``_display_rows`` so the assertion is
+    about what the user sees, which is the thing the sectioning rule is about.
+    """
+    headings = {"★ Pinned", "Active Sessions", "Previous Sessions", "⌥ Subagent Runs"}
+    current = ""
+    for line in lines:
+        stripped = line.strip()
+        if stripped in headings:
+            current = stripped
+        elif needle in line:
+            return current
+    raise AssertionError(f"{needle!r} not in any section:\n" + "\n".join(lines))
+
+
+async def _sidebar_with(pilot, app, entries, *, pins=(), show_subagents=False, total=0):
+    sidebar = app._session_sidebar
+    sidebar.set_open(True)
+    if app._sidebar_timer is not None:
+        app._sidebar_timer.pause()
+    app._sidebar_refresh_generation += 1
+    sidebar.show_subagents = show_subagents
+    sidebar.set_pins(pins)
+    sidebar.set_subagent_total(total)
+    sidebar.set_entries(entries)
+    await pilot.pause()
+    return sidebar
+
+
+@pytest.mark.asyncio
+async def test_a_pinned_row_leaves_its_old_section():
+    """A pin LIFTS a row out of the tier it ranked into; it never reorders the
+    catalog. ``rank_entries`` is the partition the mobile relay shares."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entries = [_plain("keep", active=True), _plain("pinme", active=True), _plain("old")]
+        sidebar = await _sidebar_with(pilot, app, entries, pins=("pinme",))
+        lines = sidebar.render().plain.splitlines()
+        assert _section_of_line(lines, "Session pinme") == "★ Pinned"
+        assert _section_of_line(lines, "Session keep") == "Active Sessions"
+        # The lift is display-only: the ranked tuple is untouched, because
+        # `action_move` and `_switch_session_from` both index it.
+        assert [entry.id for entry in sidebar.entries] == ["keep", "pinme", "old"]
+
+
+@pytest.mark.asyncio
+async def test_a_pinned_subagent_shows_with_the_layer_off():
+    """Pinned outranks subagent, so an explicitly pinned agent run stays
+    reachable even when the ⌥ layer is collapsed."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entries = [_plain("mine", active=True), _sub("run1", label="ship it", agent="coder")]
+        sidebar = await _sidebar_with(
+            pilot, app, entries, pins=("run1",), show_subagents=False, total=12
+        )
+        lines = sidebar.render().plain.splitlines()
+        assert _section_of_line(lines, "ship it") == "★ Pinned"
+        assert not any("⌥ Subagent Runs" in line for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_a_subagent_row_never_lands_in_active():
+    """THE SECTIONING REGRESSION GUARD.
+
+    `CatalogEntry.active` is `pending or unseen or live_state`, and the
+    attention store keys on conversation identity — so it answers True for
+    subagent ids too (45% of them carry an unseen receipt). Sectioning on
+    `active` alone therefore ranks agent runs above the user's own work. This
+    is the exact shape that breaks: subagent AND unseen.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        noisy = _sub("run1", label="audit", agent="reviewer", unseen=True)
+        assert noisy.active, "fixture must carry the shape the guard is about"
+        entries = [_plain("mine", active=True), noisy]
+        sidebar = await _sidebar_with(pilot, app, entries, show_subagents=True)
+        lines = sidebar.render().plain.splitlines()
+        assert _section_of_line(lines, "audit") == "⌥ Subagent Runs"
+        assert _section_of_line(lines, "Session mine") == "Active Sessions"
+
+
+@pytest.mark.asyncio
+async def test_the_four_sections_are_contiguous():
+    """Sections are blocks, not a scatter: the display sort is stable on the
+    section key so the catalog's order survives INSIDE each one."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        entries = [
+            _plain("a1", active=True),
+            _sub("s1", label="one", agent="scout"),
+            _plain("p1"),
+            _plain("pin1", active=True),
+            _plain("a2", active=True),
+            _sub("s2", label="two", agent="qa"),
+            _plain("p2"),
+            _plain("pin2"),
+        ]
+        sidebar = await _sidebar_with(
+            pilot, app, entries, pins=("pin1", "pin2"), show_subagents=True
+        )
+        rows = sidebar._display_rows()
+        sections = [sidebar._section_of(entry) for _kind, entry in rows if entry is not None]
+        assert sections == sorted(sections), f"sections interleaved: {sections}"
+        # Every section present, each appearing as ONE run.
+        assert [key for key, _ in itertools.groupby(sections)] == [0, 1, 2, 3]
+        # Stable within a section: pin1 ranked before pin2 and stays there.
+        pinned = [
+            entry.id for _k, entry in rows if entry is not None and entry.id.startswith("pin")
+        ]
+        assert pinned == ["pin1", "pin2"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("height", [20, 30, 40])
+async def test_page_size_accounts_for_four_headers(height):
+    """Four headings cost more chrome than two, and `page_size` must shrink by
+    exactly that or the frame overflows its own height."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, height)) as pilot:
+        await pilot.pause()
+        entries = (
+            [_plain(f"p{i}") for i in range(6)]
+            + [_plain(f"a{i}", active=True) for i in range(6)]
+            + [_sub(f"s{i}", label=f"run {i}", agent="coder") for i in range(6)]
+        )
+        sidebar = await _sidebar_with(
+            pilot, app, entries, pins=("p0", "p1"), show_subagents=True, total=99
+        )
+        lines = sidebar.render().plain.splitlines()
+        assert len(lines) <= sidebar.size.height
+        assert len(sidebar.visible_entries) <= sidebar.page_size
+        assert all(cell_len(line) <= sidebar.size.width for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_a_subagent_row_draws_its_label_and_role():
+    """A sub row is identified by what it was delegated to do, not by the name
+    the runtime generated for it, and carries ⌥ where a state glyph would be."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entry = _sub("run1", label="fix the poll", agent="coder", name="untitled-7")
+        sidebar = await _sidebar_with(pilot, app, [entry], show_subagents=True)
+        lines = sidebar.render().plain.splitlines()
+        row = next(line for line in lines if "fix the poll" in line)
+        assert "coder" in row
+        assert "untitled-7" not in row
+        # The 4-cell prefix is "» "/"› "/"  " then the mark then a space, so
+        # the mark is column 2 — the same cell `_advance_spinner` patches.
+        assert row[2] == "⌥"
+
+
+@pytest.mark.asyncio
+async def test_a_subagent_row_with_only_a_role_degrades():
+    """No label: the role alone, with no stray separator left behind."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entry = _sub("run1", label="", agent="reviewer")
+        sidebar = await _sidebar_with(pilot, app, [entry], show_subagents=True)
+        row = next(line for line in sidebar.render().plain.splitlines() if "reviewer" in line)
+        assert "·" not in row
+
+
+@pytest.mark.asyncio
+async def test_the_footer_chip_carries_the_hidden_count():
+    """The count of what the layer is hiding rides the EXISTING footer line."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sidebar = await _sidebar_with(pilot, app, [_plain("a", active=True)], total=438)
+        footer = sidebar.render().plain.splitlines()[-1]
+        assert footer.endswith("· ⌥438")
+        assert cell_len(footer) <= sidebar.size.width
+
+
+@pytest.mark.asyncio
+async def test_the_footer_chip_caps_at_999():
+    """An unbounded counter would grow the footer without limit; the cap is
+    what makes its width deterministic.
+
+    Asserted at a terminal wide enough to paint the capped chip in full (120
+    cells of terminal is 34 of list), because the narrow floor cannot: the
+    list's rendered content is **29** cells, not the 30 ``SIDEBAR_WIDTH``
+    advertises — ``_sync_sidebar_layout`` docks `content_width + gutter` and
+    then spends one more cell on the left padding, which
+    ``sidebar_content_width`` does not reserve. That is pre-existing and not
+    this change's to fix; the companion assertion below pins the documented
+    consequence, which is that an overflowing chip is CROPPED rather than
+    wrapped.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        sidebar = await _sidebar_with(pilot, app, [_plain("a", active=True)], total=1520)
+        footer = sidebar.render().plain.splitlines()[-1]
+        assert "⌥999+" in footer
+        assert cell_len(footer) <= sidebar.size.width
+
+
+@pytest.mark.asyncio
+async def test_an_overflowing_chip_crops_rather_than_breaking_the_frame():
+    """At the narrow floor the capped chip does not fit. It must lose its tail,
+    never a line: a wrapped footer would silently eat a session row."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entries = [_plain(f"a{i}", active=True) for i in range(20)]
+        sidebar = await _sidebar_with(pilot, app, entries, total=0)
+        baseline_rows = len(sidebar.render().plain.splitlines())
+        sidebar.set_subagent_total(1520)
+        await pilot.pause()
+        lines = sidebar.render().plain.splitlines()
+        assert len(lines) == baseline_rows, "the chip wrapped and cost a row"
+        assert cell_len(lines[-1]) <= sidebar.size.width
+        assert "⌥" in lines[-1], "the counter vanished entirely instead of cropping"
+
+
+@pytest.mark.asyncio
+async def test_no_chip_without_a_hidden_population():
+    """Nothing hidden, nothing said: byte-identical to the footer before this
+    change, which is what keeps the existing footer assertions honest."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sidebar = await _sidebar_with(pilot, app, [_plain("a", active=True)], total=0)
+        footer = sidebar.render().plain.splitlines()[-1]
+        assert "⌥" not in footer
+        assert footer.strip() == "f9 focus · ctrl+b hide"
+
+
+@pytest.mark.asyncio
+async def test_the_footer_is_one_line():
+    """The chip costs no session row. A second footer line would cost one at
+    every terminal height, permanently."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entries = [_plain(f"a{i}", active=True) for i in range(20)]
+        sidebar = await _sidebar_with(pilot, app, entries, total=0)
+        without = sidebar.page_size
+        without_lines = len(sidebar.render().plain.splitlines())
+        sidebar.set_subagent_total(438)
+        await pilot.pause()
+        assert sidebar.page_size == without
+        assert len(sidebar.render().plain.splitlines()) == without_lines
+
+
+@pytest.mark.asyncio
+async def test_the_paint_state_notices_a_pin():
+    """Sectioning and chip inputs do NOT live in `entries`, so `_paint_state`
+    has to carry them or a toggle paints nothing."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sidebar = await _sidebar_with(pilot, app, [_plain("a", active=True), _plain("b")])
+        before = sidebar._paint_state()
+        sidebar.set_pins(("a",))
+        after_pin = sidebar._paint_state()
+        assert after_pin != before
+        sidebar.show_subagents = True
+        after_layer = sidebar._paint_state()
+        assert after_layer != after_pin
+        sidebar.set_subagent_total(7)
+        assert sidebar._paint_state() != after_layer
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_poll_does_not_repaint():
+    """The setters run on every 2 s poll. An unconditional refresh here would
+    re-ink the list forever in every open terminal."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sidebar = await _sidebar_with(pilot, app, [_plain("a", active=True)], pins=("a",))
+        state = sidebar._paint_state()
+        with patch.object(sidebar, "refresh") as refresh:
+            sidebar.set_pins(("a",))
+            sidebar.set_subagent_total(0)
+            assert not refresh.called, "an unchanged poll forced a repaint"
+        assert sidebar._paint_state() == state
+
+
+@pytest.mark.asyncio
+async def test_ctrl_a_toggles_the_layer_only_when_focused():
+    """`ctrl+a` is SIDEBAR-scoped on purpose: it is also the composer's
+    line-start (`keymap.COMPOSER_KEYS`). In F9 mode the sidebar owns the focus
+    chain; with the Editor focused the caret must win."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sidebar = await _sidebar_with(pilot, app, [_sub("s1", label="one", agent="scout")])
+        posted: list[object] = []
+
+        def note_refresh(*_args, **_kwargs):
+            posted.append("refresh")
+
+        app._refresh_sidebar = note_refresh  # type: ignore[method-assign]
+        await _focus_settled(pilot, sidebar)
+        assert sidebar.show_subagents is False
+        await pilot.press("ctrl+a")
+        await pilot.pause()
+        assert sidebar.show_subagents is True
+        assert posted, "the toggle must ask the app to re-poll with the flag"
+
+        editor = app.query_one(Editor)
+        editor.focus()
+        for _ in range(20):
+            await pilot.pause()
+            if editor.has_focus:
+                break
+        editor.text = "hello world"
+        editor.cursor_location = (0, 5)
+        was = sidebar.show_subagents
+        await pilot.press("ctrl+a")
+        await pilot.pause()
+        assert sidebar.show_subagents is was, "ctrl+a reached the sidebar past the composer"
+        assert editor.cursor_location == (0, 0), "ctrl+a must still be the caret's line-start"
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_jumps_to_the_first_subagent_row():
+    """The layer can sit below the fold; the jump is how it is reachable
+    without paging. A no-op when there is nothing to jump to."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entries = [_plain("a1", active=True), _plain("p1"), _sub("s1", label="one", agent="qa")]
+        sidebar = await _sidebar_with(pilot, app, entries, show_subagents=False)
+        await _focus_settled(pilot, sidebar)
+        sidebar.cursor_id = "a1"
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert sidebar.cursor_id == "a1", "the layer is off; there is nothing to reveal"
+
+        sidebar.show_subagents = True
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert sidebar.cursor_id == "s1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("height", [20, 30, 40])
+async def test_a_click_lands_on_the_row_it_looks_like(height):
+    """THE SILENT-DESTRUCTIVE GUARD.
+
+    `page_size`, `_header_lines`, `_display_rows` and `_entry_at` share one
+    geometry. Move one without the others and `_entry_at` resolves a click to
+    a different session than the one painted on that line — which switches the
+    user's conversation with no error and no way to notice. Asserted across
+    EVERY painted row with all four sections drawn, not one sampled row.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, height)) as pilot:
+        await pilot.pause()
+        entries = (
+            [_plain(f"pin{i}", active=True) for i in range(2)]
+            + [_plain(f"a{i}", active=True) for i in range(3)]
+            + [_plain(f"p{i}") for i in range(3)]
+            + [_sub(f"s{i}", label=f"run {i}", agent="coder") for i in range(3)]
+        )
+        sidebar = await _sidebar_with(
+            pilot, app, entries, pins=("pin0", "pin1"), show_subagents=True, total=40
+        )
+        lines = sidebar.render().plain.splitlines()
+        rows = sidebar._display_rows()
+        title = 0 if sidebar._draws_section_headers(rows) else 1
+        painted = 0
+        for y, (_kind, entry) in enumerate(rows, title):
+            hit = sidebar._entry_at(y)
+            if entry is None:
+                assert hit is None, f"y={y} is chrome but resolved to {hit and hit.id}"
+                continue
+            assert hit is not None and hit.id == entry.id, (
+                f"y={y} paints {entry.id!r} but a click there resolves " f"{hit and hit.id!r}"
+            )
+            name = entry.sub_title if entry.subagent else entry.row.name
+            assert name.split(" · ")[0] in lines[y], f"y={y} does not paint {entry.id!r}"
+            painted += 1
+        assert painted, "no entry rows were drawn"

--- a/tests/unit/tui/test_sidebar_pins.py
+++ b/tests/unit/tui/test_sidebar_pins.py
@@ -108,6 +108,31 @@ def test_a_pin_to_a_deleted_session_is_pruned_at_read(tmp_path: Path) -> None:
     assert read_pins(tmp_path) == ["a" * 12]
 
 
+def test_an_id_bearing_a_path_separator_is_rejected(tmp_path: Path) -> None:
+    """A pin is a session id — ONE bare directory name — and the check runs
+    BEFORE the store-prune, because the prune is what would follow the escape:
+    it joins the id onto ``sessions/``, and ``sessions / "/tmp"`` IS ``/tmp``
+    while ``../agents`` climbs out of the store entirely. ``..`` is rejected
+    too, and would otherwise survive both halves — ``Path("..").name`` is
+    ``".."`` and ``sessions/..`` is a real directory.
+
+    Defence in depth rather than a live bug: nothing renders from a bogus
+    entry today, since ``load_catalog`` hydrates none of them. This keeps the
+    house rule — discovery metadata cannot redirect a read outside
+    ``sessions/`` — true of this file as well.
+    """
+    _session(tmp_path, "real")
+    (tmp_path / "agents").mkdir()
+
+    (tmp_path / PINS_FILE).write_text(json.dumps(["../agents", "..", "/tmp"]))
+    assert read_pins(tmp_path) == []
+
+    (tmp_path / PINS_FILE).write_text(
+        json.dumps(["real", "../agents", "..", ".", "/tmp", "sessions/../../etc", "real/../real"])
+    )
+    assert read_pins(tmp_path) == ["real"]
+
+
 def test_the_write_is_atomic(tmp_path: Path) -> None:
     """Same-directory temp then replace. Asserted by proving no temp file
     survives a successful write — a torn read would silently empty the pins."""

--- a/tests/unit/tui/test_sidebar_pins.py
+++ b/tests/unit/tui/test_sidebar_pins.py
@@ -1,0 +1,157 @@
+"""The sidebar's durable pinned-session list.
+
+Two properties carry this module. The first is that a pin SURVIVES — it is the
+only thing the sidebar ranks by that is not live state, so a torn or half-written
+file costs the user a deliberate choice rather than a cache. The second is that
+it never costs them anything else: a pin is recorded immediately after a keypress
+the user has already been given feedback for, so every failure mode here —
+unreadable file, unwritable directory, a pin to a session that has since been
+deleted — degrades to "no pins" instead of raising into the TUI.
+
+Everything runs against a real temporary filesystem rather than mocks, for the
+reason ``test_move_targets.py`` does: these functions exist to answer questions
+about files, and a mocked filesystem would assert that the code calls what it
+calls rather than that it gives right answers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator.tui.sidebar_pins import PINS_FILE, PINS_LIMIT, read_pins, toggle_pin
+
+
+def _session(config: Path, session_id: str) -> Path:
+    """A session directory, so the read-path prune keeps this id."""
+    directory = config / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def test_an_absent_file_reads_as_no_pins(tmp_path: Path) -> None:
+    """Reading must not be a write: a sidebar that has never pinned anything
+    should leave no trace in the config directory."""
+    assert read_pins(tmp_path) == []
+    assert not (tmp_path / PINS_FILE).exists()
+
+
+def test_a_pin_round_trips(tmp_path: Path) -> None:
+    _session(tmp_path, "aaaaaaaaaaaa")
+    assert toggle_pin(tmp_path, "aaaaaaaaaaaa") is True
+    assert read_pins(tmp_path) == ["aaaaaaaaaaaa"]
+
+
+def test_a_second_toggle_unpins(tmp_path: Path) -> None:
+    """One chord is both verbs, so the return value is the NEW state."""
+    _session(tmp_path, "aaaaaaaaaaaa")
+    toggle_pin(tmp_path, "aaaaaaaaaaaa")
+    assert toggle_pin(tmp_path, "aaaaaaaaaaaa") is False
+    assert read_pins(tmp_path) == []
+
+
+def test_the_newest_pin_leads(tmp_path: Path) -> None:
+    for session_id in ("a" * 12, "b" * 12, "c" * 12):
+        _session(tmp_path, session_id)
+        toggle_pin(tmp_path, session_id)
+    assert read_pins(tmp_path) == ["c" * 12, "b" * 12, "a" * 12]
+
+
+def test_repinning_moves_it_to_the_front(tmp_path: Path) -> None:
+    """Unpin then repin is how a user promotes an old pin, and the list is
+    newest-first, so the repinned id must lead rather than return to its slot."""
+    for session_id in ("a" * 12, "b" * 12):
+        _session(tmp_path, session_id)
+        toggle_pin(tmp_path, session_id)
+    toggle_pin(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "a" * 12)
+    assert read_pins(tmp_path) == ["a" * 12, "b" * 12]
+
+
+def test_the_cap_holds(tmp_path: Path) -> None:
+    """The OLDEST pins are what a full list drops, never the newest."""
+    for index in range(PINS_LIMIT + 10):
+        session_id = f"{index:012x}"
+        _session(tmp_path, session_id)
+        toggle_pin(tmp_path, session_id)
+    pins = read_pins(tmp_path)
+    assert len(pins) == PINS_LIMIT
+    assert pins[0] == f"{PINS_LIMIT + 9:012x}"
+    assert f"{0:012x}" not in pins
+
+
+@pytest.mark.parametrize("body", ["not json", '{"pins": []}'])
+def test_a_corrupt_file_degrades_to_no_pins(tmp_path: Path, body: str) -> None:
+    """Best-effort by contract: the sidebar ranks perfectly well without pins,
+    so an unreadable file must never be the thing that costs the user the list."""
+    (tmp_path / PINS_FILE).write_text(body)
+    assert read_pins(tmp_path) == []
+
+
+def test_non_string_members_are_dropped(tmp_path: Path) -> None:
+    _session(tmp_path, "abc123abc123")
+    (tmp_path / PINS_FILE).write_text(json.dumps([1, None, "abc123abc123", ""]))
+    assert read_pins(tmp_path) == ["abc123abc123"]
+
+
+def test_a_pin_to_a_deleted_session_is_pruned_at_read(tmp_path: Path) -> None:
+    """Pruning on the READ path is what keeps this module free of any
+    coordination with ``session/cleanup.py``: deletion needs to know nothing
+    about pins, and a pin to a cleaned-up session renders as nothing rather
+    than as a broken row."""
+    _session(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "b" * 12)
+    assert read_pins(tmp_path) == ["a" * 12]
+
+
+def test_the_write_is_atomic(tmp_path: Path) -> None:
+    """Same-directory temp then replace. Asserted by proving no temp file
+    survives a successful write — a torn read would silently empty the pins."""
+    _session(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "a" * 12)
+    leftovers = [path.name for path in tmp_path.iterdir() if path.name.startswith(".sidebar-pins-")]
+    assert leftovers == []
+    assert json.loads((tmp_path / PINS_FILE).read_text()) == ["a" * 12]
+
+
+def test_a_failing_write_never_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The keypress has already been acknowledged on screen when this runs."""
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise OSError("no space left on device")
+
+    _session(tmp_path, "a" * 12)
+    monkeypatch.setattr(os, "replace", boom)
+    assert toggle_pin(tmp_path, "a" * 12) is True
+    leftovers = [path.name for path in tmp_path.iterdir() if path.name.startswith(".sidebar-pins-")]
+    assert leftovers == [], "the temp file must not survive a failed replace"
+
+
+@pytest.mark.skipif(os.getuid() == 0, reason="root writes to unwritable directories anyway")
+def test_an_unwritable_directory_never_raises(tmp_path: Path) -> None:
+    config = tmp_path / "readonly"
+    config.mkdir()
+    config.chmod(0o500)
+    try:
+        assert toggle_pin(config, "a" * 12) is True
+        assert read_pins(config) == []
+    finally:
+        config.chmod(0o700)
+
+
+def test_last_writer_wins(tmp_path: Path) -> None:
+    """Documents the accepted multi-process behaviour rather than guarding
+    against it: two sessions pinning at once means the second write is what the
+    file holds. No precedent here takes a cross-process lock for a small index,
+    and the atomic replace means a reader sees an older list, never a torn one."""
+    for session_id in ("a" * 12, "b" * 12):
+        _session(tmp_path, session_id)
+    # Both "processes" observed the same empty base state.
+    assert read_pins(tmp_path) == []
+    toggle_pin(tmp_path, "a" * 12)
+    toggle_pin(tmp_path, "b" * 12)
+    assert read_pins(tmp_path) == ["b" * 12, "a" * 12]


### PR DESCRIPTION
## What this changes

The UI half of the `ctrl+b` sidebar upgrade. Stacked on **#1200** (the data half) — this PR targets that branch, so its diff is A-only; GitHub retargets it to `main` when #1200 merges.

The sidebar was hard to fish in. The sessions you return to are buried among the ones you do not, and delegated runs — ~75% of the store, invisible since #154 — were all-or-nothing. Three additions, in the order they matter:

| | |
| --- | --- |
| **`★ Pinned`** | a durable section above Active Sessions; pinned rows leave their old section and survive a relaunch. `f10` pins the row under the pointer, else the cursor row when the list is focused |
| **`⌥ Subagent Runs`** | a labelled `label · role` layer below Previous, hidden by default and capped at 40. `ctrl+a` toggles it, `ctrl+o` shows-then-jumps to it |
| **the footer chip** | `⌥438` — the hidden count, always present, so hidden is never *silent* |

**`f10`, not a `ctrl` chord**, and that is not a style choice. Textual's `App.__init__` injects `Binding(COMMAND_PALETTE_BINDING, "command_palette", priority=True)`, and on textual 8.2.8 that constant is `ctrl+p`. A pilot press proved the resolved map is `ctrl+p → [(probe_pin, False), (command_palette, True)]`: the palette opens and the app action never fires — priority beats widget scope, so sidebar-scoping cannot rescue it. All 26 `ctrl+<letter>` chords are audited as claimed; `f10` continues the existing `f8`/`f9` series and was verified by the pilot method `docs/design/keymap.md` §E.4 clause 5 mandates. `ctrl+a`/`ctrl+o` are sidebar-scoped only, which is exactly why they may reuse composer keys.

**The chip is a participant in this repo's fitted footer ladder, not an append.** The branch originally carried its own footer ruling; `main` shipped the D4/U1 rework while this work was stalled, so that ruling was dropped in favour of main's. Appending the chip after main's ladder paints `1–25/40 · f9 focus · ctrl+b hid…` at width 32 — main's own defect class, reintroduced. As a ladder participant, every chip-carrying candidate must self-fit, so `ctrl+b hide` or the position counter drops **whole** and never mid-word. Yield order: **lead never yields, chip never yields, `ctrl+b hide` yields first, position second.** At the 24-cell floor the position is the intended casualty.

**`f10` has no `/help` row of its own, deliberately.** `main` has zero vertical headroom in that table: any added row pushes the topmost asserted key out of the 44-row frame `test_the_paste_key_rows_do_not_wrap_at_eighty_columns` renders at (3/3 pass on main, 3/3 fail with a row added, no overlap). It folds into the `f9` row instead — `keys the sessions list; f10 pins; esc returns`, 65 cells against the 74 ceiling, **net row delta 0**.

## Evidence

**The footer ladder — swept, not sampled.** 1,368 samples across widths 23–60 × focused/unfocused × unpaged/page-1/deep-page × hidden totals {0, 1, 438, 999, 1000, 1520}:

```
zero '…' in any footer at any width
chip-empty renders byte-identically to main   (1,056 configs, two interpreters, diffed: 0 bytes)
w=29  'f9 focus · ctrl+b hide · ⌥1k+'   exactly 29
w=28  ctrl+b hide drops WHOLE
w=24  'f9 focus · ⌥1k+'  (position dropped, as ruled)
```

**And the sweep discriminates.** Patching the pre-fix blind-append ladder back in turns both new regression tests red with the exact signature (`'f9 focus · ctrl+b hide…'` at w=23) while every existing point test stays green.

**Geometry — the wrong-session-attach hazard.** A click must land on the row it looks like, and the section machinery (`_display_rows` / `_header_lines` / `_entry_at` / `page_size`) has to agree for every combination or a click silently attaches the wrong session:

```
1,768 configs (pins × sections × heights 3–19)   _entry_at → None on EVERY chrome row
                                                  exact entry on EVERY entry row, 0 failures
41,280 hit-tests against the PAINTED FRAME       0 mismatches
~5,700 configs, 8 fuzz rounds                    0 oscillation, 0 over-claim
```

A pin that lifts a row mid-gesture still selects the **pressed** id, not the row that slid under the pointer — same for a pressed row being deleted, or a pressed sub row with the layer toggled off mid-gesture.

**Column ownership.** `★` sits in the cursor-prefix slot so it cannot eat the glyph that says a session needs you:

```
pinned needs-you row → '★ ! '    (all five states checked; ★ never enters col 2)
pinned busy row      → '★ ' held across 24 frames while col 2 cycles all 8 spinner glyphs
```

The earlier form collapsed `!`, `✗`, `⊘` and `✓` into `★` — pinning a session would have hidden the one thing it was trying to tell you.

**Chords, probed against real classes:** `ctrl+a`/`ctrl+o` return `[]` at app level and fire only in sidebar scope; `f10` is the sole non-priority claimant; `ctrl+p` still opens Textual's palette; with the composer focused `ctrl+a` moves the caret `(0,11)→(0,0)` with the draft intact and the layer **not** flipped.

**Frames** — six captured, all matching their ruled strings, including `+1 more pinned` sitting *inside* `★ Pinned` rather than under Active Sessions. The 30×30 sweep row is a red→green proof: `f9 focus · ⌥438` intact where the pre-fix tree painted `⌥4…`.

**Real store, headless** (197 visible / 647 hidden): toggle → jump → pin a sub row → unpin, store left byte-identical, no leftover pins file.

## Gates

```
black --check   OK        isort --check-only   OK        flake8   OK
pyright         0 errors, 0 warnings

test_session_sidebar.py + test_app_pilot.py   447 passed, 0 failed   (-n0)
# (an earlier revision of this body quoted 457 for this line; the tree collects
#  447 and all 447 pass — agent review round 3, and re-run at 7f426f1c)
test_keymap.py                                 34 passed
paste-key blocker test                          1 passed
tests/unit                                  22862 passed / 30m50s
coverage                                    TOTAL 87%, gate passes
```

Test integrity: **0 assertions removed**, 182 added, no `xfail` or `skip` introduced. The two tests protecting the section-blank invariant are byte-identical to main's. One test was deleted — `test_the_pager_displaces_ctrl_b_not_f9`, obsolete under main's ladder; it was born and died inside this feature, never existed on main, and its one valuable assertion (`f9` survives paging) lives on at `test_session_sidebar.py:545` in a real paging fixture.

Every run used `env -i HOME=<temp> LOCAL_OPERATOR_CONFIG_DIR=<temp>`; `grep -c "REAL CONFIG CHANGED"` was **0** in every log, and the live `config.yml` sha256 was identical before and after. Pytest here constructs real `ConfigManager`s and writes to the operator's live config if run unisolated — worth knowing before running this suite.

## Review record

Independent code review at `a7bf1b06`: **APPROVE-WITH-NITS**, terminal on the code axis — 0 BLOCKER, 0 MAJOR, 1 MINOR, 3 NIT. Adversarial QA on the integrated tree: **PASS**, 0 defects at every severity across ~44,000 assertions, with its sweep proven sensitive rather than vacuous. Four design rounds; round 4 is final on intent.

The MINOR is honest and recorded: with the list open, unfocused, and the pointer off it — the click-only steady state after main's `FOCUS_ON_CLICK = False` — `f10` does nothing and says nothing. The hover-wins rule is correct and documented; the finding is the *inconsistency*, since this slice's own sibling chord treats exactly that silence as a defect worth a notice. One keystroke (`f9`) is the workaround. Filed as a follow-up.

**Still outstanding, and not fakeable:** two checks need a human with a real pointer and a real terminal — that hovering and pressing `f10` pins the *hovered* row, and that pins survive a genuine quit-and-relaunch while the layer returns to its startup default. Every synthetic approach covers the logic but not the felt behaviour. Script is in the design record.

## Known and not fixed

- `sidebar_content_width` promises 30 cells but the widget renders 29 — `_sync_sidebar_layout` docks `content_width + gutter`, then spends one more on left padding. Verified pre-existing at the base SHA; this PR pins the behaviour with a test, and the docstring is now false by one cell.
- At height 3, display rows can exceed the frame. Reproduces on pure `main` (main's `max(1, …)` floor in `page_size`); this PR widens the band to heights 3–4 because more sections mean more chrome. No hit-test failure in any config, and a 3–4 row sidebar is not a reachable terminal. Backlog.

